### PR TITLE
Make "incomplete application" email synchronous

### DIFF
--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -295,6 +295,35 @@ class NotificationService:
             email_reply_to_id=self.REPLY_TO_EMAILS_WITH_NOTIFY_ID.get(contact_help_email),
         )
 
+    def send_incomplete_application_email(
+        self,
+        email_address: str,
+        fund_name: str,
+        application_reference: str,
+        round_name: str,
+        questions: str,
+        contact_help_email: str,
+        govuk_notify_reference: str | None = None,
+    ) -> Notification:
+        return self._send_email(
+            email_address,
+            self.APPLICATION_INCOMPLETE_TEMPLATE_ID,
+            personalisation={
+                "name of fund": fund_name,
+                "application reference": application_reference,
+                "round name": round_name,
+                "question": {
+                    "file": questions,
+                    "filename": None,
+                    "confirm_email_before_download": None,
+                    "retention_period": None,
+                },
+                "contact email": contact_help_email,
+            },
+            govuk_notify_reference=govuk_notify_reference,
+            email_reply_to_id=self.REPLY_TO_EMAILS_WITH_NOTIFY_ID.get(contact_help_email),
+        )
+
 
 def get_notification_service() -> NotificationService:
     return current_app.extensions["notification_service"]


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#101**
* ➡️ **#100**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


https://mhclgdigital.atlassian.net/browse/FSPT-172

### Change description
This changes the "incomplete application" email send when a fund round closes and people have applications which have been started but not submitted.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Start an application for the crash test dummy fund.
2. Set the `round.deadline` value for Crash Round 1 to a date in the past.
3. Open a shell in the pre-award container with `docker exec -it funding-service-pre-award-1 bash`
3. Run `PYTHONPATH=. python application_store/scripts/send_application_on_closure.py --fund_id 3dcfa617-cff8-4c2c-9edd-9568aa367d13 --round_id 7ecd7d64-1854-44ab-a10c-a7af4b8d68e1 --send_email true --single_application false` from inside the `pre-award` docker container.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
