### PR TITLE
Fix failing test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,5 @@ dev = [
     "requests-mock==1.11.0",
     "ruff==0.8.4",
     "flask-debugtoolbar==0.16.0",
+    "freezegun>=1.5.1",
 ]

--- a/tests/application_store_tests/test_send_app_on_closure.py
+++ b/tests/application_store_tests/test_send_app_on_closure.py
@@ -1,4 +1,5 @@
 import pytest
+from freezegun import freeze_time
 from pytest import raises
 
 from application_store.scripts.send_application_on_closure import (
@@ -210,6 +211,7 @@ class TestSendAppOnClosure:
         result = send_incomplete_applications_after_deadline(unique_fund_round[0], unique_fund_round[1], False)
         assert 1 == result, "Unexpected result number"
 
+    @freeze_time("2024-01-01")
     def test_send_apps_before_deadline(self, mocker, app, mocked_get_fund):
         fund_id = "abc123"
         round_id = "987gfd"

--- a/uv.lock
+++ b/uv.lock
@@ -718,6 +718,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/ce/18f6d9969416d8c9e0728f042091717606f2cd46d570aff6533ce587e71f/flupy-1.2.1.tar.gz", hash = "sha256:42aab3b4b3eb1984a4616c40d8f049ecdee546eaad9467470731d456dbff7fa4", size = 12346 }
 
 [[package]]
+name = "freezegun"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ef/722b8d71ddf4d48f25f6d78aa2533d505bf3eec000a7cacb8ccc8de61f2f/freezegun-1.5.1.tar.gz", hash = "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9", size = 33697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/0b/0d7fee5919bccc1fdc1c2a7528b98f65c6f69b223a3fd8f809918c142c36/freezegun-1.5.1-py3-none-any.whl", hash = "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1", size = 17569 },
+]
+
+[[package]]
 name = "funding-service-design-utils"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -816,6 +828,7 @@ dev = [
     { name = "deepdiff" },
     { name = "dparse" },
     { name = "flask-debugtoolbar" },
+    { name = "freezegun" },
     { name = "invoke" },
     { name = "json2html" },
     { name = "moto", extra = ["s3"] },
@@ -892,6 +905,7 @@ dev = [
     { name = "deepdiff", specifier = "==8.0.1" },
     { name = "dparse", specifier = "==0.6.4" },
     { name = "flask-debugtoolbar", specifier = "==0.16.0" },
+    { name = "freezegun", specifier = ">=1.5.1" },
     { name = "invoke", specifier = "==2.2.0" },
     { name = "json2html", specifier = "==1.3.0" },
     { name = "moto", extras = ["s3", "sqs"], specifier = "==5.0.23" },


### PR DESCRIPTION
Add freezegun dev dependency to fix test.

Test was failing because it had a hardcoded date that's supposed to be in the future: 2025-01-01

Now that the date is in the past, it failed.

Freezegun freezes the time to 2024-01-01 for the test so that it will forever pass.