### PR TITLE
BAU Fix host matching for authenticator errors

### DIFF
--- a/common/error_routes.py
+++ b/common/error_routes.py
@@ -50,7 +50,7 @@ def internal_server_error(error):
     if request.host == current_app.config["ASSESS_HOST"]:
         return render_template("assess/500.html", is_error=True), 500
 
-    if request.host == current_app.config["AUTHENTICATOR_HOST"]:
+    if request.host == current_app.config["AUTH_HOST"]:
         return render_template("authenticator/500.html", is_error=True), 500
 
     return render_template("apply/500.html", is_error=True), 500

--- a/tests/authenticator_tests/test_errors.py
+++ b/tests/authenticator_tests/test_errors.py
@@ -32,4 +32,4 @@ def test_500(authenticator_test_client, mocker):
 
     soup = BeautifulSoup(response.data, "html.parser")
 
-    assert soup.find("title").text == "Sorry, there is a problem with the service - Access Funding"
+    assert soup.find("title").text == "Sorry, there is a problem with the service – Access Funding"


### PR DESCRIPTION
`AUTHENTICATOR_HOST` looks like it refers to the publicly addressable URL for authenticator (used to build links), `AUTH_HOST` is the internal server name part we'd expect to be passed in the request header.

This confusion should only exist in the short period the apps and stores are combined but haven't had the network layer removed/ been de-duplicated.