### PR TITLE
Assess frontend hotfix

### DIFF
--- a/assess/assessments/routes.py
+++ b/assess/assessments/routes.py
@@ -1537,6 +1537,7 @@ def application(application_id):
         )
 
     state = get_state_for_tasklist_banner(application_id)
+    flags_list = get_flags(application_id)
 
     comment_response = get_comments(
         application_id=application_id,

--- a/assess/services/data_services.py
+++ b/assess/services/data_services.py
@@ -545,7 +545,7 @@ def get_change_requests(application_id: str) -> List[Flag]:
     flags_data = get_data(Config.ASSESSMENT_FLAGS_ENDPOINT.format(application_id=application_id))
 
     if flags_data:
-        return [flag for flag in Flag.from_list(flags_data) if not flag.is_change_request]
+        return [flag for flag in Flag.from_list(flags_data) if flag.is_change_request]
     else:
         return []
 


### PR DESCRIPTION
- Reverting removing the `flags_list = get_flags(application_id)` form the applications() view. I still think it does nothing, but it's the only change I did directly inside of the view
- Removing an extra `not` form `get_change_requests` function