### PR TITLE
FSPT-208 Serialise application date submitted in a guaranteed format

### DIFF
--- a/application_store/db/schemas/application.py
+++ b/application_store/db/schemas/application.py
@@ -37,5 +37,6 @@ class ApplicationSchema(SQLAlchemyAutoSchema):
     started_at = DateTime(format="iso")
     status = Enum(Status)
     last_edited = DateTime(format="iso")
+    date_submitted = DateTime(format="%Y-%m-%dT%H:%M:%S.%f")
     round_name = Method("get_round_name")
     forms = Nested(FormsRunnerSchema, many=True, allow_none=True)

--- a/tests/application_store_tests/test_submit.py
+++ b/tests/application_store_tests/test_submit.py
@@ -226,6 +226,11 @@ def test_submit_route_success(
     assert assessment_record
     assert assessment_record.jsonb_blob["forms"]
 
+    try:
+        datetime.strptime(assessment_record.jsonb_blob["date_submitted"], "%Y-%m-%dT%H:%M:%S.%f")
+    except ValueError as e:
+        pytest.fail(f"Unexpected serialised application date format {e}")
+
 
 def test_submit_route_submit_error(flask_test_client, seed_application_records, mocker, mock_successful_location_call):
     target_application = seed_application_records[0]


### PR DESCRIPTION
`date_submitted` is stored both in the application table and in the JSON representation of an application used by the assess tool.

Marshmallow will serialise the properties from the application model depending on if there is timezone information included or not. Previously the application store was first "submitting" an application (updating the status and setting the `date_submitted` property) in one database transaction and then separately fetching the application and putting in on a queue to be processed by assess.

When we changed this behaviour to update the application and write to the assessment table in one transaction we don't fetch a new application from the database.

When the `date_submitted` property is set directly in the code we have been including `timezone.utc` on the `datetime` property. When the application is fetched from the database it does not include (or store) the timezone information - I'm assuming everything by default is in UTC.

This means that we changed to serialising the JSON with timezone information (`+00.00`) which caused issues when the assessment code tried to serialise it.

This is one method of dealing with that and explicitly instructs marshmallow to serialise the JSON (then stored in the `jsonb_blob` property of assessments) using the format that has been used so far.