### PR TITLE
Change API host for scheduled jobs

### DIFF
--- a/account_store/core/account.py
+++ b/account_store/core/account.py
@@ -69,7 +69,10 @@ def get_bulk_accounts() -> Dict:
     :return:
         Nested dict of account_id: {account object}
     """
-    account_id = request.args.getlist("account_id")
+    raw_account_id = request.args.getlist("account_id")
+
+    # Filter out any empty/blank strings like '', which could happen with eg `?account_id=`
+    account_id = [account_id for account_id in raw_account_id if account_id]
     if not account_id:
         return {"error": "Bad request: please provide at least 1 account_id "}, 400
 

--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -60,7 +60,7 @@ variables:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-NotificationDeadLetterQueueURL
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   SENTRY_TRACES_SAMPLE_RATE: 1.0
-  API_HOST: "fsd-pre-award"
+  API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"
 
   ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
   APPLICANT_FRONTEND_HOST: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk" # TODO: remove me when all frontends combined
@@ -195,7 +195,7 @@ environments:
       APPLY_HOST: "frontend.access-funding.levellingup.gov.uk"
       ASSESS_HOST: "assessment.access-funding.levellingup.gov.uk"
       AUTH_HOST: "authenticator.access-funding.levellingup.gov.uk"
-      API_HOST: fsd-pre-award:8080
+      API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local:8080"
       APPLICANT_FRONTEND_HOST: "https://frontend.access-funding.levellingup.gov.uk" # TODO: remove me when all frontends combined
       FORMS_SERVICE_PUBLIC_HOST: "https://forms.access-funding.levellingup.gov.uk"
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.levellingup.gov.uk"


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-207

Change the host that API endpoints are exposed on from just the copilot app name (fsd-pre-award), to the app name plus service discovery namespace (fsd-pre-award.<env>.pre-award.local).

This is because we have a scheduled ECS task for post-award that talks to the account-store. Scheduled tasks are not able to resolve just the app's short name and need the namespace as well, so it would make requests to fsd-pre-award.dev.pre-award.local.

If we only configure the API endpoints' host_matching setting as `fsd-pre-award`, then those requests will 404. So we either need to support _both_ fsd-pre-award and the FQDN on API endpoints (more complex code change), or just switch everything to use the FQDN. This does the latter.

This deployment needs to be done in sync with updates to all of the FSD_PRE_AWARD_*_STORE_API_HOST parameter store variables.