### PR TITLE
Fix rendering of assessment PDF

### DIFF
--- a/assess/assessments/models/full_application.py
+++ b/assess/assessments/models/full_application.py
@@ -74,4 +74,4 @@ class FullApplicationPdfContext:
         )
 
 
-generate_full_application_pdf = partial(generate_pdf, "app/blueprints/assessments/templates/full_application.html")
+generate_full_application_pdf = partial(generate_pdf, "assessments/full_application.html")

--- a/assess/assessments/pdf_generator.py
+++ b/assess/assessments/pdf_generator.py
@@ -1,13 +1,7 @@
 from io import BytesIO
 
-from jinja2 import Environment, FileSystemLoader
+from flask import render_template
 from xhtml2pdf import pisa
-
-
-def _render_template(template_path: str, context) -> str:
-    env = Environment(loader=FileSystemLoader("."), autoescape=True)
-    template = env.get_template(template_path)
-    return template.render(context)
 
 
 class PDFCreationException(Exception):
@@ -41,7 +35,7 @@ def generate_pdf(template_path: str, context) -> BytesIO:
         from functools import partial
 
         generate_full_application_pdf = partial(
-            generate_pdf, "app/pdf/templates/full_application.html"
+            generate_pdf, "assessments/full_application.html"
         )
         ```
 
@@ -49,6 +43,6 @@ def generate_pdf(template_path: str, context) -> BytesIO:
         the "full_application.html" template and convert it to a PDF.
     """
     pdf_file = BytesIO()
-    html_content = _render_template(template_path, context)
+    html_content = render_template(template_path, **context)
     _convert_html_to_pdf(html_content, pdf_file)
     return pdf_file

--- a/fund_store/scripts/generate_all_questions.py
+++ b/fund_store/scripts/generate_all_questions.py
@@ -152,13 +152,13 @@ def print_html(sections: dict) -> str:
 )
 @click.option(
     "--output_location",
-    default="../funding-service-design-frontend/app/templates/all_questions/",
+    default="../apply/templates/apply/all_questions/",
     help="Folder to write output html to (language code will be appended as an intermediate path)",
     prompt=True,
 )
 @click.option(
     "--forms_dir",
-    default="../digital-form-builder/fsd_config/form_jsons/",
+    default="../../digital-form-builder/fsd_config/form_jsons/",
     help="Local, absolute path, to the form JSONs to use to generate question lists",
     prompt=True,
 )

--- a/tests/assess_tests/test_pdf_generator.py
+++ b/tests/assess_tests/test_pdf_generator.py
@@ -8,7 +8,7 @@ from assess.assessments.pdf_generator import PDFCreationException, generate_pdf
 
 @pytest.fixture
 def mock_render_template():
-    with patch("assess.assessments.pdf_generator._render_template") as mock:
+    with patch("assess.assessments.pdf_generator.render_template") as mock:
         mock.return_value = "<html><body>Test PDF</body></html>"
         yield mock
 
@@ -32,7 +32,7 @@ def test_generate_pdf_successful(mock_render_template, mock_convert_html_to_pdf_
 
     pdf_file = generate_pdf(template_path, context)
 
-    mock_render_template.assert_called_once_with(template_path, context)
+    mock_render_template.assert_called_once_with(template_path, **context)
     mock_convert_html_to_pdf_success.assert_called_once()
     assert isinstance(pdf_file, BytesIO)
 
@@ -44,5 +44,5 @@ def test_generate_pdf_with_error(mock_render_template, mock_convert_html_to_pdf_
     with pytest.raises(PDFCreationException, match="Mocked Error"):
         generate_pdf(template_path, context)
 
-    mock_render_template.assert_called_once_with(template_path, context)
+    mock_render_template.assert_called_once_with(template_path, **context)
     mock_convert_html_to_pdf_error.assert_called_once()


### PR DESCRIPTION
There were a couple of issues with this that we fix here:

* The path to the template to render (full_application.html) has been broken since we consolidate repos. This fixes the path, and removes some of the custom jinja environment handling because that isn't needed any more.
* Update a couple of path references in docstrings and default CLI args.

## To test
1. Submit an application
2. Go to the assessment
3. Visit the `/export` URL, eg https://assessment.levellingup.gov.localhost:3010/assess/application/3dc45a6c-8284-4b94-b90d-81b593a8cd54/export
4. Click 'download PDF'