### PR TITLE
Fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>communitiesuk/renovate-config"
+    "github>communitiesuk/renovate-config"
   ]
 }


### PR DESCRIPTION
This should be pointing at github-hosted config, not whatever `local` is.

https://docs.renovatebot.com/config-presets/#github