### PR TITLE
Send "application submitted" emails synchronously

### DIFF
--- a/application_store/_helpers/application.py
+++ b/application_store/_helpers/application.py
@@ -2,7 +2,6 @@ from operator import itemgetter
 
 from flask import current_app
 from fsd_utils import Decision
-from fsd_utils.config.notify_constants import NotifyConstants
 
 from application_store.config.key_report_mappings.mappings import (
     ROUND_ID_TO_KEY_REPORT_MAPPING,
@@ -11,8 +10,7 @@ from application_store.db.queries.application import create_qa_base64file
 from application_store.db.queries.reporting.queries import (
     map_application_key_fields,
 )
-from application_store.external_services.models.notification import Notification
-from config import Config
+from services.notify import NotificationError, get_notification_service
 
 
 def order_applications(applications, order_by, order_rev):
@@ -43,13 +41,20 @@ def send_submit_notification(
     application,
     round_data,
 ):
-    contents = {
-        NotifyConstants.APPLICATION_FIELD: create_qa_base64file(application_with_form_json_and_fund_name, True),
-        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
-    }
-    del contents[NotifyConstants.APPLICATION_FIELD]["forms"]
+    application_data = create_qa_base64file(application_with_form_json_and_fund_name, True)
+    del application_data["forms"]
     full_name = account.full_name
 
+    questions = application_data.get("questions_file")
+    submission_date = application_data.get("date_submitted")
+    fund_name = application_data.get("fund_name")
+    fund_id = application_data.get("fund_id")
+    round_name = application_data.get("round_name")
+    application_reference = application_data.get("reference")
+    language = application_data.get("language")
+    prospectus_url = application_data.get("prospectus_url", "")
+
+    notification = None
     if eoi_results:
         eoi_decision = eoi_results["decision"]
         if not full_name:
@@ -64,11 +69,41 @@ def send_submit_notification(
                 return  # we don't send emails for a failure
 
             case Decision.PASS:
-                notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS
+                try:
+                    notification = get_notification_service().send_eoi_pass_email(
+                        email_address=account.email,
+                        contact_name=full_name.title() if full_name else None,
+                        language=language,
+                        fund_id=fund_id,
+                        fund_name=fund_name,
+                        application_reference=application_reference,
+                        submission_date=submission_date,
+                        round_name=round_name,
+                        questions=questions,
+                        contact_help_email=round_data.contact_email,
+                    )
+                except NotificationError:
+                    current_app.logger.exception("Failed to send EOI Pass email")
 
             case Decision.PASS_WITH_CAVEATS:
-                notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS_W_CAVEATS
-                contents[NotifyConstants.APPLICATION_CAVEATS] = eoi_results["caveats"]
+                caveats = eoi_results["caveats"]
+                try:
+                    notification = get_notification_service().send_eoi_pass_with_caveats_email(
+                        email_address=account.email,
+                        contact_name=full_name.title() if full_name else None,
+                        language=language,
+                        fund_id=fund_id,
+                        fund_name=fund_name,
+                        application_reference=application_reference,
+                        submission_date=submission_date,
+                        round_name=round_name,
+                        questions=questions,
+                        caveats=caveats,
+                        contact_help_email=round_data.contact_email,
+                    )
+                except NotificationError:
+                    current_app.logger.exception("Failed to send EOI Pass (with caveats) email")
+
             case _:
                 current_app.logger.error(
                     "Unknown eoi_decision [{eoi_decision}], unable to send submit notification",
@@ -76,16 +111,23 @@ def send_submit_notification(
                 )
                 return
     else:
-        notify_template = Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION
+        try:
+            notification = get_notification_service().send_submit_application_email(
+                email_address=account.email,
+                language=language,
+                fund_name=fund_name,
+                application_reference=application_reference,
+                submission_date=submission_date,
+                round_name=round_name,
+                questions=questions,
+                prospectus_url=prospectus_url,
+                contact_help_email=round_data.contact_email,
+            )
+        except NotificationError:
+            current_app.logger.exception("Failed to send submitted application email")
 
-    message_id = Notification.send(
-        notify_template,
-        account.email,
-        full_name.title() if full_name else None,
-        contents,
-    )
-
-    current_app.logger.info(
-        "Message added to the notification queue msg_id: [{message_id}]",
-        extra=dict(message_id=message_id),
-    )
+    if notification:
+        current_app.logger.info(
+            "Sent notification {notification_id} for application {application_reference}",
+            extra=dict(notification_id=notification.id, application_reference=application_reference),
+        )

--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -25,6 +25,19 @@ class Notification:
     id: uuid.UUID
 
 
+def _format_submitted_datetime(submission_date):
+    if submission_date is None:
+        return submission_date
+
+    UTC_timezone = pytz.timezone("UTC")
+    UK_timezone = pytz.timezone("Europe/London")
+    UK_datetime = UTC_timezone.localize(datetime.strptime(submission_date, "%Y-%m-%dT%H:%M:%S.%f")).astimezone(
+        UK_timezone
+    )
+
+    return UK_datetime.strftime(f"{'%d %B %Y'} at {'%I:%M%p'}").replace("AM", "am").replace("PM", "pm")
+
+
 class NotificationService:
     MAGIC_LINK_TEMPLATE_ID = os.environ.get("MAGIC_LINK_TEMPLATE_ID", "02a6d48a-f227-4b9a-9dd7-9e0cf203c8a2")
 
@@ -176,16 +189,7 @@ class NotificationService:
             "template_id"
         ].get(language, "en")
 
-        if submission_date is not None:
-            UTC_timezone = pytz.timezone("UTC")
-            UK_timezone = pytz.timezone("Europe/London")
-            UK_datetime = UTC_timezone.localize(datetime.strptime(submission_date, "%Y-%m-%dT%H:%M:%S.%f")).astimezone(
-                UK_timezone
-            )
-
-            submission_date = (
-                UK_datetime.strftime(f"{'%d %B %Y'} at {'%I:%M%p'}").replace("AM", "am").replace("PM", "pm")
-            )
+        submission_date = _format_submitted_datetime(submission_date)
 
         return self._send_email(
             email_address,
@@ -226,16 +230,7 @@ class NotificationService:
             NotifyConstants.TEMPLATE_TYPE_EOI_PASS_W_CAVEATS
         ]["template_id"].get(language, "en")
 
-        if submission_date is not None:
-            UTC_timezone = pytz.timezone("UTC")
-            UK_timezone = pytz.timezone("Europe/London")
-            UK_datetime = UTC_timezone.localize(datetime.strptime(submission_date, "%Y-%m-%dT%H:%M:%S.%f")).astimezone(
-                UK_timezone
-            )
-
-            submission_date = (
-                UK_datetime.strftime(f"{'%d %B %Y'} at {'%I:%M%p'}").replace("AM", "am").replace("PM", "pm")
-            )
+        submission_date = _format_submitted_datetime(submission_date)
 
         return self._send_email(
             email_address,
@@ -277,16 +272,7 @@ class NotificationService:
             else self.APPLICATION_SUBMISSION_TEMPLATE_ID_EN
         )
 
-        if submission_date is not None:
-            UTC_timezone = pytz.timezone("UTC")
-            UK_timezone = pytz.timezone("Europe/London")
-            UK_datetime = UTC_timezone.localize(datetime.strptime(submission_date, "%Y-%m-%dT%H:%M:%S.%f")).astimezone(
-                UK_timezone
-            )
-
-            submission_date = (
-                UK_datetime.strftime(f"{'%d %B %Y'} at {'%I:%M%p'}").replace("AM", "am").replace("PM", "pm")
-            )
+        submission_date = _format_submitted_datetime(submission_date)
 
         return self._send_email(
             email_address,

--- a/tests/application_store_tests/api_data/get_endpoint_data.json
+++ b/tests/application_store_tests/api_data/get_endpoint_data.json
@@ -28,50 +28,80 @@
       "name": "COF",
       "short_name": "COF",
       "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
-      "description": "An example fund for testing the funding service"
+      "description": "An example fund for testing the funding service",
+      "welsh_available": false,
+      "name_json": {"en": "Community Ownership Fund", "cy": ""},
+      "funding_type": "COMPETITIVE"
     },
     {
       "name": "Fund B",
       "short_name": "FUB",
       "id": "fund-b",
-      "description": "An example fund for testing the funding service"
+      "description": "An example fund for testing the funding service",
+      "welsh_available": false,
+      "name_json": {"en": "Fund B", "cy": ""},
+      "funding_type": "COMPETITIVE"
     },
     {
       "name": "Funding Service Design",
       "short_name": "FSD",
       "id": "funding-service-design",
-      "description": "An example fund for testing the funding service"
+      "description": "An example fund for testing the funding service",
+      "welsh_available": false,
+      "name_json": {"en": "Funding Service Design", "cy": ""},
+      "funding_type": "COMPETITIVE"
     },
     {
       "name": "Community Ownership Fund",
       "short_name": "CON",
       "id": "community-ownership-fund",
-      "description": "An example Community Ownership Fund for testing the funding service"
+      "description": "An example Community Ownership Fund for testing the funding service",
+      "welsh_available": true,
+      "name_json": {
+          "en": "Community Ownership Fund",
+          "cy": "Y Cronfa Perchnogaeth Gymunedol"
+      },
+      "funding_type": "COMPETITIVE"
     }
   ],
   "fund_store/funds/47aef2f5-3fcb-4d45-acb5-f0152b5f03c4": {
     "name": "COF",
     "short_name": "COF",
     "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
-    "description": "An example fund for testing the funding service"
+    "description": "An example fund for testing the funding service",
+    "welsh_available": false,
+    "name_json": {"en": "Community Ownership Fund", "cy": ""},
+      "funding_type": "COMPETITIVE"
   },
   "fund_store/funds/fund-b": {
     "name": "Fund B",
     "short_name": "FUB",
     "id": "fund-b",
-    "description": "An example fund for testing the funding service"
+    "description": "An example fund for testing the funding service",
+    "welsh_available": false,
+    "name_json": {"en": "Fund B", "cy": ""},
+      "funding_type": "COMPETITIVE"
   },
   "fund_store/funds/funding-service-design": {
     "name": "Funding Service Design",
     "short_name": "FSD",
     "id": "funding-service-design",
-    "description": "An example fund for testing the funding service"
+    "description": "An example fund for testing the funding service",
+    "welsh_available": false,
+    "name_json": {"en": "Funding Service Design", "cy": ""},
+      "funding_type": "COMPETITIVE"
   },
   "fund_store/funds/community-ownership-fund": {
     "name": "COF",
     "short_name": "CON",
     "id": "community-ownership-fund",
-    "description": "An example Community Ownership Fund for testing the funding service"
+    "description": "An example Community Ownership Fund for testing the funding service",
+    "welsh_available": true,
+    "name_json": {
+        "en": "Community Ownership Fund",
+        "cy": "Y Cronfa Perchnogaeth Gymunedol"
+    },
+    "funding_type": "COMPETITIVE"
   },
   "fund_store/funds/47aef2f5-3fcb-4d45-acb5-f0152b5f03c4/rounds": [
     {

--- a/tests/test_services/test_notify.py
+++ b/tests/test_services/test_notify.py
@@ -32,7 +32,7 @@ class TestNotificationService:
                     }
                 )
             ],
-            json={"id": "00000000-0000-0000-0000-000000000000"},
+            json={"id": "00000000-0000-0000-0000-000000000000"},  # partial GOV.UK Notify response
         )
 
         resp = get_notification_service().send_magic_link(
@@ -44,4 +44,144 @@ class TestNotificationService:
             "abc123",
         )
         assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000000"))
+        assert request_matcher.call_count == 1
+
+    @responses.activate
+    def test_send_eoi_pass_email(self, app):
+        request_matcher = responses.post(
+            url="https://api.notifications.service.gov.uk/v2/notifications/email",
+            status=201,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "email_address": "test@test.com",
+                        "template_id": "04db42f4-a74e-4ab3-b9e2-565592fd6f46",
+                        "personalisation": {
+                            "name of fund": "COF-EOI",
+                            "application reference": "app-123",
+                            "date submitted": "10 February 2024 at 10:00am",
+                            "round name": "test round",
+                            "question": {
+                                "file": "YWJjMTIz",  # base64 `abc123`
+                                "filename": None,
+                                "confirm_email_before_download": None,
+                                "retention_period": None,
+                            },
+                            "full name": "Test User",
+                        },
+                        "reference": "abc123",
+                    }
+                )
+            ],
+            json={"id": "00000000-0000-0000-0000-000000000001"},  # partial GOV.UK Notify response
+        )
+
+        resp = get_notification_service().send_eoi_pass_email(
+            "test@test.com",
+            "Test User",
+            language="en",
+            fund_id="54c11ec2-0b16-46bb-80d2-f210e47a8791",
+            fund_name="COF-EOI",
+            application_reference="app-123",
+            submission_date="2024-02-10T10:00:00.000000",
+            round_name="test round",
+            questions="YWJjMTIz",
+            contact_help_email="contact@test.com",
+            govuk_notify_reference="abc123",
+        )
+        assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000001"))
+        assert request_matcher.call_count == 1
+
+    @responses.activate
+    def test_send_eoi_pass_with_caveats_email(self, app):
+        request_matcher = responses.post(
+            url="https://api.notifications.service.gov.uk/v2/notifications/email",
+            status=201,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "email_address": "test@test.com",
+                        "template_id": "705684c7-6985-4d4c-9170-08a85f47b8e1",
+                        "personalisation": {
+                            "name of fund": "COF-EOI",
+                            "application reference": "app-123",
+                            "date submitted": "10 February 2024 at 10:00am",
+                            "round name": "test round",
+                            "question": {
+                                "file": "YWJjMTIz",  # base64 `abc123`
+                                "filename": None,
+                                "confirm_email_before_download": None,
+                                "retention_period": None,
+                            },
+                            "caveats": ["a", "b", "c"],
+                            "full name": "Test User",
+                        },
+                        "reference": "abc123",
+                    }
+                )
+            ],
+            json={"id": "00000000-0000-0000-0000-000000000002"},  # partial GOV.UK Notify response
+        )
+
+        resp = get_notification_service().send_eoi_pass_with_caveats_email(
+            "test@test.com",
+            "Test User",
+            language="en",
+            fund_id="54c11ec2-0b16-46bb-80d2-f210e47a8791",
+            fund_name="COF-EOI",
+            application_reference="app-123",
+            submission_date="2024-02-10T10:00:00.000000",
+            round_name="test round",
+            questions="YWJjMTIz",
+            caveats=["a", "b", "c"],
+            contact_help_email="contact@test.com",
+            govuk_notify_reference="abc123",
+        )
+        assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000002"))
+        assert request_matcher.call_count == 1
+
+    @responses.activate
+    def test_send_submit_application_email(self, app):
+        request_matcher = responses.post(
+            url="https://api.notifications.service.gov.uk/v2/notifications/email",
+            status=201,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "email_address": "test@test.com",
+                        "template_id": "6adbba70-2fde-4ca7-94cb-7f7eb264efaa",
+                        "personalisation": {
+                            "name of fund": "COF-EOI",
+                            "application reference": "app-123",
+                            "date submitted": "10 February 2024 at 10:00am",
+                            "round name": "test round",
+                            "question": {
+                                "file": "YWJjMTIz",
+                                "filename": None,
+                                "confirm_email_before_download": None,
+                                "retention_period": None,
+                            },
+                            "URL of prospectus": "https://prospectus",
+                            "contact email": "contact@test.com",
+                        },
+                        "reference": "abc123",
+                    }
+                )
+            ],
+            json={"id": "00000000-0000-0000-0000-000000000003"},  # partial GOV.UK Notify response
+        )
+
+        resp = get_notification_service().send_submit_application_email(
+            "test@test.com",
+            language="en",
+            fund_name="COF-EOI",
+            application_reference="app-123",
+            submission_date="2024-02-10T10:00:00.000000",
+            round_name="test round",
+            questions="YWJjMTIz",
+            prospectus_url="https://prospectus",
+            contact_help_email="contact@test.com",
+            govuk_notify_reference="abc123",
+        )
+        assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000003"))
         assert request_matcher.call_count == 1


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#101**
* **#100**
* ➡️ **#95**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


https://mhclgdigital.atlassian.net/browse/FSPT-172


### Change description
This changes the three emails that get sent when an application is submitted to be sent synchronously to GOV.UK Notify using the new NotificationService.

The three emails are:
* application submitted
* EOI submitted; unconditional pass
* EOI submitted; pass with caveats

The mock data for the fund-store return values were missing some data (at least: welsh_available, name_json). These have been added and the tests have been made slightly more representative of reality, although more foundational work is probably needed here.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Run through the crash test dummy fund locally. Upon submission, you should see an email sent for 'application submitted' in GOV.UK Notify's web API console.
- Open COF-EOI locally and fill in two applications - one that is an unconditional pass, and one that is a pass with caveats.


### Screenshots of UI changes (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
