### PR TITLE
Help SQL Alchemy with conflicts

### DIFF
--- a/assessment_store/db/models/assessment_record/assessment_records.py
+++ b/assessment_store/db/models/assessment_record/assessment_records.py
@@ -71,6 +71,7 @@ class AssessmentRecord(BaseModel):
         "AssessmentFlag",
         primaryjoin="and_(AssessmentFlag.application_id == AssessmentRecord.application_id, "
         "AssessmentFlag.is_change_request == True)",
+        overlaps="flags",
     )
     # These are defined as column_properties not as hybrid_property due to performance
     # Using column_property below forces the json parsing to be done on the DB side which is quicker than in python


### PR DESCRIPTION
Fix sql alchemy conflict warning on `make pre up`:

```
/Users/sam/git/runner/apps/funding-service-pre-award/.venv/lib/python3.10/site-packages/marshmallow_sqlalchemy/convert.py:124: SAWarning: relationship 'AssessmentRecord.change_requests' will copy column assessmen
t_records.application_id to column assessment_flag.application_id, which conflicts with relationship(s): 'AssessmentRecord.flags' (copies assessment_records.application_id to assessment_flag.application_id). If t
his is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign ke
y constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="flags"' to the 'Ass
essmentRecord.change_requests' relationship. (Background on this warning at: https://sqlalche.me/e/20/qzyx) (This warning originated from the `configure_mappers()` process, which was invoked automatically in resp
onse to a user-initiated operation.)
```

### How to test
Do a `make pre up` you won't see the error anymore.