### PR TITLE
Fix running individual tests

### DIFF
--- a/tests/account_store_tests/conftest.py
+++ b/tests/account_store_tests/conftest.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from flask import Flask
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
@@ -16,8 +17,10 @@ from config import Config
 
 
 @pytest.fixture(scope="session")
-def app(mock_redis):
-    yield create_app()
+def app(request) -> Flask:
+    app = create_app()
+    request.getfixturevalue("mock_redis")
+    yield app
 
 
 class _FlaskClientWithHost(FlaskClient):

--- a/tests/application_store_tests/conftest.py
+++ b/tests/application_store_tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from flask import Flask
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
@@ -22,13 +23,10 @@ from tests.application_store_tests.helpers import (
 
 
 @pytest.fixture(scope="session")
-def app(mock_redis):
-    """
-    Creates the test client we will be using to test the responses
-    from our app, this is a test fixture.
-    :return: A flask test client.
-    """
-    yield create_app()
+def app(request) -> Flask:
+    app = create_app()
+    request.getfixturevalue("mock_redis")
+    yield app
 
 
 class _FlaskClientWithHost(FlaskClient):

--- a/tests/authenticator_tests/testing/mocks/mocks/live_server.py
+++ b/tests/authenticator_tests/testing/mocks/mocks/live_server.py
@@ -1,14 +1,11 @@
 import pytest
+from flask import Flask
 
 from app import create_app
 
 
 @pytest.fixture(scope="session")
-def app(mock_redis):
-    """
-    Returns an instance of the Flask app as a fixture for testing,
-    which is available for the testing session and accessed with the
-    @pytest.mark.uses_fixture('live_server')
-    :return: An instance of the Flask app.
-    """
-    yield create_app()
+def app(request) -> Flask:
+    app = create_app()
+    request.getfixturevalue("mock_redis")
+    yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,9 @@ pytest_plugins = ["fsd_test_utils.fixtures.db_fixtures"]
 
 
 @pytest.fixture(scope="session")
-def app(mock_redis) -> Flask:
+def app(request) -> Flask:
     app = create_app()
+    request.getfixturevalue("mock_redis")
     yield app
 
 

--- a/tests/fund_store_tests/conftest.py
+++ b/tests/fund_store_tests/conftest.py
@@ -183,8 +183,9 @@ def seed_dynamic_data(request, app, clear_test_data, _db):
 
 
 @pytest.fixture(scope="session")
-def app(mock_redis) -> Flask:
+def app(request) -> Flask:
     app = create_app()
+    request.getfixturevalue("mock_redis")
     yield app
 
 


### PR DESCRIPTION
The `mock_redis` fixture was being setup incorrectly - before app creation. One of the things that mock_redis mocks is a method on `app.redis_mlinks`, which is only fully configured *after* the app has been made.