### PR TITLE
Updating template ID for welsh translation

### DIFF
--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -80,8 +80,8 @@ class NotificationService:
         "APPLICATION_SUBMISSION_TEMPLATE_ID_EN", "6adbba70-2fde-4ca7-94cb-7f7eb264efaa"
     )
     APPLICATION_SUBMISSION_TEMPLATE_ID_CY = os.environ.get(
-        "APPLICATION_SUBMISSION_TEMPLATE_ID_CY", "6adbba70-2fde-4ca7-94cb-7f7eb264efaa"
-    )  # TODO update once translation received
+        "APPLICATION_SUBMISSION_TEMPLATE_ID_CY", "60bb6baa-0ef9-4059-954e-7c2744e6c63a"
+    )
 
     APPLICATION_INCOMPLETE_TEMPLATE_ID = os.environ.get(
         "APPLICATION_INCOMPLETE_TEMPLATE_ID", "944cb37d-c9e0-4731-88f5-d752514da57f"

--- a/tests/test_services/test_notify.py
+++ b/tests/test_services/test_notify.py
@@ -228,6 +228,52 @@ class TestNotificationService:
         assert request_matcher.call_count == 1
 
     @responses.activate
+    def test_send_submit_application_email_welsh(self, app):
+        request_matcher = responses.post(
+            url="https://api.notifications.service.gov.uk/v2/notifications/email",
+            status=201,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "email_address": "test@test.com",
+                        "template_id": "60bb6baa-0ef9-4059-954e-7c2744e6c63a",
+                        "personalisation": {
+                            "name of fund": "COF-EOI",
+                            "application reference": "app-123",
+                            "date submitted": "10 February 2024 at 10:00am",
+                            "round name": "test round",
+                            "question": {
+                                "file": "YWJjMTIz",
+                                "filename": None,
+                                "confirm_email_before_download": None,
+                                "retention_period": None,
+                            },
+                            "URL of prospectus": "https://prospectus",
+                            "contact email": "contact@test.com",
+                        },
+                        "reference": "abc123",
+                    }
+                )
+            ],
+            json={"id": "00000000-0000-0000-0000-000000000003"},  # partial GOV.UK Notify response
+        )
+
+        resp = get_notification_service().send_submit_application_email(
+            "test@test.com",
+            language="cy",
+            fund_name="COF-EOI",
+            application_reference="app-123",
+            submission_date="2024-02-10T10:00:00.000000",
+            round_name="test round",
+            questions="YWJjMTIz",
+            prospectus_url="https://prospectus",
+            contact_help_email="contact@test.com",
+            govuk_notify_reference="abc123",
+        )
+        assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000003"))
+        assert request_matcher.call_count == 1
+
+    @responses.activate
     def test_send_application_deadline_reminder_email(self, app):
         request_matcher = responses.post(
             url="https://api.notifications.service.gov.uk/v2/notifications/email",


### PR DESCRIPTION
### Change description
Updating template ID for Application Record of Submission (Welsh) now the translation for the new generic template is available.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Submit an application in welsh
The welsh 'record of submission' email template should be used.


### Screenshots of UI changes (if applicable)
Screenshots of email being sent are on the ticket comments: https://mhclgdigital.atlassian.net/browse/FSPT-131
