### PR TITLE
Re-enable DB migrations checking

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -94,7 +94,7 @@ jobs:
     with:
       environment: test
       app_name: pre-award
-      run_db_migrations: false
+      run_db_migrations: true
       image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_test_deploy_tests:
@@ -126,7 +126,7 @@ jobs:
     with:
       environment: uat
       app_name: pre-award
-      run_db_migrations: false
+      run_db_migrations: true
       image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_uat_deploy_tests:
@@ -158,5 +158,5 @@ jobs:
     with:
       environment: prod
       app_name: pre-award
-      run_db_migrations: false
+      run_db_migrations: true
       image_location: ${{ needs.paketo_build.outputs.image_location }}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-204

### Change description
We temporarily disabled DB migrations checking for the first deployment of the new combined `funding-service-pre-award` app. Now that deployment has hit prod, we need to turn this back on.