### PR TITLE
FSPT-192 Temporarily log the pre-pre-award app source

### DIFF
--- a/app.py
+++ b/app.py
@@ -423,6 +423,13 @@ def create_app() -> Flask:  # noqa: C901
 
     @flask_app.before_request
     def filter_all_requests():
+        source_app_host_match = {
+            current_app.config["APPLY_HOST"]: "apply_frontend",
+            current_app.config["ASSESS_HOST"]: "assess_frontend",
+            current_app.config["AUTH_HOST"]: "authenticator_frontend",
+            current_app.config["API_HOST"]: request.blueprint,
+        }
+        request.get_extra_log_context = lambda: {"source": source_app_host_match.get(request.host)}
         if request.host == current_app.config["API_HOST"]:
             return
 


### PR DESCRIPTION
One method of including information about which app a request was for in the logs.

We expect that the stores/ frontend boundaries will be removed very soon so this doesn't need to exist for very long, in the meantime it should help developers see which context a log came from.

In the future the top level blueprints that are decided on could specify their own `@bp.after_request` which could include a common key representing the domain boundary (likely "apply" or "assess").

As the "API_HOST" is shared between the 4 stores (application, assessment, account and fund) log the string version of the blueprint used to serve that API request - this relies on the convention that the blueprints are named appropriately but should work for now.

---

Note this doesn't anticipate what would happen (and would break) if there is no host on the request object. I don't think this is possible but sensible code would definitely not want to break in this before request hook!