### PR TITLE
Change format style of log messages

### DIFF
--- a/account_store/db/models/account.py
+++ b/account_store/db/models/account.py
@@ -24,5 +24,5 @@ class Account(db.Model):
     def highest_role_map(self) -> Mapping[str, str]:
         roles_as_strings = [r.role for r in self.roles]
         role_map = get_highest_role_map(roles_as_strings)
-        current_app.logger.debug("Role map for {id}: {role_map}", extra=dict(id=self.id, role_map=role_map))
+        current_app.logger.debug("Role map for %(id)s: %(role_map)s", dict(id=self.id, role_map=role_map))
         return role_map

--- a/app.py
+++ b/app.py
@@ -348,11 +348,11 @@ def create_app() -> Flask:  # noqa: C901
                     fund = find_fund_in_request()
                 except Exception as e:  # noqa
                     current_app.logger.warning(
-                        "Exception: %s, occured when trying to reach url: %s, with view_args: %s, and args: %s",
-                        e,
-                        request.url,
-                        request.view_args,
-                        request.args,
+                        (
+                            "Exception: %(e)s, occured when trying to reach url: %(url)s, "
+                            "with view_args: %(view_args)s, and args: %(args)s"
+                        ),
+                        dict(e=e, url=request.url, view_args=request.view_args, args=request.args),
                     )
             if fund:
                 return gettext("Apply for") + " " + fund.title
@@ -396,11 +396,11 @@ def create_app() -> Flask:  # noqa: C901
                 )
         except Exception as e:  # noqa
             current_app.logger.warning(
-                "Exception: %s, occured when trying to reach url: %s, with view_args: %s, and args: %s",
-                e,
-                request.url,
-                request.view_args,
-                request.args,
+                (
+                    "Exception: %(e)s, occured when trying to reach url: %(url)s, "
+                    "with view_args: %(view_args)s, and args: %(args)s"
+                ),
+                dict(e=e, url=request.url, view_args=request.view_args, args=request.args),
             )
         return dict(
             accessibility_statement_url=url_for("content_routes.accessibility_statement"),
@@ -440,7 +440,7 @@ def create_app() -> Flask:  # noqa: C901
             request.path.endswith("js") or request.path.endswith("css") or request.path.endswith("/healthcheck")
         ):
             current_app.logger.warning(
-                "Application is in the Maintenance mode reach url: {url}", extra=dict(url=request.url)
+                "Application is in the Maintenance mode reach url: %(url)s", dict(url=request.url)
             )
 
             if request.host == current_app.config["ASSESS_HOST"]:

--- a/application_store/_helpers/application.py
+++ b/application_store/_helpers/application.py
@@ -106,8 +106,8 @@ def send_submit_notification(
 
             case _:
                 current_app.logger.error(
-                    "Unknown eoi_decision [{eoi_decision}], unable to send submit notification",
-                    extra=dict(eoi_decision=eoi_decision),
+                    "Unknown eoi_decision [%(eoi_decision)s], unable to send submit notification",
+                    dict(eoi_decision=eoi_decision),
                 )
                 return
     else:
@@ -128,6 +128,6 @@ def send_submit_notification(
 
     if notification:
         current_app.logger.info(
-            "Sent notification {notification_id} for application {application_reference}",
-            extra=dict(notification_id=notification.id, application_reference=application_reference),
+            "Sent notification %(notification_id)s for application %(application_reference)s",
+            dict(notification_id=notification.id, application_reference=application_reference),
         )

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -110,7 +110,9 @@ class ApplicationByIdView(MethodView):
             return_dict = create_qa_base64file(return_dict, with_questions_file)
             return return_dict, 200
         except ValueError as e:
-            current_app.logger.error("Value error getting application ID: {application_id}")
+            current_app.logger.error(
+                "Value error getting application ID: %(application_id)s", dict(application_id=application_id)
+            )
             raise e
         except NoResultFound as e:
             return {"code": 404, "message": str(e)}, 404
@@ -246,8 +248,8 @@ class SubmitApplicationView(MethodView):
 
         except NotificationError:
             current_app.logger.exception(
-                "Notification error on sending SUBMIT notification for application {application_id}",
-                extra=dict(application_id=application_id),
+                "Notification error on sending SUBMIT notification for application %(application_id)s",
+                dict(application_id=application_id),
             )
 
         return {

--- a/application_store/db/queries/application/queries.py
+++ b/application_store/db/queries/application/queries.py
@@ -97,10 +97,10 @@ def _create_application_try(account_id, fund_id, round_id, key, language, refere
     except IntegrityError:
         db.session.remove()
         current_app.logger.error(
-            "Failed {attempt} attempt(s) to create application with"
-            " application reference {reference}, for fund_id"
-            " {fund_id} and round_id {round_id}",
-            extra=dict(attempt=attempt, reference=reference, fund_id=fund_id, round_id=round_id),
+            "Failed %(attempt)s attempt(s) to create application with"
+            " application reference %(reference)s, for fund_id"
+            " %(fund_id)s and round_id %(round_id)s",
+            dict(attempt=attempt, reference=reference, fund_id=fund_id, round_id=round_id),
         )
 
 
@@ -267,8 +267,8 @@ def update_application_fields(existing_json_blob, new_json_blob) -> set:
 
 def submit_application(application_id) -> Applications:  # noqa: C901
     current_app.logger.info(
-        "Submitting application {application_id} and importing to assessment store",
-        extra=dict(application_id=application_id),
+        "Submitting application %(application_id)s and importing to assessment store",
+        dict(application_id=application_id),
     )
     try:
         application = get_application(application_id, include_forms=True)
@@ -343,19 +343,18 @@ def submit_application(application_id) -> Applications:  # noqa: C901
             inserted_application_ids = [item.application_id for item in result]
             if not len(inserted_application_ids):
                 current_app.logger.warning(
-                    "Application already exists in the database: {app_id}", extra=dict(app_id=row["application_id"])
+                    "Application already exists in the database: %(app_id)s", dict(app_id=row["application_id"])
                 )
             else:
                 current_app.logger.info(
-                    "Successfully inserted application: {app_id}", extra=dict(app_id=row["application_id"])
+                    "Successfully inserted application: %(app_id)s", dict(app_id=row["application_id"])
                 )
             db.session.commit()
     except exc.SQLAlchemyError as e:
         db.session.rollback()
-        current_app.logger.error(
-            msg="Error occurred while submitting application {application_id}",
-            exc_info=e,
-            extra=dict(application_id=row["application_id"]),
+        current_app.logger.exception(
+            "Error occurred while submitting application %(application_id)s}",
+            dict(application_id=row["application_id"]),
         )
         raise SubmitError(application_id=application_id) from e
 
@@ -396,8 +395,8 @@ def get_fund_id(application_id):
             return None
     except Exception:
         current_app.logger.error(
-            "Incorrect application id: {application_id}",
-            extra=dict(application_id=application_id),
+            "Incorrect application id: %(application_id)s",
+            dict(application_id=application_id),
         )
         return None
 

--- a/application_store/db/queries/feedback/queries.py
+++ b/application_store/db/queries/feedback/queries.py
@@ -130,8 +130,8 @@ def retrieve_all_feedbacks_and_surveys(fund_id, round_id, status):
             applicant_organisation = result["organisation_name"]
         except Exception as e:
             current_app.logger.error(
-                "Coudn't extract applicant email & organisation.  Exception :{error}",
-                extra=dict(error=e),
+                "Coudn't extract applicant email & organisation. Exception: %(error)s",
+                dict(error=e),
             )
             applicant_email = ""
             applicant_organisation = ""

--- a/application_store/db/queries/updating/queries.py
+++ b/application_store/db/queries/updating/queries.py
@@ -16,8 +16,11 @@ def update_application_and_related_form(application_id, question_json, form_name
     application = get_application(application_id)
     if application.status == ApplicationStatus.SUBMITTED:
         current_app.logger.error(
-            "Not allowed. Attempted to PUT data into a SUBMITTED application with an application_id: {application_id}.",
-            extra=dict(application_id=application_id),
+            (
+                "Not allowed. "
+                "Attempted to PUT data into a SUBMITTED application with an application_id: %(application_id)s."
+            ),
+            dict(application_id=application_id),
         )
         abort(400, "Not allowed to edit a submitted application.")
 
@@ -29,8 +32,8 @@ def update_application_and_related_form(application_id, question_json, form_name
     update_statuses(application_id, form_name, is_summary_page_submit)
     db.session.commit()
     current_app.logger.info(
-        "Application updated for application_id: '{application_id}.",
-        extra=dict(application_id=application_id),
+        "Application updated for application_id: %(application_id)s.",
+        dict(application_id=application_id),
     )
 
 
@@ -48,8 +51,8 @@ def update_form(application_id, form_name, question_json, is_summary_page_submit
         # Removing all data in the form (should not be allowed)
         elif form_sql_row.json and not question_json:
             current_app.logger.error(
-                "Application update aborted for application_id: '{application_id}. Invalid data supplied",
-                extra=dict(application_id=application_id),
+                "Application update aborted for application_id: '%(application_id)s'. Invalid data supplied",
+                dict(application_id=application_id),
             )
             raise Exception("ABORTING UPDATE, INVALID DATA GIVEN")
         # Updating form subsequent times

--- a/application_store/external_services/data.py
+++ b/application_store/external_services/data.py
@@ -27,20 +27,20 @@ def get_data(endpoint: str, params: Optional[dict] = None):
 
     if Config.USE_LOCAL_DATA:
         current_app.logger.info(
-            "Fetching local data from '{endpoint}' with params {params}.",
-            extra=dict(endpoint=endpoint, params=params),
+            "Fetching local data from '%(endpoint)s' with params %(params)s.",
+            dict(endpoint=endpoint, params=params),
         )
         data = get_local_data(endpoint, params)
     else:
         current_app.logger.info(
-            "Fetching data from '{endpoint}' with params {params}.",
-            extra=dict(endpoint=endpoint, params=params),
+            "Fetching data from '%(endpoint)s' with params %(params)s.",
+            dict(endpoint=endpoint, params=params),
         )
         data = get_remote_data(endpoint, params)
     if data is None:
         current_app.logger.error(
-            "Data request failed, unable to recover: {endpoint}",
-            extra=dict(endpoint=endpoint),
+            "Data request failed, unable to recover: %(endpoint)s",
+            dict(endpoint=endpoint),
         )
         return abort(500)
     return data
@@ -60,8 +60,8 @@ def get_remote_data(endpoint, params: Optional[dict] = None):
         return data
     else:
         current_app.logger.warning(
-            "GET remote data call was unsuccessful with status code: {status_code}.",
-            extra=dict(status_code=response.status_code),
+            "GET remote data call was unsuccessful with status code: %(status_code)s.",
+            dict(status_code=response.status_code),
         )
         return None
 
@@ -106,7 +106,7 @@ def get_funds() -> list[Fund] | None:
 
 def get_fund(fund_id: str) -> Fund | None:
     endpoint = Config.FUND_STORE_API_HOST + Config.FUND_ENDPOINT.format(fund_id=fund_id)
-    current_app.logger.info("Request made to {endpoint}", extra=dict(endpoint=endpoint))
+    current_app.logger.info("Request made to %(endpoint)s", dict(endpoint=endpoint))
     response = get_data(endpoint)
     if response is None:
         current_app.logger.info("Request to fund store returned None")

--- a/application_store/external_services/http_methods.py
+++ b/application_store/external_services/http_methods.py
@@ -11,22 +11,22 @@ from config import Config
 
 def post_data(endpoint: str, json_payload: Optional[dict] = None) -> dict:
     if Config.USE_LOCAL_DATA:
-        current_app.logger.info("Posting to local dummy endpoint: {endpoint}", extra=dict(endpoint=endpoint))
+        current_app.logger.info("Posting to local dummy endpoint: %(endpoint)s", dict(endpoint=endpoint))
         response = post_local_data(endpoint)
 
     else:
         if json_payload:
             json_payload = {k: v for k, v in json_payload.items() if v is not None}
         current_app.logger.info(
-            "Attempting POST to the following endpoint: '{endpoint}'.",
-            extra=dict(endpoint=endpoint),
+            "Attempting POST to the following endpoint: '%(endpoint)s'.",
+            dict(endpoint=endpoint),
         )
         response = requests.post(endpoint, json=json_payload)
 
     if response.status_code in [200, 201]:
         current_app.logger.info(
-            "Post successfully sent to {endpoint} with response code: '{status_code}'.",
-            extra=dict(endpoint=endpoint, status_code=response.status_code),
+            "Post successfully sent to {endpoint} with response code: '%(status_code)s'.",
+            dict(endpoint=endpoint, status_code=response.status_code),
         )
 
         return response.json()

--- a/application_store/scripts/send_application_on_closure.py
+++ b/application_store/scripts/send_application_on_closure.py
@@ -81,10 +81,10 @@ def send_incomplete_applications_after_deadline(
                 )
 
         current_app.logger.info(
-            "Found {matching_app_count} applications with matching"
-            " statuses. Retrieved all data for {apps_to_send_count} of"
+            "Found %(matching_app_count)s applications with matching"
+            " statuses. Retrieved all data for %(apps_to_send_count)s of"
             " them.",
-            extra=dict(
+            dict(
                 matching_app_count=len(matching_applications),
                 apps_to_send_count=len(applications_to_send),
             ),
@@ -92,8 +92,8 @@ def send_incomplete_applications_after_deadline(
         if send_email:
             total_applications = len(applications_to_send)
             current_app.logger.info(
-                "Send email set to true, will now send {total_applications} {emails}.",
-                extra=dict(
+                "Send email set to true, will now send %(total_applications)s %(emails)s.",
+                dict(
                     total_applications=total_applications,
                     emails="emails" if total_applications > 1 else "email",
                 ),
@@ -105,8 +105,8 @@ def send_incomplete_applications_after_deadline(
                         for application in application.values()
                     }
                     current_app.logger.info(
-                        "Sending application {count} of {total_applications} to {email}",
-                        extra=dict(
+                        "Sending application %(count)s of %(total_applications)s to %(email)s",
+                        dict(
                             count=count,
                             total_applications=total_applications,
                             email=email.get("email"),
@@ -123,14 +123,12 @@ def send_incomplete_applications_after_deadline(
                         contact_help_email=application["contact_help_email"],
                     )
                     current_app.logger.info(
-                        "Sent notification {notification_id} for application {application_reference}",
-                        extra=dict(
-                            notification_id=notification.id, application_reference=application_data["reference"]
-                        ),
+                        "Sent notification %(notification_id)s for application %(application_reference)s",
+                        dict(notification_id=notification.id, application_reference=application_data["reference"]),
                     )
                 current_app.logger.info(
-                    "Sent {count} {emails}",
-                    extra=dict(count=count, emails="emails" if count > 1 else "email"),
+                    "Sent %(count)s %(emails)s",
+                    dict(count=count, emails="emails" if count > 1 else "email"),
                 )
                 return count
             else:
@@ -139,8 +137,8 @@ def send_incomplete_applications_after_deadline(
         else:
             count = len(applications_to_send)
             current_app.logger.warning(
-                "Send email set to false, will not send {count} {emails}.",
-                extra=dict(count=count, emails="emails" if count > 1 else "email"),
+                "Send email set to false, will not send %(count)s %(emails)s.",
+                dict(count=count, emails="emails" if count > 1 else "email"),
             )
             return len(applications_to_send)
     else:

--- a/application_store/scripts/send_application_reminder.py
+++ b/application_store/scripts/send_application_reminder.py
@@ -37,8 +37,8 @@ def application_deadline_reminder(flask_app):  # noqa:C901 from before ruff
 
                 if not reminder_date_str:
                     current_app.logger.info(
-                        "No reminder is set for the round {round_title}",
-                        extra=dict(round_title=round.get("title")),
+                        "No reminder is set for the round %(round_title)s",
+                        dict(round_title=round.get("title")),
                     )
                     continue
 
@@ -86,8 +86,8 @@ def application_deadline_reminder(flask_app):  # noqa:C901 from before ruff
                             email = {"email": application["application"]["account_email"]}
 
                             current_app.logger.info(
-                                "Sending reminder {count} of {total}",
-                                extra=dict(count=count, total=len(unique_email_account)),
+                                "Sending reminder %(count)s of %(total)s",
+                                dict(count=count, total=len(unique_email_account)),
                             )
 
                             try:
@@ -100,8 +100,8 @@ def application_deadline_reminder(flask_app):  # noqa:C901 from before ruff
                                     contact_help_email=application["application"]["contact_help_email"],
                                 )
                                 current_app.logger.info(
-                                    "Sent notification {notification_id} for application {application_reference}",
-                                    extra=dict(
+                                    "Sent notification %(notification_id)s for application %(application_reference)s",
+                                    dict(
                                         notification_id=notification.id,
                                         application_reference=application["application"]["reference"],
                                     ),
@@ -117,15 +117,15 @@ def application_deadline_reminder(flask_app):  # noqa:C901 from before ruff
                                             current_app.logger.info(
                                                 "The application reminder has been"
                                                 " sent successfully for round_id"
-                                                " {round_id}",
-                                                extra=dict(found_id=round_id),
+                                                " %(round_id)s",
+                                                dict(found_id=round_id),
                                             )
                                     except Exception as e:
                                         current_app.logger.info(
                                             "There was an issue updating the"
                                             " application_reminder_sent column in the"
-                                            " Round store for {round_id}. Errro {errno}",
-                                            extra=dict(round_id=round_id, errno=e),
+                                            " Round store for %(round_id)s. Errro %(errno)s",
+                                            dict(round_id=round_id, errno=e),
                                         )
 
                             except NotificationError as e:

--- a/apply/default/account_routes.py
+++ b/apply/default/account_routes.py
@@ -173,7 +173,7 @@ def dashboard():
     show_language_column = determine_show_language_column(applications)
 
     display_data = build_application_data_for_display(applications, fund_short_name, round_short_name)
-    current_app.logger.info("Setting up applicant dashboard for :'{account_id}'", extra=dict(account_id=account_id))
+    current_app.logger.info("Setting up applicant dashboard for: '{%(account_id)s'", dict(account_id=account_id))
     if not welsh_available and template_name == TEMPLATE_SINGLE_FUND:
         render_lang = "en"
     with force_locale(render_lang):
@@ -221,7 +221,7 @@ def new():
     )
     new_application_json = new_application.json()
     current_app.logger.info(
-        "Creating new application:{new_application_json}", extra=dict(new_application_json=new_application_json)
+        "Creating new application: %(new_application_json)s", dict(new_application_json=new_application_json)
     )
     if new_application.status_code != 201 or not new_application_json.get("id"):
         raise Exception(

--- a/apply/default/application_routes.py
+++ b/apply/default/application_routes.py
@@ -128,8 +128,8 @@ def verify_round_open(f):
             return f(*args, **kwargs)
         else:
             current_app.logger.info(
-                "User {account_id} tried to update application {application_id} outside of the round being open",
-                extra=dict(account_id=g.account_id, application_id=application_id),
+                "User %(account_id)s tried to update application %(application_id)s outside of the round being open",
+                dict(account_id=g.account_id, application_id=application_id),
             )
             if redirect_to_fund is not False:
                 fund = get_fund(fund_id=application.fund_id)
@@ -376,7 +376,7 @@ def continue_application(application_id):
         request.host_url
         + url_for("application_routes.fund_round_close_notification", application_id=application_id)[1:]
     )
-    current_app.logger.info("Url the form runner should return to '{return_url}'.", extra=dict(return_url=return_url))
+    current_app.logger.info("Url the form runner should return to '%(return_url)s'.", dict(return_url=return_url))
 
     application = get_application_data(application_id)
     fund, round = get_fund_and_round(fund_id=application.fund_id, round_id=application.round_id)

--- a/apply/default/content_routes.py
+++ b/apply/default/content_routes.py
@@ -54,8 +54,8 @@ def determine_all_questions_template_name(fund_short_name: str, round_short_name
 @content_bp.route("/all_questions/<fund_short_name>/<round_short_name>", methods=["GET"])
 def all_questions(fund_short_name, round_short_name):
     current_app.logger.info(
-        "All questions page loaded for fund {fund_short_name} round {round_short_name}.",
-        extra=dict(fund_short_name=fund_short_name, round_short_name=round_short_name),
+        "All questions page loaded for fund %(fund_short_name)s round %(round_short_name)s.",
+        dict(fund_short_name=fund_short_name, round_short_name=round_short_name),
     )
     fund, round = get_fund_and_round(fund_short_name=fund_short_name, round_short_name=round_short_name)
 
@@ -73,8 +73,8 @@ def all_questions(fund_short_name, round_short_name):
             )
         except TemplateNotFound:
             current_app.logger.warning(
-                "No all questions page found for {fund_short_name}:{round_short_name}",
-                extra=dict(fund_short_name=fund_short_name, round_short_name=round_short_name),
+                "No all questions page found for %(fund_short_name)s:%(round_short_name)s",
+                dict(fund_short_name=fund_short_name, round_short_name=round_short_name),
             )
     return abort(404)
 
@@ -121,8 +121,8 @@ def privacy():
 
     if privacy_notice_url:
         current_app.logger.info(
-            "Privacy notice loading for fund {fund_short_name} round {round_short_name}.",
-            extra=dict(fund_short_name=fund.short_name, round_short_name=round.short_name),
+            "Privacy notice loading for fund %(fund_short_name)s round %(round_short_name)s.",
+            dict(fund_short_name=fund.short_name, round_short_name=round.short_name),
         )
         return redirect(privacy_notice_url)
 

--- a/apply/default/data.py
+++ b/apply/default/data.py
@@ -52,15 +52,15 @@ def get_data(endpoint: str, params: dict = None):
         endpoint = endpoint + "?" + query_string
 
     if Config.USE_LOCAL_DATA:
-        current_app.logger.info("Fetching local data from '{endpoint}'.", extra=dict(endpoint=endpoint))
+        current_app.logger.info("Fetching local data from '%(endpoint)s'.", dict(endpoint=endpoint))
         data = get_local_data(endpoint)
     else:
-        current_app.logger.info("Fetching data from '{endpoint}'.", extra=dict(endpoint=endpoint))
+        current_app.logger.info("Fetching data from '%(endpoint)s'.", dict(endpoint=endpoint))
         data, response_code = get_remote_data(endpoint)
         if response_code != 200:
             return abort(response_code)
     if data is None:
-        current_app.logger.error("Data request failed, unable to recover: {endpoint}", extra=dict(endpoint=endpoint))
+        current_app.logger.error("Data request failed, unable to recover: %(endpoint)s", dict(endpoint=endpoint))
         return abort(500)
     return data
 
@@ -85,16 +85,16 @@ def get_data_or_fail_gracefully(endpoint: str, params: dict = None):
         endpoint = endpoint + "?" + query_string
 
     if Config.USE_LOCAL_DATA:
-        current_app.logger.info("Fetching local data from '{endpoint}'.", extra=dict(endpoint=endpoint))
+        current_app.logger.info("Fetching local data from '%(endpoint)s'.", dict(endpoint=endpoint))
         data = get_local_data(endpoint)
         response_status = 200 if data else 404
     else:
-        current_app.logger.info("Fetching data from '{endpoint}'.", extra=dict(endpoint=endpoint))
+        current_app.logger.info("Fetching data from '%(endpoint)s'.", dict(endpoint=endpoint))
         response_status, data = get_remote_data_force_return(endpoint)
     if (data is None) or (response_status in [404, 500]):
-        current_app.logger.warning("Data request failed, unable to recover: {endpoint}", extra=dict(endpoint=endpoint))
-        current_app.logger.warning("Data retrieved: {data}", extra=dict(data=data))
-        current_app.logger.warning("Service response status code: {response_status}", extra=dict(endpoint=endpoint))
+        current_app.logger.warning("Data request failed, unable to recover: %(endpoint)s", dict(endpoint=endpoint))
+        current_app.logger.warning("Data retrieved: %(data)s", dict(data=data))
+        current_app.logger.warning("Service response status code: %(response_status)s", dict(endpoint=endpoint))
         return abort(404)
     return data
 
@@ -106,8 +106,8 @@ def get_remote_data(endpoint):
         return data, 200
     else:
         current_app.logger.warning(
-            "GET remote data call was unsuccessful with status code: {status_code}.",
-            extra=dict(status_code=response.status_code),
+            "GET remote data call was unsuccessful with status code: %(status_code)s.",
+            dict(status_code=response.status_code),
         )
         return None, response.status_code
 
@@ -181,9 +181,7 @@ def get_fund_data_by_short_name(fund_short_name, language=None, as_dict=False, t
     del ttl_hash  # Only needed for lru_cache
     all_funds = {fund["short_name"].lower() for fund in get_all_funds(ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME))}
     if fund_short_name.lower() not in all_funds:
-        current_app.logger.warning(
-            "Invalid fund {fund_short_name}!", extra=dict(fund_short_name=fund_short_name.lower())
-        )
+        current_app.logger.warning("Invalid fund %(fund_short_name)s!", dict(fund_short_name=fund_short_name.lower()))
         abort(404)
     fund_request_url = Config.GET_FUND_DATA_BY_SHORT_NAME_ENDPOINT.format(fund_short_name=fund_short_name.lower())
     params = {"language": language or get_lang(), "use_short_name": True}
@@ -239,7 +237,7 @@ def get_round_data_by_short_names(
     ]
     if round_short_name.lower() not in all_rounds:
         current_app.logger.warning(
-            "Invalid round {round_short_name}!", extra=dict(round_short_name=round_short_name.lower())
+            "Invalid round %(round_short_name)s!", dict(round_short_name=round_short_name.lower())
         )
         return None
     params = {"language": language or get_lang(), "use_short_name": "true"}
@@ -277,8 +275,11 @@ def get_round_data_fail_gracefully(fund_id, round_id, use_short_name=False):
             return Round.from_dict(round_response)
     except:  # noqa
         current_app.logger.warning(
-            "Failed to retrieve round using fund_id {fund_id}, round_id {round_id}, use_short_name={use_short_name}",
-            extra=dict(fund_id=fund_id, round_id=round_id, use_short_name=use_short_name),
+            (
+                "Failed to retrieve round using fund_id %(fund_id)s, "
+                "round_id %(round_id)s, use_short_name=%(use_short_name)s"
+            ),
+            dict(fund_id=fund_id, round_id=round_id, use_short_name=use_short_name),
         )
     # return valid Round object with no values so we know we've
     # failed and can handle in templates appropriately
@@ -430,8 +431,8 @@ def get_feedback(application_id, section_id, fund_id, round_id):
         return FeedbackSubmission.from_dict(feedback_response.json())
 
     current_app.logger.info(
-        "No feedback found for {application_id} section {section_id}",
-        extra=dict(application_id=application_id, section_id=section_id),
+        "No feedback found for %(application_id)s section %(section_id)s",
+        dict(application_id=application_id, section_id=section_id),
     )
 
 

--- a/apply/default/eligibility_routes.py
+++ b/apply/default/eligibility_routes.py
@@ -19,8 +19,8 @@ def eligiblity_result(fund_short_name, round_name):
         round_name = redirect_to_eligible_round
 
     current_app.logger.info(
-        "Eligibility launch result: {fund_short_name} {round_name}",
-        extra=dict(fund_short_name=fund_short_name, round_name=round_name),
+        "Eligibility launch result: %(fund_short_name)s %(round_name)s",
+        dict(fund_short_name=fund_short_name, round_name=round_name),
     )
     fund, round = get_fund_and_round(fund_short_name=fund_short_name, round_short_name=round_name)
     return redirect(url_for("account_routes.new", fund_id=round.fund_id, round_id=round.id))
@@ -36,13 +36,13 @@ def launch_eligibility(fund_id, round_id):
     form_name = f"{fund_name}-{round_name}-eligibility"
 
     current_app.logger.info(
-        "Eligibility launch request for fund {fund_name} round {round_name}",
-        extra=dict(fund_name=fund_name, round_name=round_name),
+        "Eligibility launch request for fund %(fund_name)s round %(round_name)s",
+        dict(fund_name=fund_name, round_name=round_name),
     )
 
     return_url = request.host_url + url_for("account_routes.dashboard", fund=fund_name, round=round_name)
 
-    current_app.logger.info("Url the form runner should return to '{return_url}'.", extra=dict(return_url=return_url))
+    current_app.logger.info("Url the form runner should return to '%(return_url)s'.", dict(return_url=return_url))
 
     rehydrate_payload = format_rehydrate_payload(
         form_data={"questions": []},

--- a/apply/default/error_routes.py
+++ b/apply/default/error_routes.py
@@ -28,7 +28,7 @@ def not_found(error):
 @application_bp.errorhandler(Exception)
 @content_bp.errorhandler(Exception)
 def internal_server_error(error):
-    current_app.logger.exception("Encountered 500: {error}", extra=dict(error=str(error)))
+    current_app.logger.exception("Encountered 500: %(error)s", dict(error=str(error)))
     return render_template("apply/500.html", is_error=True), 500
 
 
@@ -48,5 +48,5 @@ def unauthorised_error(error):
 def csrf_token_expiry(error):
     if not g.account_id:
         return redirect(g.logout_url)
-    current_app.logger.exception("Encountered 500: {error}", extra=dict(error=str(error)))
+    current_app.logger.exception("Encountered 500: %(error)s", dict(error=str(error)))
     return render_template("apply/500.html", is_error=True), 500

--- a/apply/default/routes.py
+++ b/apply/default/routes.py
@@ -16,8 +16,8 @@ def index():
 @default_bp.route("/funding-round/<fund_short_name>/<round_short_name>")
 def index_fund_round(fund_short_name, round_short_name):
     current_app.logger.info(
-        "In fund-round start page {fund_short_name} {round_short_name}",
-        extra=dict(fund_short_name=fund_short_name, round_short_name=round_short_name),
+        "In fund-round start page %(fund_short_name)s %(round_short_name)s",
+        dict(fund_short_name=fund_short_name, round_short_name=round_short_name),
     )
 
     fund_data, round_data = get_fund_and_round(fund_short_name=fund_short_name, round_short_name=round_short_name)
@@ -51,14 +51,14 @@ def index_fund_round(fund_short_name, round_short_name):
 def index_fund_only(fund_short_name):
     if str.upper(fund_short_name) in get_all_fund_short_names(get_ttl_hash(Config.LRU_CACHE_TIME)):
         current_app.logger.info(
-            "In fund-only start page route for {fund_short_name}", extra=dict(fund_short_name=fund_short_name)
+            "In fund-only start page route for %(fund_short_name)s", dict(fund_short_name=fund_short_name)
         )
         default_round = get_default_round_for_fund(fund_short_name=fund_short_name)
         if default_round:
             return redirect(f"/funding-round/{fund_short_name}/{default_round.short_name}")
 
         current_app.logger.warning(
-            "Unable to retrieve default round for fund {fund_short_name}", extra=dict(fund_short_name=fund_short_name)
+            "Unable to retrieve default round for fund %(fund_short_name)s", dict(fund_short_name=fund_short_name)
         )
     return (
         render_template(

--- a/apply/helpers.py
+++ b/apply/helpers.py
@@ -32,8 +32,8 @@ def get_all_fund_short_names(ttl_hash):
 
 def get_token_to_return_to_application(form_name: str, rehydrate_payload):
     current_app.logger.info(
-        "obtaining session rehydration token for application id: {application_id}.",
-        extra=dict(application_id=rehydrate_payload["metadata"]["application_id"]),
+        "obtaining session rehydration token for application id: %(application_id)s.",
+        dict(application_id=rehydrate_payload["metadata"]["application_id"]),
     )
     res = requests.post(
         Config.FORM_GET_REHYDRATION_TOKEN_URL.format(form_name=form_name),
@@ -118,10 +118,10 @@ def format_rehydrate_payload(
 
     current_app.logger.info(
         (
-            "constructing session rehydration payload for application id:{application_id}, "
-            "markAsCompleteEnabled: {markAsCompleteEnabled}."
+            "constructing session rehydration payload for application id:%(application_id)s, "
+            "markAsCompleteEnabled: %(markAsCompleteEnabled)s."
         ),
-        extra=dict(application_id=application_id, markAsCompleteEnabled=markAsCompleteEnabled),
+        dict(application_id=application_id, markAsCompleteEnabled=markAsCompleteEnabled),
     )
     formatted_data = {}
 

--- a/apply/models/application.py
+++ b/apply/models/application.py
@@ -47,9 +47,9 @@ class Application:
         current_app.logger.info(
             (
                 "Sorting forms into order using section config associated with "
-                "fund: {fund_id}, round: {round_id}, for application id:{application_id}."
+                "fund: %(fund_id)s, round: %(round_id)s, for application id:%(application_id)s."
             ),
-            extra=dict(fund_id=self.fund_id, round_id=self.round_id, application_id=self.id),
+            dict(fund_id=self.fund_id, round_id=self.round_id, application_id=self.id),
         )
         sections_config = [
             {

--- a/assess/assessments/routes.py
+++ b/assess/assessments/routes.py
@@ -275,8 +275,8 @@ def _get_fund_dashboard_data(fund: Fund, round: Round, request):
     if users_not_mapped:
         current_app.logger.warning(
             "The following users were assigned applications but could not be"
-            "found in the account store: {users_not_mapped}",
-            extra=dict(users_not_mapped=users_not_mapped),
+            "found in the account store: %(users_not_mapped)s",
+            dict(users_not_mapped=users_not_mapped),
         )
 
     tags_in_application_map, tag_option_groups = get_tag_map_and_tag_options(
@@ -1017,8 +1017,8 @@ def assignment_overview(fund_short_name: str, round_short_name: str):  # noqa: C
             if future.result() is None:
                 user_id, application_id = future_assignments[future].split(",")
                 current_app.logger.error(
-                    "Could not create assignment for user {user_id} and application {application_id}",
-                    extra=dict(user_id=user_id, application_id=application_id),
+                    "Could not create assignment for user %(user_id)s and application %(application_id)s",
+                    dict(user_id=user_id, application_id=application_id),
                 )
 
         return redirect(
@@ -1144,14 +1144,14 @@ def display_sub_criteria(
     """
     Page showing sub criteria and themes for an application
     """
-    current_app.logger.info("Processing GET to {request_path}.", extra=dict(request_path=request.path))
+    current_app.logger.info("Processing GET to %(request_path)s.", dict(request_path=request.path))
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
     theme_id = request.args.get("theme_id", sub_criteria.themes[0].id)
     comment_form = CommentsForm()
     try:
         current_theme: Theme = next(iter(t for t in sub_criteria.themes if t.id == theme_id))
     except StopIteration:
-        current_app.logger.warning("Unknown theme ID requested: {theme_id}", extra=dict(theme_id=theme_id))
+        current_app.logger.warning("Unknown theme ID requested: %(theme_id)s", dict(theme_id=theme_id))
         abort(404)
     add_comment_argument = request.args.get("add_comment") == "1"
     if add_comment_argument and comment_form.validate_on_submit():
@@ -1343,7 +1343,7 @@ def request_changes(application_id, sub_criteria_id, theme_id):
 @check_access_application_id(roles_required=[Config.LEAD_ASSESSOR])
 def generate_doc_list_for_download(application_id):
     current_app.logger.info(
-        "Generating docs for application id {application_id}", extra=dict(application_id=application_id)
+        "Generating docs for application id %(application_id)s", dict(application_id=application_id)
     )
     state = get_state_for_tasklist_banner(application_id)
     short_id = state.short_id[-6:]
@@ -1387,8 +1387,8 @@ def generate_doc_list_for_download(application_id):
 @check_access_application_id(roles_required=[Config.LEAD_ASSESSOR])
 def download_application_answers(application_id: str, short_id: str, file_type: str):
     current_app.logger.info(
-        "Generating application Q+A download for application {application_id} in {file_type} format",
-        extra=dict(application_id=application_id, file_type=file_type),
+        "Generating application Q+A download for application %(application_id)s in %(file_type)s format",
+        dict(application_id=application_id, file_type=file_type),
     )
     application_json = get_application_json(application_id)
     application_json_blob = application_json["jsonb_blob"]

--- a/assess/assessments/status.py
+++ b/assess/assessments/status.py
@@ -56,6 +56,6 @@ def update_ar_status_to_qa_completed(application_id, user_id):
         return response
     else:
         current_app.logger.error(
-            "Could not create qa_complete record for application {application_id}",
-            extra=dict(application_id=application_id),
+            "Could not create qa_complete record for application %(application_id)s",
+            dict(application_id=application_id),
         )

--- a/assess/blueprint_middleware.py
+++ b/assess/blueprint_middleware.py
@@ -15,7 +15,7 @@ from assess.tagging.routes import tagging_bp
 @shared_bp.errorhandler(404)
 @tagging_bp.errorhandler(404)
 def not_found(error):
-    current_app.logger.info("Encountered 404 against url {request_path}", extra=dict(request_path=request.path))
+    current_app.logger.info("Encountered 404 against url %(request_path)s", dict(request_path=request.path))
     return render_template("assess/404.html"), 404
 
 
@@ -32,7 +32,7 @@ def forbidden(error):
         else error.description
     )
 
-    current_app.logger.info("Encountered 403: {error}", extra=dict(error=str(error)))
+    current_app.logger.info("Encountered 403: %(error)s", dict(error=str(error)))
     return (
         render_template("assess/403.html", error_description=error.description),
         403,
@@ -61,7 +61,7 @@ def error_503(error):
 @scoring_bp.errorhandler(500)
 @scoring_bp.errorhandler(Exception)
 def internal_server_error(error):
-    current_app.logger.exception("Encountered 500: {error}", extra=dict(error=str(error)))
+    current_app.logger.exception("Encountered 500: %(error)s", dict(error=str(error)))
     return render_template("assess/500.html"), 500
 
 

--- a/assess/scoring/helpers.py
+++ b/assess/scoring/helpers.py
@@ -19,9 +19,7 @@ def get_scoring_class(round_id):
         }
         scoring_form_class = class_mapping[scoring_system]
     except KeyError:
-        current_app.logger.error(
-            "Scoring system '{scoring_system}' not found.", extra=dict(scoring_system=scoring_system)
-        )
+        current_app.logger.error("Scoring system '%(scoring_system)s' not found.", dict(scoring_system=scoring_system))
         abort(
             500,
             description=f"Scoring system '{scoring_system}' for round {round_id} has not been configured.",

--- a/assess/scoring/routes.py
+++ b/assess/scoring/routes.py
@@ -49,7 +49,7 @@ def score(
     is_rescore = rescore_form.validate_on_submit()
     if not is_rescore and request.method == "POST":
         if score_form.validate_on_submit():
-            current_app.logger.info("Processing POST to {request_path}.", extra=dict(rqeuest_path=request.path))
+            current_app.logger.info("Processing POST to %(request_path)s.", dict(request_path=request.path))
             score = int(score_form.score.data)
             user_id = g.account_id
             justification = score_form.justification.data

--- a/assess/services/aws.py
+++ b/assess/services/aws.py
@@ -32,7 +32,7 @@ def get_file_for_download_from_aws(file_name: str, application_id: str):
 
     try:
         current_app.logger.info(
-            "Retrieving file {prefixed_file_name} from AWS", extra=dict(prefixed_file_name=prefixed_file_name)
+            "Retrieving file %(prefixed_file_name)s from AWS", dict(prefixed_file_name=prefixed_file_name)
         )
         obj = _S3_CLIENT.get_object(Bucket=Config.AWS_BUCKET_NAME, Key=prefixed_file_name)
 

--- a/assess/tagging/routes.py
+++ b/assess/tagging/routes.py
@@ -208,7 +208,7 @@ def create_tag(fund_id, round_id):
         return redirect(url_for("tagging_bp.create_tag", fund_id=fund_id, round_id=round_id))
 
     elif request.method == "POST":
-        current_app.logger.info("Tag creation form failed validation: {errors}", extra=dict(errors=new_tag_form.errors))
+        current_app.logger.info("Tag creation form failed validation: %(errors)s", dict(errors=new_tag_form.errors))
         errors = new_tag_form.errors
 
     return render_template(
@@ -246,7 +246,7 @@ def deactivate_tag(fund_id, round_id, tag_id):
     }
     if deactivate_tag_form.validate_on_submit():
         current_app.logger.info(
-            "Tag deactivation form validated, deactivating tag_id: {tag_id}.", extra=dict(tag_id=tag_id)
+            "Tag deactivation form validated, deactivating tag_id: %(tag_id)s.", dict(tag_id=tag_id)
         )
         tag_update_to_deactivate = [{"id": tag_id, "active": False}]
         tag_deactivated = update_tags(fund_id, round_id, tag_update_to_deactivate)
@@ -262,7 +262,7 @@ def deactivate_tag(fund_id, round_id, tag_id):
 
     elif request.method == "POST":
         current_app.logger.info(
-            "Tag deactivation form failed validation: {errors}", extra=dict(errors=deactivate_tag_form.errors)
+            "Tag deactivation form failed validation: %(errors)s", dict(errors=deactivate_tag_form.errors)
         )
         flash(TAG_DEACTIVATE_ERROR_MESSAGE)
     return render_template(
@@ -299,7 +299,7 @@ def reactivate_tag(fund_id, round_id, tag_id):
     }
     if reactivate_tag_form.validate_on_submit():
         current_app.logger.info(
-            "Tag reactivation form validated, reactivating tag_id: {tag_id}.", extra=dict(tag_id=tag_id)
+            "Tag reactivation form validated, reactivating tag_id: %(tag_id)s.", dict(tag_id=tag_id)
         )
         tag_to_reactivate = [{"id": tag_id, "active": True}]
         tag_reactivated = update_tags(fund_id, round_id, tag_to_reactivate)
@@ -314,7 +314,7 @@ def reactivate_tag(fund_id, round_id, tag_id):
         flash(TAG_REACTIVATE_ERROR_MESSAGE)
     elif request.method == "POST":
         current_app.logger.info(
-            "Tag reactivation form failed validation: {errors}", extra=dict(errors=reactivate_tag_form.errors)
+            "Tag reactivation form failed validation: %(errors)s", dict(errors=reactivate_tag_form.errors)
         )
         flash(TAG_REACTIVATE_ERROR_MESSAGE)
     return render_template(
@@ -334,7 +334,7 @@ def edit_tag(fund_id, round_id, tag_id):
     fund_round = get_fund_round(fund_id, round_id)
     tag = get_tag(fund_id, round_id, tag_id)
     if request.method == "GET":
-        current_app.logger.info("Loading edit tag page for id {tag_id}", extra=dict(tag_id=tag_id))
+        current_app.logger.info("Loading edit tag page for id %(tag_id)s", dict(tag_id=tag_id))
 
     elif request.method == "POST":
         current_app.logger.info("In edit tag post")
@@ -352,9 +352,7 @@ def edit_tag(fund_id, round_id, tag_id):
             else:
                 flash("An error occurred and your changes were not saved. Please try again later.")
         else:
-            current_app.logger.info(
-                "Edit tag form failed validation: {errors}", extra=dict(errors=edit_tag_form.errors)
-            )
+            current_app.logger.info("Edit tag form failed validation: %(errors)s", dict(errors=edit_tag_form.errors))
             flash(FLAG_ERROR_MESSAGE)
 
     return render_template(

--- a/assess/themes/deprecated_theme_mapper.py
+++ b/assess/themes/deprecated_theme_mapper.py
@@ -28,7 +28,7 @@ def map_application_with_sub_criteria_themes_fields(
             else:
                 map_single_field_answer(theme, questions)
         except TypeError:
-            current_app.logger.error("Incorrect theme id -> {theme_id}", extra=dict(theme_id=theme_id))
+            current_app.logger.error("Incorrect theme id -> %(theme_id)s", dict(theme_id=theme_id))
             return f"Incorrect theme id -> {theme_id}"
 
     convert_boolean_values(themes_fields)
@@ -98,7 +98,7 @@ def get_themes_fields(sub_criterias, theme_id) -> str | Any:
                 if theme_id == theme.get("id")
             ][0]
         except IndexError:
-            current_app.logger.error("Incorrect theme id -> {theme_id}", extra=dict(theme_id=theme_id))
+            current_app.logger.error("Incorrect theme id -> %(theme_id)s", dict(theme_id=theme_id))
             return f"Incorrect theme id -> {theme_id}"
 
 
@@ -158,9 +158,7 @@ def deprecated_sort_add_another_component_contents(
                     amount_answer = [amount.rsplit(": ", 1)[1] for amount in theme["answer"]]
                     theme["answer"] = amount_answer
         except (KeyError, IndexError):
-            current_app.logger.debug(
-                "Answer not provided for field_id: {field_id}", extra=dict(field_id=field["field_id"])
-            )
+            current_app.logger.debug("Answer not provided for field_id: %(field_id)s", dict(field_id=field["field_id"]))
 
 
 def format_add_another_component_contents(  # noqa: C901

--- a/assessment_store/api/models/notification.py
+++ b/assessment_store/api/models/notification.py
@@ -32,8 +32,8 @@ class Notification:
             "content": content,
         }
         current_app.logger.info(
-            " json payload '{template_type}' to '{to_email}'.",
-            extra=dict(template_type=template_type, to_email=to_email),
+            " json payload '%(template_type)s' to '%(to_email)s'.",
+            dict(template_type=template_type, to_email=to_email),
         )
         try:
             sqs_extended_client = Notification._get_sqs_client()
@@ -50,7 +50,7 @@ class Notification:
                 },
             )
             current_app.logger.info(
-                "Message sent to SQS queue and message id is [{message_id}]", extra=dict(message_id=message_id)
+                "Message sent to SQS queue and message id is [%(message_id)s]", dict(message_id=message_id)
             )
             return message_id
         except Exception:

--- a/assessment_store/api/routes/assessment_routes.py
+++ b/assessment_store/api/routes/assessment_routes.py
@@ -47,8 +47,8 @@ def calculate_overall_score_percentage_for_application(application):
     if mapping["scored_criteria"] == []:
         # We have no scoring config for this round (possibly an EOI)
         current_app.logger.info(
-            "No scoring config found for {fund_id}:{round_id}",
-            extra=dict(fund_id=application["fund_id"], round_id=application["round_id"]),
+            "No scoring config found for %(fund_id)s:%(round_id)s",
+            dict(fund_id=application["fund_id"], round_id=application["round_id"]),
         )
         return None
 
@@ -152,16 +152,23 @@ def sub_criteria(application_id, sub_criteria_id) -> Dict:
     :return: A sub criteria dictionary.
 
     """
-    current_app.logger.info("Processing request for sub criteria: {sub_criteria_id}.")
+    current_app.logger.info(
+        "Processing request for sub criteria: %(sub_criteria_id)s.", dict(sub_criteria_id=sub_criteria_id)
+    )
     metadata = find_assessor_task_list_state(application_id)
-    current_app.logger.info("Searching assessment mapping for sub criteria: {sub_criteria_id}.")
+    current_app.logger.info(
+        "Searching assessment mapping for sub criteria: %(sub_criteria_id)s.", dict(sub_criteria_id=sub_criteria_id)
+    )
     sub_criteria_config_from_mapping = return_subcriteria_from_mapping(
         sub_criteria_id,
         metadata["fund_id"],
         metadata["round_id"],
         metadata["language"],
     )
-    current_app.logger.info("Getting application subcriteria metadata for application: {sub_criteria_id}.")
+    current_app.logger.info(
+        "Getting application subcriteria metadata for application: %(sub_criteria_id)s.",
+        dict(sub_criteria_id=sub_criteria_id),
+    )
     application_metadata_for_subcriteria = get_assessment_sub_critera_state(application_id)
     sub_criteria = SubCriteria.from_filtered_dict(
         {

--- a/assessment_store/api/routes/flag_routes.py
+++ b/assessment_store/api/routes/flag_routes.py
@@ -77,7 +77,7 @@ def get_team_flag_stats(
 @assessment_flag_bp.get("/flag_data")
 def get_flag():
     flag_id = request.args["flag_id"]
-    current_app.logger.info("Get flags for id {flag_id}", extra=dict(flag_id=flag_id))
+    current_app.logger.info("Get flags for id %(flag_id)s", dict(flag_id=flag_id))
     flags = get_flag_by_id(flag_id)
     flag_schema = AssessmentFlagSchema()
     return flag_schema.dump(flags, many=True)[0]
@@ -85,7 +85,7 @@ def get_flag():
 
 @assessment_flag_bp.get("/flags/<application_id>")
 def get_all_flags_for_application(application_id):
-    current_app.logger.info("Get all flags for application {application_id}", extra=dict(application_id=application_id))
+    current_app.logger.info("Get all flags for application %(application_id)s", dict(application_id=application_id))
     flags = get_flags_for_application(application_id)
     flag_schema = AssessmentFlagSchema()
     return flag_schema.dump(flags, many=True)
@@ -95,7 +95,7 @@ def get_all_flags_for_application(application_id):
 def create_flag_for_application():
     create_flag_json = request.json
     current_app.logger.info(
-        "Create flag for application {application_id}", extra=dict(application_id=create_flag_json["application_id"])
+        "Create flag for application %(application_id)s", dict(application_id=create_flag_json["application_id"])
     )
     created_flag = add_flag_for_application(**create_flag_json)
     return AssessmentFlagSchema().dump(created_flag)

--- a/assessment_store/api/routes/subcriterias/get_sub_criteria.py
+++ b/assessment_store/api/routes/subcriterias/get_sub_criteria.py
@@ -25,7 +25,7 @@ def get_all_subcriteria(fund_id, round_id, language):
 
 def return_subcriteria_from_mapping(sub_criteria_id, fund_id, round_id, language):
     current_app.logger.info(
-        "Finding sub criteria data in config for: {sub_criteria_id}", extra=dict(sub_criteria_id=sub_criteria_id)
+        "Finding sub criteria data in config for: %(sub_criteria_id)s", dict(sub_criteria_id=sub_criteria_id)
     )
     display_config = copy.deepcopy(Config.ASSESSMENT_MAPPING_CONFIG[f"{fund_id}:{round_id}"])
     sub_criterias = get_all_subcriteria(fund_id, round_id, language)
@@ -48,11 +48,11 @@ def return_subcriteria_from_mapping(sub_criteria_id, fund_id, round_id, language
         return sub_crit
     elif len(matching_sub_criteria) > 1:
         current_app.logger.error(
-            "sub_criteria: '{sub_criteria_id}' duplicated.", extra=dict(sub_criteria_id=sub_criteria_id)
+            "sub_criteria: '%(sub_criteria_id)s' duplicated.", dict(sub_criteria_id=sub_criteria_id)
         )
         raise ValueError(f"sub_criteria: '{sub_criteria_id}' duplicated.")
     else:
         current_app.logger.warning(
-            "sub_criteria: '{sub_criteria_id}' not found.", extra=dict(sub_criteria_id=sub_criteria_id)
+            "sub_criteria: '%(sub_criteria_id)s' not found.", dict(sub_criteria_id=sub_criteria_id)
         )
         abort(404, description=f"sub_criteria: '{sub_criteria_id}' not found.")

--- a/assessment_store/api/routes/tag_routes.py
+++ b/assessment_store/api/routes/tag_routes.py
@@ -85,7 +85,7 @@ def add_tag_for_fund_round(fund_id, round_id):
         serialiser = TagSchema()
         serialised_tags = [serialiser.dump(r) for r in inserted_tags]
         return serialised_tags
-    current_app.logger.error("Add tags attempt failed for tags: {tags}.", extra=dict(tags=tags))
+    current_app.logger.error("Add tags attempt failed for tags: %(tags)s.", dict(tags=tags))
     abort(404)
 
 
@@ -110,7 +110,7 @@ def update_tags_for_fund_round(fund_id, round_id):
         serialiser = TagSchema()
         serialised_tags = [serialiser.dump(r) for r in updated_tags]
         return serialised_tags
-    current_app.logger.error("Update tags attempt failed for tags: {tags}.", extra=dict(tags=tags))
+    current_app.logger.error("Update tags attempt failed for tags: %(tags)s.", dict(tags=tags))
     abort(404)
 
 
@@ -140,8 +140,8 @@ def associate_tags_with_assessment(application_id):
 @assessment_tag_bp.get("/application/<application_id>/tag")
 def get_active_tags_associated_with_assessment(application_id):
     current_app.logger.info(
-        "Getting tags associated with assessment with application_id: {application_id}.",
-        extra=dict(application_id=application_id),
+        "Getting tags associated with assessment with application_id: %(application_id)s.",
+        dict(application_id=application_id),
     )
     associated_tags = select_active_tags_associated_with_assessment(application_id)
     if associated_tags:
@@ -154,7 +154,7 @@ def get_active_tags_associated_with_assessment(application_id):
 @assessment_tag_bp.get("/application/<application_id>/tags")
 def get_all_tags_associated_with_application(application_id):
     current_app.logger.info(
-        "Getting tags associated with with application_id: {application_id}.", extra=dict(application_id=application_id)
+        "Getting tags associated with with application_id: %(application_id)s.", dict(application_id=application_id)
     )
     associated_tags = select_all_tags_associated_with_application(application_id)
     if associated_tags:

--- a/assessment_store/api/routes/user_routes.py
+++ b/assessment_store/api/routes/user_routes.py
@@ -44,8 +44,8 @@ def get_all_users_associated_with_application(application_id):
         return serialiser.dump(associations, many=True)
 
     current_app.logger.error(
-        "Could not find any users associated with application {application_id}",
-        extra=dict(application_id=application_id),
+        "Could not find any users associated with application %(application_id)s",
+        dict(application_id=application_id),
     )
     abort(404)
 
@@ -72,8 +72,8 @@ def get_user_application_association(application_id, user_id):
         return serialiser.dump(association[0])
 
     current_app.logger.error(
-        "Could not find association between {user_id} and application {application_id}",
-        extra=dict(user_id=user_id, application_id=application_id),
+        "Could not find association between %(user_id)s and application %(application_id)s",
+        dict(user_id=user_id, application_id=application_id),
     )
     abort(404)
 
@@ -130,8 +130,8 @@ def add_user_application_association(application_id, user_id):
         return serialiser.dump(association), 201
 
     current_app.logger.error(
-        "Could not create association between {user_id} and application {application_id}",
-        extra=dict(user_id=user_id, application_id=application_id),
+        "Could not create association between %(user_id)s and application %(application_id)s",
+        dict(user_id=user_id, application_id=application_id),
     )
     abort(404)
 
@@ -208,8 +208,8 @@ def update_user_application_association(application_id, user_id):
         return serialiser.dump(association)
 
     current_app.logger.error(
-        "Could not update association between {user_id} and application {application_id}",
-        extra=dict(user_id=user_id, application_id=application_id),
+        "Could not update association between %(user_id)s and application %(application_id)s",
+        dict(user_id=user_id, application_id=application_id),
     )
     abort(404)
 
@@ -234,9 +234,7 @@ def get_all_applications_associated_with_user(user_id, active=None):
         serialiser = AllocationAssociationSchema()
         return serialiser.dump(associations, many=True)
 
-    current_app.logger.error(
-        "Could not find any applications associated with user {user_id}", extra=dict(user_id=user_id)
-    )
+    current_app.logger.error("Could not find any applications associated with user %(user_id)s", dict(user_id=user_id))
     abort(404)
 
 
@@ -261,6 +259,6 @@ def get_all_associations_assigned_by_user(assigner_id, active=None):
         return serialiser.dump(associations, many=True)
 
     current_app.logger.error(
-        "Could not find any applications assigned by user {assigner_id}", extra=dict(assigner_id=assigner_id)
+        "Could not find any applications assigned by user %(assigner_id)s", dict(assigner_id=assigner_id)
     )
     abort(404)

--- a/assessment_store/db/queries/assessment_records/_helpers.py
+++ b/assessment_store/db/queries/assessment_records/_helpers.py
@@ -22,8 +22,8 @@ def get_answer_value(application_json, answer_key):
         )
     except Exception as e:
         current_app.logger.warning(
-            "Could not extract answer from question {answer_key} in application: {application_id}.",
-            extra=dict(application_id=application_json["id"], answer_key=answer_key),
+            "Could not extract answer from question %(answer_key)s in application: %(application_id)s.",
+            dict(application_id=application_json["id"], answer_key=answer_key),
             exc_info=e,
         )
         return None
@@ -43,8 +43,8 @@ def get_answer_value_for_multi_input(application_json, answer_key, value_key):
         return funding_one
     except Exception as e:
         current_app.logger.warning(
-            "Could not extract answer from question {answer_key} in application: {application_id}.",
-            extra=dict(application_id=application_json["id"], answer_key=answer_key),
+            "Could not extract answer from question %(answer_key)s in application: %(application_id)s.",
+            dict(application_id=application_json["id"], answer_key=answer_key),
             exc_info=e,
         )
         return None
@@ -61,8 +61,8 @@ def get_location_json_from_postcode(raw_postcode):
         )
         if response.status_code != 200:
             current_app.logger.error(
-                "Failed requesting location data for postcode {postcode}. Received error response {response}",
-                extra=dict(postcode=raw_postcode, response=response),
+                "Failed requesting location data for postcode %(postcode)s. Received error response %(response)s",
+                dict(postcode=raw_postcode, response=response),
             )
             return None
 
@@ -88,7 +88,7 @@ def get_location_json_from_postcode(raw_postcode):
 
     except Exception as e:
         current_app.logger.error(
-            "Failed requesting location data for postcode {postcode}", exc_info=e, extra=dict(postcode=raw_postcode)
+            "Failed requesting location data for postcode %(postcode)s", dict(postcode=raw_postcode), exc_info=e
         )
         return None
 
@@ -135,7 +135,7 @@ def derive_application_values(application_json):  # noqa: C901 - historical sadn
         return derived_values
 
     current_app.logger.info(
-        "Deriving values for application id: {application_id}.", extra=dict(application_id=application_id)
+        "Deriving values for application id: %(application_id)s.", dict(application_id=application_id)
     )
 
     try:
@@ -190,9 +190,9 @@ def derive_application_values(application_json):  # noqa: C901 - historical sadn
         current_app.logger.error(
             # Shouldn't ever get here, but quick catch all for the interim removal of the queue
             # and not breaking the submit process
-            "Unexpected error when deriving values for application {application_id}",
+            "Unexpected error when deriving values for application %(application_id)s",
+            dict(application_id=application_id),
             exc_info=e,
-            extra=dict(application_id=application_id),
         )
 
     return derived_values
@@ -267,7 +267,7 @@ def filter_tags(incoming_tags, existing_tags):
         )
         if _incoming_tag:
             current_app.logger.info(
-                "Tag id is already associated: {existing_tag_id}", extra=dict(existing_tag_id=existing_tag_id)
+                "Tag id is already associated: %(existing_tag_id)s", dict(existing_tag_id=existing_tag_id)
             )
         else:
             filtered_tags.append(existing_tag_list)

--- a/assessment_store/db/queries/assessment_records/queries.py
+++ b/assessment_store/db/queries/assessment_records/queries.py
@@ -101,8 +101,8 @@ def get_metadata_for_fund_round_id(  # noqa: C901 - historical sadness
     )
     if search_term != "":
         current_app.logger.info(
-            "Performing assessment search on search term: {search_term} in fields {search_in}",
-            extra=dict(search_term=search_term, search_in=search_in),
+            "Performing assessment search on search term: %(search_term)s in fields %(search_in)s",
+            dict(search_term=search_term, search_in=search_in),
         )
         search_term = search_term.replace(" ", "%")
 
@@ -134,34 +134,32 @@ def get_metadata_for_fund_round_id(  # noqa: C901 - historical sadness
         statement = statement.where(AssessmentRecord.application_id.in_(record_ids_with_tag_id))
 
     if "all" not in countries:
-        current_app.logger.info(
-            "Performing assessment search on countries: {countries}.", extra=dict(countries=countries)
-        )
+        current_app.logger.info("Performing assessment search on countries: %(countries)s.", dict(countries=countries))
         statement = statement.where(AssessmentRecord.location_json_blob["country"].astext.ilike(func.any_(countries)))
 
     if asset_type != "ALL" and asset_type != "":
         current_app.logger.info(
-            "Performing assessment search on asset type: {asset_type}.", extra=dict(asset_type=asset_type)
+            "Performing assessment search on asset type: %(asset_type)s.", dict(asset_type=asset_type)
         )
         statement = statement.where(AssessmentRecord.asset_type == asset_type)
 
     if country != "" and country != "ALL":
-        current_app.logger.info("Performing assessment search on country: {country}.", extra=dict(country=country))
+        current_app.logger.info("Performing assessment search on country: %(country)s.", dict(country=country))
         statement = statement.where(AssessmentRecord.location_json_blob["country"].astext == country)
 
     if region != "" and region != "ALL":
-        current_app.logger.info("Performing assessment search on region: {region}.", extra=dict(region=region))
+        current_app.logger.info("Performing assessment search on region: %(region)s.", dict(region=region))
         statement = statement.where(AssessmentRecord.location_json_blob["region"].astext == region)
 
     if datasets != "" and datasets != "ALL":
         datasets = True if str(datasets).lower() == "yes" or datasets is True else False
-        current_app.logger.info("Performing assessment search on datasets: {datasets}.", extra=dict(datasets=datasets))
+        current_app.logger.info("Performing assessment search on datasets: %(datasets)s.", dict(datasets=datasets))
         statement = statement.where(cast(AssessmentRecord.datasets, String) == str(datasets).lower())
 
     if publish_datasets != "" and publish_datasets != "ALL":
         current_app.logger.info(
-            "Performing assessment search on publish_datasets: {publish_datasets}.",
-            extra=dict(publish_datasets=publish_datasets),
+            "Performing assessment search on publish_datasets: %(publish_datasets)s.",
+            dict(publish_datasets=publish_datasets),
         )
         if publish_datasets == "None":
             statement = statement.where(AssessmentRecord.publish_datasets.is_(None))
@@ -171,14 +169,14 @@ def get_metadata_for_fund_round_id(  # noqa: C901 - historical sadness
     if team_in_place != "" and team_in_place != "ALL":
         team_in_place = True if str(team_in_place).lower() == "yes" or team_in_place is True else False
         current_app.logger.info(
-            "Performing assessment search on team_in_place: {team_in_place}.", extra=dict(team_in_place=team_in_place)
+            "Performing assessment search on team_in_place: %(team_in_place)s.", dict(team_in_place=team_in_place)
         )
         statement = statement.where(cast(AssessmentRecord.team_in_place, String) == str(team_in_place).lower())
 
     if local_authority != "" and local_authority != "ALL":
         current_app.logger.info(
-            "Performing assessment search on local_authority: {local_authority}.",
-            extra=dict(local_authority=local_authority),
+            "Performing assessment search on local_authority: %(local_authority)s.",
+            dict(local_authority=local_authority),
         )
 
         subquery = (
@@ -195,8 +193,8 @@ def get_metadata_for_fund_round_id(  # noqa: C901 - historical sadness
 
     if joint_application != "" and joint_application != "ALL" and joint_application in ["true", "false"]:
         current_app.logger.info(
-            "Performing assessment search on joint_application: {joint_application}.",
-            extra=dict(joint_application=joint_application),
+            "Performing assessment search on joint_application: %(joint_application)s.",
+            dict(joint_application=joint_application),
         )
 
         subquery = (
@@ -212,7 +210,7 @@ def get_metadata_for_fund_round_id(  # noqa: C901 - historical sadness
 
     if funding_type != "ALL" and funding_type != "":
         current_app.logger.info(
-            "Performing assessment search on funding type: {funding_type}.", extra=dict(funding_type=funding_type)
+            "Performing assessment search on funding type: %(funding_type)s.", dict(funding_type=funding_type)
         )
         # TODO SS figure out how to stop double quoting this - it works but is ugly
         # it's because when we retrieve the json element as funding_type, we get it as a json element, not pure text,
@@ -409,8 +407,8 @@ def get_application_jsonb_blob(application_id: str) -> dict:
 
 def update_status_to_completed(application_id):
     current_app.logger.info(
-        "Updating application status to COMPLETED for application: {application_id}.",
-        extra=dict(application_id=application_id),
+        "Updating application status to COMPLETED for application: %(application_id)s.",
+        dict(application_id=application_id),
     )
     db.session.query(AssessmentRecord).filter(AssessmentRecord.application_id == application_id).update(
         {AssessmentRecord.workflow_status: Status.COMPLETED},
@@ -520,7 +518,7 @@ def associate_assessment_tags(application_id, tags: List):
         if incoming_tag_id and not _existing_tags:
             # If no existing tags are found, create a new tag(s) with incoming tags info.
             current_app.logger.info(
-                "Creating new tag(s) for {incoming_tag_id}", extra=dict(incoming_tag_id=incoming_tag_id)
+                "Creating new tag(s) for %(incoming_tag_id)s", dict(incoming_tag_id=incoming_tag_id)
             )
             create_tag(application_id, incoming_tag_id, True, incoming_user_id)
 
@@ -536,11 +534,11 @@ def associate_assessment_tags(application_id, tags: List):
                 # If it's already associated, skip, otherwise, create a new associated tag.
                 if most_recent_tag.associated:
                     current_app.logger.info(
-                        "Tag is alreday associated: {tag_id}", extra=dict(tag_id=most_recent_tag.tag_id)
+                        "Tag is alreday associated: %(tag_id)s", dict(tag_id=most_recent_tag.tag_id)
                     )
                 else:
                     current_app.logger.info(
-                        "Creating new tag: {incoming_tag_id}", extra=dict(incoming_tag_id=incoming_tag_id)
+                        "Creating new tag: %(incoming_tag_id)s", dict(incoming_tag_id=incoming_tag_id)
                     )
                     create_tag(
                         application_id,
@@ -549,9 +547,7 @@ def associate_assessment_tags(application_id, tags: List):
                         incoming_user_id,
                     )
             else:
-                current_app.logger.info(
-                    "Creating new tag: {incoming_tag_id}", extra=dict(incoming_tag_id=incoming_tag_id)
-                )
+                current_app.logger.info("Creating new tag: %(incoming_tag_id)s", dict(incoming_tag_id=incoming_tag_id))
                 create_tag(application_id, incoming_tag_id, True, incoming_user_id)
 
         if not incoming_tag_id:
@@ -560,8 +556,8 @@ def associate_assessment_tags(application_id, tags: List):
                 most_recent_tag = max(filterted_tag, key=lambda x: x[0])[1]
                 if most_recent_tag.associated:
                     current_app.logger.info(
-                        "Dis-associating existing associated tag_id: {tag_id}",
-                        extra=dict(tag_id=most_recent_tag.tag_id),
+                        "Dis-associating existing associated tag_id: %(tag_id)s",
+                        dict(tag_id=most_recent_tag.tag_id),
                     )
                     create_tag(
                         application_id,

--- a/assessment_store/db/queries/scores/queries.py
+++ b/assessment_store/db/queries/scores/queries.py
@@ -144,7 +144,7 @@ def get_scoring_system_for_round_id(round_id: str) -> dict:
         metadata_serialiser = ScoringSystemMetadata()
         processed_scoring_system = metadata_serialiser.dump(scoring_system_instance)
         app.logger.warning(
-            "No scoring system found for round_id: {round_id}. Defaulting to OneToFive", extra=dict(round_id=round_id)
+            "No scoring system found for round_id: %(round_id)s. Defaulting to OneToFive", dict(round_id=round_id)
         )
     return processed_scoring_system
 

--- a/assessment_store/db/queries/tags/queries.py
+++ b/assessment_store/db/queries/tags/queries.py
@@ -144,8 +144,8 @@ def select_tags_for_fund_round(
     )
     if search_term != "":
         current_app.logger.info(
-            "Performing tag search on search term: {search_term} in fields {search_in}",
-            extra=dict(search_term=search_term, search_in=search_in),
+            "Performing tag search on search term: %(search_term)s in fields %(search_in)s",
+            dict(search_term=search_term, search_in=search_in),
         )
         # using % for sql LIKE search
         search_term = search_term.replace(" ", "%")

--- a/assessment_store/scripts/data_updates/FS-3661-total-funding-requested-cyp.py
+++ b/assessment_store/scripts/data_updates/FS-3661-total-funding-requested-cyp.py
@@ -20,9 +20,7 @@ def update_funding_amount_requested_for_cyp():
     cyp_records = db.session.execute(select_assessment_records_for_round_stmt)
 
     for application_id, jsonb_blob in cyp_records:
-        current_app.logger.info(
-            "Processing application id {application_id}.", extra=dict(application_id=application_id)
-        )
+        current_app.logger.info("Processing application id %(application_id)s.", dict(application_id=application_id))
         total_funding = 0
         for key in fund_round_data_key_mappings["CYPR1"]["funding_two"]:
             total_funding = total_funding + int(
@@ -37,8 +35,8 @@ def update_funding_amount_requested_for_cyp():
 
         new_funding_amount_requested = total_funding
         current_app.logger.info(
-            "New funding amount requested: {new_funding_amount_requested}",
-            extra=dict(new_funding_amount_requested=new_funding_amount_requested),
+            "New funding amount requested: %(new_funding_amount_requested)s",
+            dict(new_funding_amount_requested=new_funding_amount_requested),
         )
         update_statement = (
             update(AssessmentRecord)

--- a/assessment_store/scripts/derive_assessment_values.py
+++ b/assessment_store/scripts/derive_assessment_values.py
@@ -20,8 +20,8 @@ def derive_assessment_values(application_id):
     from db import db
 
     current_app.logger.info(
-        "Deriving values for {application_id}",
-        extra=dict(application_id=application_id),
+        "Deriving values for %(application_id)s",
+        dict(application_id=application_id),
     )
 
     application_json = get_application(application_id, include_forms=True, as_json=True)

--- a/assessment_store/services/data_services.py
+++ b/assessment_store/services/data_services.py
@@ -10,12 +10,12 @@ def get_data(endpoint: str, payload: Dict = None):
     try:
         if payload:
             current_app.logger.info(
-                "Fetching data from '{endpoint}', with payload: {payload}.",
-                extra=dict(endpoint=endpoint, payload=payload),
+                "Fetching data from '%(endpoint)s', with payload: %(payload)s.",
+                dict(endpoint=endpoint, payload=payload),
             )
             response = requests.get(endpoint, payload)
         else:
-            current_app.logger.info("Fetching data from '{endpoint}'.", extra=dict(endpoint=endpoint))
+            current_app.logger.info("Fetching data from '%(endpoint)s'.", dict(endpoint=endpoint))
             response = requests.get(endpoint)
         if response.status_code == 200:
             if "application/json" == response.headers["Content-Type"]:
@@ -24,10 +24,10 @@ def get_data(endpoint: str, payload: Dict = None):
                 return response.content
         elif response.status_code == 204:
             current_app.logger.warning(
-                "Request successful but no resources returned for endpoint '{endpoint}'.", extra=dict(endpoint=endpoint)
+                "Request successful but no resources returned for endpoint '%(endpoint)s'.", dict(endpoint=endpoint)
             )
         else:
-            current_app.logger.error("Could not get data for endpoint '{endpoint}' ", extra=dict(endpoint=endpoint))
+            current_app.logger.error("Could not get data for endpoint '%(endpoint)s' ", dict(endpoint=endpoint))
     except requests.exceptions.RequestException:
         current_app.logger.exception("Unable to get_data")
 

--- a/authenticator/api/magic_links/routes.py
+++ b/authenticator/api/magic_links/routes.py
@@ -57,8 +57,8 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             account = AccountMethods.get_account(account_id=link.get("accountId"))
             if not account:
                 current_app.logger.error(
-                    "Tried to use magic link for non-existent account_id {account_id}",
-                    extra=dict(account_id=link.get("accountId")),
+                    "Tried to use magic link for non-existent account_id %(account_id)s",
+                    dict(account_id=link.get("accountId")),
                 )
                 redirect(
                     url_for(
@@ -117,11 +117,11 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             query_string = urlencode(query_params)
             frontend_account_url = urljoin(Config.APPLICANT_FRONTEND_HOST, f"account?{query_string}")
             current_app.logger.warning(
-                "The magic link with hash: '{link_hash}' has already been"
-                " used but the user with account_id: '{account_id}' is"
+                "The magic link with hash: '%(link_hash)s' has already been"
+                " used but the user with account_id: '%(account_id)s' is"
                 " logged in, redirecting to"
-                " '{frontend_account_url}'.",
-                extra=dict(link_hash=link_hash, account_id=g.account_id, frontend_account_url=frontend_account_url),
+                " '%(frontend_account_url)s'.",
+                dict(link_hash=link_hash, account_id=g.account_id, frontend_account_url=frontend_account_url),
             )
             return redirect(frontend_account_url)
         return redirect(

--- a/authenticator/api/session/auth_session.py
+++ b/authenticator/api/session/auth_session.py
@@ -51,7 +51,7 @@ class AuthSessionBase:
                 status = "expired_token"
             except jwt.PyJWTError as e:
                 current_app.logger.warning(
-                    "PyJWTError: {error_name} - {error}", extra=dict(error_name=e.__class__.__name__, error=str(e))
+                    "PyJWTError: %(error_name)s - %(error)s", dict(error_name=e.__class__.__name__, error=str(e))
                 )
                 status = "invalid_token"
 
@@ -69,11 +69,11 @@ class AuthSessionBase:
             if safe_app := Config.SAFE_RETURN_APPS.get(return_app):
                 redirect_route = safe_app.logout_endpoint
                 current_app.logger.info(
-                    "Returning to {return_app} using {redirect_route}",
-                    extra=dict(return_app=return_app, redirect_route=redirect_route),
+                    "Returning to %(return_app)s using %(redirect_route)s",
+                    dict(return_app=return_app, redirect_route=redirect_route),
                 )
             else:
-                current_app.logger.warning("{return_app} not listed as a safe app.", extra=dict(return_app=return_app))
+                current_app.logger.warning("%(return_app)s not listed as a safe app.", dict(return_app=return_app))
                 resp = make_response({"detail": "Unknown return app."}, 400)
                 resp.headers["Content-Type"] = "application/json"
                 return resp
@@ -152,7 +152,7 @@ class AuthSessionBase:
                 samesite=Config.FSD_USER_TOKEN_COOKIE_SAMESITE,
                 httponly=Config.SESSION_COOKIE_HTTPONLY,
             )
-            current_app.logger.info("User logged in to account : {account_id}", extra=dict(account_id=account.id))
+            current_app.logger.info("User logged in to account : %(account_id)s", dict(account_id=account.id))
             return response
         except SessionCreateError as e:
             error_response(404, str(e))

--- a/authenticator/api/sso/routes.py
+++ b/authenticator/api/sso/routes.py
@@ -97,7 +97,7 @@ class SsoLoginView(SsoBase, MethodView):
             session["return_app"] = return_app
             session["return_path"] = request.args.get("return_path")
             current_app.logger.debug(
-                "Setting return app to {return_app} for this session", extra=dict(return_app=return_app)
+                "Setting return app to %(return_app)s for this session", dict(return_app=return_app)
             )
 
         return redirect(session["flow"]["auth_uri"]), 302
@@ -148,7 +148,7 @@ class SsoGetTokenView(SsoBase, MethodView):
             session["user"] = result.get("id_token_claims")
             self._save_cache(cache)
         except ValueError as e:  # Usually caused by CSRF
-            current_app.logger.warning("Value Error on get_token route: {error}", extra=dict(error=str(e)))
+            current_app.logger.warning("Value Error on get_token route: %(error)s", dict(error=str(e)))
 
         if "user" not in session or not session["user"].get("sub"):
             return {"message": "No valid token"}, 404
@@ -171,11 +171,11 @@ class SsoGetTokenView(SsoBase, MethodView):
                     redirect_url = safe_app.login_url
 
                 current_app.logger.info(
-                    "Returning to {return_app} @ {redirect_url}",
-                    extra=dict(return_app=return_app, redirect_url=redirect_url),
+                    "Returning to %(return_app)s @ %(redirect_url)s",
+                    dict(return_app=return_app, redirect_url=redirect_url),
                 )
             else:
-                current_app.logger.warning("{return_app} not listed as a safe app.", extra=dict(return_app=return_app))
+                current_app.logger.warning("%(return_app)s not listed as a safe app.", dict(return_app=return_app))
                 resp = make_response({"detail": "Unknown return app."}, 400)
                 resp.headers["Content-Type"] = "application/json"
                 return resp

--- a/authenticator/frontend/default/routes.py
+++ b/authenticator/frontend/default/routes.py
@@ -27,7 +27,7 @@ def internal_server_error(error):
     error_message = f"Encountered 500: {error}"
     stack_trace = traceback.format_exc()
     current_app.logger.error(
-        "{error_message}\n{stack_trace}", extra=dict(error_message=error_message, stack_trace=stack_trace)
+        "%(error_message)s\n%(stack_trace)s", dict(error_message=error_message, stack_trace=stack_trace)
     )
 
     return render_template("authenticator/500.html", is_error=True), 500

--- a/authenticator/frontend/magic_links/routes.py
+++ b/authenticator/frontend/magic_links/routes.py
@@ -169,7 +169,7 @@ def new():
 
             if Config.AUTO_REDIRECT_LOGIN:
                 current_app.logger.info(
-                    "Auto redirecting to magic link:  {created_link}", extra=dict(created_link=created_link)
+                    "Auto redirecting to magic link: %(created_link)s", dict(created_link=created_link)
                 )
                 return redirect(created_link)
 

--- a/authenticator/models/account.py
+++ b/authenticator/models/account.py
@@ -206,7 +206,7 @@ class AccountMethods(Account):
                 fund_short_name=fund_short_name if fund_short_name else "",
                 round_short_name=round_short_name if round_short_name else "",
             )
-            current_app.logger.debug("Magic Link URL: {link}", extra=dict(link=new_link_json.get("link")))
+            current_app.logger.debug("Magic Link URL: %(link)s", dict(link=new_link_json.get("link")))
 
             get_notification_service().send_magic_link(
                 email_address=account.email,
@@ -226,6 +226,6 @@ class AccountMethods(Account):
 
             return new_link_json.get("link")
         current_app.logger.error(
-            "Could not create an account ({account}) for email '{email}'", extra=dict(account=account, email=email)
+            "Could not create an account (%(account)s) for email '%(email)s'", dict(account=account, email=email)
         )
         raise AccountError(message="Sorry, we couldn't create an account for this email, please contact support")

--- a/authenticator/models/data.py
+++ b/authenticator/models/data.py
@@ -58,7 +58,7 @@ def put_data(endpoint: str, params: dict = None):
             return response.json()
         else:
             current_app.logger.error(
-                "API error response of : {response_string}", extra=dict(response_string=str(response.json()))
+                "API error response of: %(response_string)s", dict(response_string=str(response.json()))
             )
     else:
         return local_api_call(endpoint, params, "put")

--- a/authenticator/models/magic_link.py
+++ b/authenticator/models/magic_link.py
@@ -175,7 +175,7 @@ class MagicLinkMethods(object):
         :param redirect_url: (str, optional) An optional redirect_url
         :return:
         """
-        current_app.logger.info("Creating magic link for {account}", extra=dict(account=account))
+        current_app.logger.info("Creating magic link for %(account)s", dict(account=account))
 
         if not redirect_url:
             redirect_url = urljoin(
@@ -213,8 +213,8 @@ class MagicLinkMethods(object):
                     "link": magic_link_url,
                 }
             )
-            current_app.logger.info("Magic link created for {account}", extra=dict(account=account))
+            current_app.logger.info("Magic link created for %(account)s", dict(account=account))
             return new_link_json
 
-        current_app.logger.error("Magic link for account {account} could not be created", extra=dict(account=account))
+        current_app.logger.error("Magic link for account %(account)s could not be created", dict(account=account))
         raise MagicLinkError(message="Could not create a magic link")

--- a/fund_store/api/routes.py
+++ b/fund_store/api/routes.py
@@ -395,7 +395,8 @@ def update_application_reminder_sent_status(round_id):
             db.session.commit()
             (
                 current_app.logger.info(
-                    {f"application_reminder_sent status has been updated to True for round {round_id}"}
+                    "application_reminder_sent status has been updated to True for round %(round_id)s",
+                    dict(round_id=round_id),
                 ),
                 200,
             )
@@ -412,8 +413,8 @@ def update_application_reminder_sent_status(round_id):
     except Exception as e:
         (
             current_app.logger.error(
-                "The application_reminder_sent status could not be updated {error}",
-                extra=dict(error=str(e)),
+                "The application_reminder_sent status could not be updated %(error)s",
+                dict(error=str(e)),
             ),
             400,
         )

--- a/fund_store/scripts/data_updates/FS-2433-application_guidance.py
+++ b/fund_store/scripts/data_updates/FS-2433-application_guidance.py
@@ -10,8 +10,8 @@ from fund_store.db.models.round import Round
 def update_rounds_with_application_guidance(rounds):
     for round in rounds:
         current_app.logger.info(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=str(round["id"])),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=str(round["id"])),
         )
         if round.get("application_guidance"):
             current_app.logger.info("\t\tUpdating application_guidance")

--- a/fund_store/scripts/data_updates/FS-2900-ns-section-update.py
+++ b/fund_store/scripts/data_updates/FS-2900-ns-section-update.py
@@ -10,8 +10,8 @@ def update_section_titles(section_config):
     if len(section_config) > 0:
         for section in section_config:
             current_app.logger.info(
-                "\t\tUpdating section title from {section_old_title} to {section_new_title}.",
-                extra=dict(
+                "\t\tUpdating section title from %(section_old_title)s to %(section_new_title)s.",
+                dict(
                     section_old_title=section["old_title"],
                     section_new_title=section["new_title"],
                 ),

--- a/fund_store/scripts/data_updates/FS-2965_ns_guidance.py
+++ b/fund_store/scripts/data_updates/FS-2965_ns_guidance.py
@@ -9,8 +9,8 @@ from fund_store.db.models.round import Round
 def update_rounds_with_links(rounds):
     for round in rounds:
         current_app.logger.warning(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=str(round["id"])),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=str(round["id"])),
         )
         if round.get("application_guidance"):
             current_app.logger.warning("\t\tUpdating application_guidance")

--- a/fund_store/scripts/data_updates/FS-3471-application_guidance.py
+++ b/fund_store/scripts/data_updates/FS-3471-application_guidance.py
@@ -9,8 +9,8 @@ from fund_store.db.models.round import Round
 def update_rounds_with_application_guidance(rounds):
     for round in rounds:
         current_app.logger.info(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=str(round["id"])),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=str(round["id"])),
         )
         if round.get("application_guidance"):
             current_app.logger.info("\t\tUpdating application_guidance")

--- a/fund_store/scripts/data_updates/FS-3749_dpif_guidance_url.py
+++ b/fund_store/scripts/data_updates/FS-3749_dpif_guidance_url.py
@@ -9,8 +9,8 @@ from fund_store.db.models.round import Round
 def update_rounds_with_links(rounds):
     for round in rounds:
         current_app.logger.warning(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=str(round["id"])),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=str(round["id"])),
         )
         if round.get("guidance_url"):
             current_app.logger.warning("\t\tUpdating guidance_url")

--- a/fund_store/scripts/data_updates/FS-3808_dpif_application_fields_download_available.py
+++ b/fund_store/scripts/data_updates/FS-3808_dpif_application_fields_download_available.py
@@ -9,8 +9,8 @@ from fund_store.db.models.round import Round
 def update_application_fields_download_available(rounds):
     for round in rounds:
         current_app.logger.warning(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=str(round["id"])),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=str(round["id"])),
         )
         if round.get("application_fields_download_available"):
             current_app.logger.warning("\t\tUpdating application_fields_download_available")

--- a/fund_store/scripts/data_updates/FS-3866_fix_incorrect_instructions_url.py
+++ b/fund_store/scripts/data_updates/FS-3866_fix_incorrect_instructions_url.py
@@ -9,8 +9,8 @@ from fund_store.db.models.round import Round
 def update_rounds_with_links(rounds):
     for round in rounds:
         current_app.logger.warning(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=round["id"]),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=round["id"]),
         )
         if round.get("instructions"):
             current_app.logger.warning("\t\tUpdating instructions")

--- a/fund_store/scripts/data_updates/FS-4264_update_eoi_welsh_instructions.py
+++ b/fund_store/scripts/data_updates/FS-4264_update_eoi_welsh_instructions.py
@@ -8,8 +8,8 @@ from fund_store.db.models.round import Round
 
 def update_rounds_with_links(round_config):
     current_app.logger.warning(
-        "\tRound: {round_short_name} ({round_id})",
-        extra=dict(
+        "\tRound: %(round_short_name)s (%(round_id)s)",
+        dict(
             round_short_name=round_config[0]["short_name"],
             round_id=str(round_config[0]["id"]),
         ),

--- a/fund_store/scripts/data_updates/FS2910_ns_links.py
+++ b/fund_store/scripts/data_updates/FS2910_ns_links.py
@@ -9,8 +9,8 @@ from fund_store.db.models.round import Round
 def update_rounds_with_links(rounds):
     for round in rounds:
         current_app.logger.warning(
-            "\tRound: {round_short_name} ({round_id})",
-            extra=dict(round_short_name=round["short_name"], round_id=str(round["id"])),
+            "\tRound: %(round_short_name)s (%(round_id)s)",
+            dict(round_short_name=round["short_name"], round_id=str(round["id"])),
         )
         if round.get("prospectus") and round.get("privacy_notice"):
             current_app.logger.warning("\t\tUpdating prospectus and privacy notice")

--- a/fund_store/scripts/data_updates/FS2956_ns_weightings.py
+++ b/fund_store/scripts/data_updates/FS2956_ns_weightings.py
@@ -9,8 +9,8 @@ from fund_store.db.models.section import Section
 
 def update_section_weightings(section):
     current_app.logger.warning(
-        "\tSection: {section_tree_path} ({section_name})",
-        extra=dict(
+        "\tSection: %(section_tree_path)s (%(section_name)s)",
+        dict(
             section_tree_path=str(section["tree_path"]),
             section_name=str(section["section_name"]["en"]),
         ),

--- a/fund_store/scripts/data_updates/patch_cyp_name.py
+++ b/fund_store/scripts/data_updates/patch_cyp_name.py
@@ -7,7 +7,7 @@ from fund_store.db.models.fund import Fund
 
 
 def update_fund_name(fund_config):
-    current_app.logger.info("Fund: {fund_id}", extra=dict(fund_id=str(fund_config["id"])))
+    current_app.logger.info("Fund: %(fund_id)s", dict(fund_id=str(fund_config["id"])))
     current_app.logger.info("\t\tUpdating fund name")
     stmt = update(Fund).where(Fund.id == fund_config["id"]).values(name_json=fund_config["name_json"])
 

--- a/fund_store/scripts/data_updates/patch_cypr1_guidance_201023.py
+++ b/fund_store/scripts/data_updates/patch_cypr1_guidance_201023.py
@@ -8,8 +8,8 @@ from fund_store.db.models.round import Round
 
 def update_round_guidance(round_config):
     current_app.logger.info(
-        "Round: {round_short_name}, id: {round_id}",
-        extra=dict(
+        "Round: %(round_short_name)s, id: %(round_id)s",
+        dict(
             round_short_name=round_config["short_name"],
             round_id=str(round_config["id"]),
         ),

--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -133,8 +133,8 @@ class NotificationService:
     ) -> Notification:
         if current_app.config["DISABLE_NOTIFICATION_SERVICE"]:
             current_app.logger.info(
-                "Notification service is disabled. Would have sent email to {email_address}",
-                extra=dict(email_address=email_address),
+                "Notification service is disabled. Would have sent email to %(email_address)s",
+                dict(email_address=email_address),
             )
             return Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000000"))
 

--- a/tests/assess_tests/test_deprecated_theme_mapper.py
+++ b/tests/assess_tests/test_deprecated_theme_mapper.py
@@ -213,6 +213,4 @@ def test_deprecated_sort_add_another_component_contents_log_when_no_answer(
 
     deprecated_sort_add_another_component_contents(themes_answers)
 
-    current_app.logger.debug.assert_called_with(
-        "Answer not provided for field_id: {field_id}", extra=dict(field_id="123")
-    )
+    current_app.logger.debug.assert_called_with("Answer not provided for field_id: %(field_id)s", dict(field_id="123"))

--- a/tests/assessment_store_tests/conftest.py
+++ b/tests/assessment_store_tests/conftest.py
@@ -81,8 +81,8 @@ def bulk_insert_application_record(
 
         if derived_values["location_json_blob"]["error"]:
             current_app.logger.error(
-                "Location key not found or invalid postcode provided for the application: {short_id}.",
-                extra=dict(short_id=derived_values["short_id"]),
+                "Location key not found or invalid postcode provided for the application: %(short_id)s.",
+                dict(short_id=derived_values["short_id"]),
             )
 
         row = {


### PR DESCRIPTION
### Change description
The {} with `extras` style is used by a custom log formatted that we have in fsd-utils, which interpolates messages eagerly as they get handled.

This style is supported natively by Python logging, which means that it's better supported by things that integrate with Python - like Sentry.

Currently in Sentry, our log messages don't show up interpolated, so you'll get a raw string like "I'm a log message for {data}". Which isn't very useful if you care about the value of `data`.

By using "I'm a log message for %(data)s" instead, Sentry will still group all error logs under a single issue, but it'll also correctly interpolate the value of `data` into the message, which should aid debugging.