### PR TITLE
FSPT-208 Script to make nested JSON date strings consistent

### DIFF
--- a/assessment_store/scripts/data_updates/FSPT-208-fix-inconsistent-date-strings.sql
+++ b/assessment_store/scripts/data_updates/FSPT-208-fix-inconsistent-date-strings.sql
@@ -1,0 +1,15 @@
+begin;
+
+/* Check the result is {some} */
+select count(*) from assessment_records where jsonb_blob->>'date_submitted' like '%+00.00';
+
+/* Check we've updated {some} */
+update assessment_records
+set jsonb_blob['date_submitted'] = to_jsonb(replace(jsonb_blob->>'date_submitted', '+00.00', ''))
+where jsonb_blob->>'date_submitted' like '%+00.00';
+
+/* Check the result is 0 */
+select count(*) from assessment_records where jsonb_blob->>'date_submitted' like '%+00.00';
+
+/* Only commit if everything lined up as expected */
+commit;


### PR DESCRIPTION
For a ~2 week period application `date_submitted` properties were incorrectly set with timezone information (in this case consistently UTC with `+00.00`).

The consumer of these dates (the assess tool) has been updated in places to parse any valid ISO format but leaving different formats of dates could lead to unpredictable behaviour.

Update existing assessment records to make this consistent.

Depends on https://github.com/communitiesuk/funding-service-pre-award/pull/126