### PR TITLE
FSPT-208 Set the application date submitted property using sql alchemy utils

### DIFF
--- a/application_store/db/queries/application/queries.py
+++ b/application_store/db/queries/application/queries.py
@@ -277,7 +277,7 @@ def submit_application(application_id) -> Applications:  # noqa: C901
         application = process_files(application, all_application_files)
 
         # Mark the application as submitted
-        application.date_submitted = datetime.now(timezone.utc)
+        application.date_submitted = func.now()
         application.status = ApplicationStatus.SUBMITTED
 
         application_type = "".join(application.reference.split("-")[:1])


### PR DESCRIPTION
This resolves the issue with timestamps by using an sql alchemy util that will use the databases now equivalent (`CURRENT_TIMESTAMP` in postgres).

Assuming that our we treat our Postgres dates as default UTC, this should have the added benefit of lining up with all of the other dates that are populated by the database. Relying on apps to generate accurate and consistent times can cause issues with minor drift and there can be benefits to having a single database instance own as much of date/ timestamp generation as possible.

In this case this resolves the issue as the `date_submitted` property that is then returned is read consistently from the model as it has come from the database - that means it won't include timezone information and will be serialised consistently with the previous application store method.

---

`date_submitted` is stored both in the application table and in the JSON representation of an application used by the assess tool.

Marshmallow will serialise the properties from the application model depending on if there is timezone information included or not. Previously the application store was first "submitting" an application (updating the status and setting the `date_submitted` property) in one database transaction and then separately fetching the application and putting in on a queue to be processed by assess.

When we changed this behaviour to update the application and write to the assessment table in one transaction we don't fetch a new application from the database.

When the `date_submitted` property is set directly in the code we have been including `timezone.utc` on the `datetime` property. When the application is fetched from the database it does not include (or store) the timezone information - I'm assuming everything by default is in UTC.

This means that we changed to serialising the JSON with timezone information (`+00.00`) which caused issues when the assessment code tried to serialise it.

