### PR TITLE
FLS-820 Accept sub-criteria in uncompeted workflow

### DIFF
--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1203,8 +1203,11 @@ def display_sub_criteria(
     change_request_user_ids = set(
         flag_item["user_id"] for change_request in sub_criteria_change_requests for flag_item in change_request.updates
     )
+    approval_users_ids = set(score_item["user_id"] for score_item in score)
 
-    change_request_users = get_bulk_accounts_dict(change_request_user_ids, state.fund_short_name)
+    approval_change_request_users = get_bulk_accounts_dict(
+        change_request_user_ids.union(approval_users_ids), state.fund_short_name
+    )
 
     comment_response = get_comments(
         application_id=application_id,
@@ -1269,7 +1272,7 @@ def display_sub_criteria(
         "application_id": application_id,
         "comments": theme_matched_comments,
         "change_requests": sub_criteria_change_requests,
-        "accounts_list": change_request_users,
+        "accounts_list": approval_change_request_users,
         "is_flaggable": False,  # Flag button is disabled in sub-criteria page,
         "display_comment_box": add_comment_argument,
         "display_comment_edit_box": edit_comment_argument,

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -92,6 +92,7 @@ from pre_award.assess.config.display_value_mappings import (
     search_params_default,
 )
 from pre_award.assess.flagging.forms.request_changes_form import RequestChangesForm
+from pre_award.assess.scoring.forms.scores_and_justifications import ApprovalForm
 from pre_award.assess.scoring.helpers import get_scoring_class
 from pre_award.assess.services.aws import get_file_for_download_from_aws
 from pre_award.assess.services.data_services import (
@@ -147,6 +148,7 @@ from pre_award.assess.themes.deprecated_theme_mapper import (
     order_entire_application_by_themes,
 )
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as WorkflowStatus
+from pre_award.assessment_store.db.queries.scores.queries import approve_sub_criteria
 from pre_award.common.blueprints import Blueprint
 from pre_award.config import Config
 
@@ -1135,7 +1137,7 @@ def fund_dashboard(fund_short_name: str, round_short_name: str):
     methods=["POST", "GET"],
 )
 @check_access_application_id
-def display_sub_criteria(
+def display_sub_criteria(  # noqa: C901
     application_id,
     sub_criteria_id,
 ):
@@ -1147,8 +1149,12 @@ def display_sub_criteria(
     """
     current_app.logger.info("Processing GET to %(request_path)s.", dict(request_path=request.path))
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
+    score = get_score_and_justification(
+        application_id=application_id, sub_criteria_id=sub_criteria_id, score_history=False
+    )
     theme_id = request.args.get("theme_id", sub_criteria.themes[0].id)
     comment_form = CommentsForm()
+    approval_form = ApprovalForm()
     try:
         current_theme: Theme = next(iter(t for t in sub_criteria.themes if t.id == theme_id))
     except StopIteration:
@@ -1173,6 +1179,18 @@ def display_sub_criteria(
                 sub_criteria_id=sub_criteria_id,
                 theme_id=theme_id,
                 _anchor="comments",
+            )
+        )
+
+    if approval_form.validate_on_submit():
+        approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=g.account_id)
+
+        return redirect(
+            url_for(
+                "assessment_bp.display_sub_criteria",
+                application_id=application_id,
+                sub_criteria_id=sub_criteria_id,
+                theme_id=theme_id,
             )
         )
 
@@ -1251,6 +1269,7 @@ def display_sub_criteria(
 
     common_template_config = {
         "sub_criteria": sub_criteria,
+        "score": score[0] if score else None,
         "fund": get_fund(sub_criteria.fund_id),
         "application_id": application_id,
         "comments": theme_matched_comments,
@@ -1261,6 +1280,7 @@ def display_sub_criteria(
         "display_comment_edit_box": edit_comment_argument,
         "comment_id": comment_id,
         "comment_form": comment_form,
+        "approval_form": approval_form,
         "current_theme": current_theme,
         "flag_status": flag_status,
         "assessment_status": assessment_status,

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1203,7 +1203,7 @@ def display_sub_criteria(
     change_request_user_ids = set(
         flag_item["user_id"] for change_request in sub_criteria_change_requests for flag_item in change_request.updates
     )
-    approval_users_ids = set(score_item["user_id"] for score_item in score)
+    approval_users_ids = set(score_item["user_id"] for score_item in score) if score else set()
 
     approval_change_request_users = get_bulk_accounts_dict(
         change_request_user_ids.union(approval_users_ids), state.fund_short_name

--- a/pre_award/assess/assessments/templates/assessments/sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/sub_criteria.html
@@ -64,9 +64,11 @@ Error:
         {% for change_request in change_requests %}
             {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], application_id) }}
         {% endfor %}
+        {#
         {% if fund.funding_type == 'UNCOMPETED' and score %}
             {{ assessment_subcriteria_accepted(score.date_created, accounts_list[score.user_id]) }}
         {% endif %}
+        #}
         <h3 class="govuk-heading-m response-title">Applicant's response</h3>
         {{ theme(answers_meta)}}
         {% if fund.funding_type == 'UNCOMPETED' %}

--- a/pre_award/assess/assessments/templates/assessments/sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/sub_criteria.html
@@ -10,6 +10,7 @@
 {% from "assess/macros/sub_criteria_heading.html" import sub_criteria_heading %}
 {% from "assess/macros/migration_banner.html" import migration_banner %}
 {% from "assess/macros/assessment_change_request.html" import assessment_change_request %}
+{% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
 {%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
 
 {% set pageHeading -%}
@@ -63,10 +64,13 @@ Error:
         {% for change_request in change_requests %}
             {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], application_id) }}
         {% endfor %}
+        {% if fund.funding_type == 'UNCOMPETED' and score %}
+            {{ assessment_subcriteria_accepted(score.date_created, accounts_list[score.user_id]) }}
+        {% endif %}
         <h3 class="govuk-heading-m response-title">Applicant's response</h3>
         {{ theme(answers_meta)}}
         {% if fund.funding_type == 'UNCOMPETED' %}
-            {{ application_feedback(application_id, sub_criteria, current_theme.id) }}
+            {{ application_feedback(application_id, sub_criteria, current_theme.id, approval_form) }}
         {% endif %}
         {{ comment(comments, False) }}
         {% if display_comment_box != True and not display_comment_edit_box %}

--- a/pre_award/assess/assessments/templates/assessments/sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/sub_criteria.html
@@ -64,14 +64,12 @@ Error:
         {% for change_request in change_requests %}
             {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], application_id) }}
         {% endfor %}
-        {#
-        {% if fund.funding_type == 'UNCOMPETED' and score %}
+        {% if toggle_dict.get("UNCOMPETED_WORKFLOW") and fund.funding_type == 'UNCOMPETED' and score %}
             {{ assessment_subcriteria_accepted(score.date_created, accounts_list[score.user_id]) }}
         {% endif %}
-        #}
         <h3 class="govuk-heading-m response-title">Applicant's response</h3>
         {{ theme(answers_meta)}}
-        {% if fund.funding_type == 'UNCOMPETED' %}
+        {% if toggle_dict.get("UNCOMPETED_WORKFLOW") and fund.funding_type == 'UNCOMPETED' %}
             {{ application_feedback(application_id, sub_criteria, current_theme.id, approval_form) }}
         {% endif %}
         {{ comment(comments, False) }}

--- a/pre_award/assess/scoring/forms/scores_and_justifications.py
+++ b/pre_award/assess/scoring/forms/scores_and_justifications.py
@@ -3,6 +3,10 @@ from wtforms import RadioField, TextAreaField
 from wtforms.validators import InputRequired
 
 
+class ApprovalForm(FlaskForm):
+    pass
+
+
 class ScoreForm(FlaskForm):
     """
     Given class is a form class model for scoring a sub-criteria fund

--- a/pre_award/assess/scoring/routes.py
+++ b/pre_award/assess/scoring/routes.py
@@ -15,6 +15,7 @@ from pre_award.assess.services.data_services import (
 from pre_award.assess.services.models.sub_criteria import SubCriteria
 from pre_award.assess.services.shared_data_helpers import get_state_for_tasklist_banner
 from pre_award.assess.shared.helpers import determine_assessment_status, determine_flag_status
+from pre_award.assessment_store.db.queries.scores.queries import approve_sub_criteria as _approve_sub_criteria
 from pre_award.common.blueprints import Blueprint
 from pre_award.config import Config
 
@@ -108,3 +109,12 @@ def score(
         migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
         pagination=state.get_pagination_from_sub_criteria_id(sub_criteria_id),
     )
+
+
+@scoring_bp.route(
+    "/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/approve",
+    methods=["POST"],
+)
+@check_access_application_id(roles_required=["LEAD_ASSESSOR", "ASSESSOR"])
+def approve_sub_criteria(application_id, sub_criteria_id):
+    _approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=g.account_id)

--- a/pre_award/assess/scoring/routes.py
+++ b/pre_award/assess/scoring/routes.py
@@ -15,7 +15,6 @@ from pre_award.assess.services.data_services import (
 from pre_award.assess.services.models.sub_criteria import SubCriteria
 from pre_award.assess.services.shared_data_helpers import get_state_for_tasklist_banner
 from pre_award.assess.shared.helpers import determine_assessment_status, determine_flag_status
-from pre_award.assessment_store.db.queries.scores.queries import approve_sub_criteria as _approve_sub_criteria
 from pre_award.common.blueprints import Blueprint
 from pre_award.config import Config
 

--- a/pre_award/assess/scoring/routes.py
+++ b/pre_award/assess/scoring/routes.py
@@ -109,12 +109,3 @@ def score(
         migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
         pagination=state.get_pagination_from_sub_criteria_id(sub_criteria_id),
     )
-
-
-@scoring_bp.route(
-    "/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/approve",
-    methods=["POST"],
-)
-@check_access_application_id(roles_required=["LEAD_ASSESSOR", "ASSESSOR"])
-def approve_sub_criteria(application_id, sub_criteria_id):
-    _approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=g.account_id)

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -334,7 +334,7 @@ def get_available_teams(fund_id: str, round_id: str, ttl_hash=None) -> list:
     return teams_available or []
 
 
-def get_bulk_accounts_dict(account_ids: List, fund_short_name: str):
+def get_bulk_accounts_dict(account_ids: Collection, fund_short_name: str):
     if account_ids:
         account_ids_to_retrieve = list(set(account_ids))
         account_url = Config.BULK_ACCOUNTS_ENDPOINT

--- a/pre_award/assess/templates/assess/macros/application_feedback.html
+++ b/pre_award/assess/templates/assess/macros/application_feedback.html
@@ -2,7 +2,7 @@
 
 
 {% macro application_feedback(application_id, sub_criteria, current_theme_id, approval_form) %}
-    <div class="govuk-!-margin-top-7">
+    <div class="govuk-!-margin-top-7 govuk-!-display-none">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Request application changes
         </h2>

--- a/pre_award/assess/templates/assess/macros/application_feedback.html
+++ b/pre_award/assess/templates/assess/macros/application_feedback.html
@@ -1,8 +1,8 @@
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 
-{% macro application_feedback(application_id, sub_criteria, current_theme_id) %}
-    <div class="govuk-!-margin-top-7 govuk-!-display-none">
+{% macro application_feedback(application_id, sub_criteria, current_theme_id, approval_form) %}
+    <div class="govuk-!-margin-top-7">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Request application changes
         </h2>
@@ -10,9 +10,11 @@
             Do you have feedback for this section to the applicant.
         </p>
         <div class="govuk-button-group">
-            <a href="#" class="govuk-button primary-button">
-                Approve
-            </a>
+            <form method="post" action="{{ url_for('assessment_bp.display_sub_criteria',
+                    application_id=application_id,
+                    sub_criteria_id=sub_criteria.id) }}">
+            {{ approval_form.csrf_token }}
+            <button type="submit" class="govuk-button primary-button">Approve</button>
             <a
                 href="{{ url_for(
                     'assessment_bp.request_changes',

--- a/pre_award/assess/templates/assess/macros/application_feedback.html
+++ b/pre_award/assess/templates/assess/macros/application_feedback.html
@@ -2,7 +2,7 @@
 
 
 {% macro application_feedback(application_id, sub_criteria, current_theme_id, approval_form) %}
-    <div class="govuk-!-margin-top-7 govuk-!-display-none">
+    <div class="govuk-!-margin-top-7">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
             Request application changes
         </h2>

--- a/pre_award/assess/templates/assess/macros/assessment_subcriteria_accepted.html
+++ b/pre_award/assess/templates/assess/macros/assessment_subcriteria_accepted.html
@@ -1,0 +1,26 @@
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
+{% macro assessment_subcriteria_accepted(score_date, user_info) %}
+    {% set title_html %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+            Acceptance
+        </div>
+        <div class="govuk-grid-column-one-half govuk-!-text-align-right">
+            <span class="govuk-!-font-weight-regular">{{ score_date | utc_to_bst }}</span>
+        </div>
+    </div>
+    {% endset %}
+    {% set notification_banner_html %}
+    <p class="govuk-body">
+        <strong>Approved by</strong><br>
+        {{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}
+    </p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+        "html": notification_banner_html,
+        "titleHtml": title_html,
+        "type": "success"
+    }) }}
+{% endmacro %}

--- a/pre_award/assessment_store/db/queries/assessment_records/queries.py
+++ b/pre_award/assessment_store/db/queries/assessment_records/queries.py
@@ -410,7 +410,7 @@ def update_status_to_completed(application_id):
         "Updating application status to COMPLETED for application: %(application_id)s.",
         dict(application_id=application_id),
     )
-    update_application_status(Status.COMPLETED)
+    update_application_status(application_id=application_id, status=Status.COMPLETED)
 
 
 def update_application_status(application_id: str, status: Status):

--- a/pre_award/assessment_store/db/queries/assessment_records/queries.py
+++ b/pre_award/assessment_store/db/queries/assessment_records/queries.py
@@ -410,11 +410,14 @@ def update_status_to_completed(application_id):
         "Updating application status to COMPLETED for application: %(application_id)s.",
         dict(application_id=application_id),
     )
+    update_application_status(Status.COMPLETED)
+
+
+def update_application_status(application_id: str, status: Status):
     db.session.query(AssessmentRecord).filter(AssessmentRecord.application_id == application_id).update(
-        {AssessmentRecord.workflow_status: Status.COMPLETED},
+        {AssessmentRecord.workflow_status: status},
         synchronize_session=False,
     )
-
     db.session.commit()
 
 

--- a/pre_award/assessment_store/db/queries/scores/queries.py
+++ b/pre_award/assessment_store/db/queries/scores/queries.py
@@ -14,6 +14,16 @@ from sqlalchemy.orm.exc import NoResultFound
 from pre_award.assessment_store.db.models import AssessmentRecord
 from pre_award.assessment_store.db.models.score import AssessmentRound, Score, ScoringSystem
 from pre_award.assessment_store.db.schemas import AssessmentRoundMetadata, ScoreMetadata, ScoringSystemMetadata
+
+from pre_award.assessment_store.db.models.assessment_record.enums import Status as ApplicationStatus
+from pre_award.assessment_store.db.queries.assessment_records.queries import (
+    check_all_change_requests_accepted,
+    update_application_status,
+)
+from pre_award.assessment_store.db.queries.flags.queries import (
+    resolve_open_change_requests_for_sub_criteria,
+)
+
 from pre_award.db import db
 
 
@@ -175,3 +185,21 @@ def insert_scoring_system_for_round_id(round_id: str, scoring_system_id: str) ->
     metadata_serialiser = AssessmentRoundMetadata()
     inserted_assessment_round = metadata_serialiser.dump(assessment_round)
     return inserted_assessment_round
+
+
+def approve_sub_criteria(application_id, sub_criteria_id, user_id):
+    # Temporary solution to "accept" a sub-criteria is to provide it a non-zero score
+    create_score_for_app_sub_crit(
+        score=1,
+        justification="Approved by assessor",
+        application_id=application_id,
+        user_id=user_id,
+        sub_criteria_id=sub_criteria_id,
+    )
+
+    resolve_open_change_requests_for_sub_criteria(
+        application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=user_id
+    )
+
+    if check_all_change_requests_accepted(application_id=application_id):
+        update_application_status(application_id=application_id, status=ApplicationStatus.IN_PROGRESS)

--- a/pre_award/assessment_store/db/queries/scores/queries.py
+++ b/pre_award/assessment_store/db/queries/scores/queries.py
@@ -12,10 +12,8 @@ from sqlalchemy import select
 from sqlalchemy.orm.exc import NoResultFound
 
 from pre_award.assessment_store.db.models import AssessmentRecord
-from pre_award.assessment_store.db.models.score import AssessmentRound, Score, ScoringSystem
-from pre_award.assessment_store.db.schemas import AssessmentRoundMetadata, ScoreMetadata, ScoringSystemMetadata
-
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as ApplicationStatus
+from pre_award.assessment_store.db.models.score import AssessmentRound, Score, ScoringSystem
 from pre_award.assessment_store.db.queries.assessment_records.queries import (
     check_all_change_requests_accepted,
     update_application_status,
@@ -23,7 +21,7 @@ from pre_award.assessment_store.db.queries.assessment_records.queries import (
 from pre_award.assessment_store.db.queries.flags.queries import (
     resolve_open_change_requests_for_sub_criteria,
 )
-
+from pre_award.assessment_store.db.schemas import AssessmentRoundMetadata, ScoreMetadata, ScoringSystemMetadata
 from pre_award.db import db
 
 

--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -331,7 +331,12 @@ class DefaultConfig(object):
     TOGGLES_URL = REDIS_INSTANCE_URI + "/0"
     REDIS_SESSIONS_URL = REDIS_INSTANCE_URI + "/1"
     SESSION_REDIS = redis.from_url(REDIS_SESSIONS_URL)
-    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": False, **CommonConfig.dev_feature_configuration}
+    FEATURE_CONFIG = {
+        "TAGGING": True,
+        "ASSESSMENT_ASSIGNMENT": False,
+        "UNCOMPETED_WORKFLOW": False,
+        **CommonConfig.dev_feature_configuration,
+    }
 
     # LRU cache settings
     LRU_CACHE_TIME = int(environ.get("LRU_CACHE_TIME", 3600))  # in seconds

--- a/pre_award/config/envs/dev.py
+++ b/pre_award/config/envs/dev.py
@@ -3,7 +3,7 @@
 import logging
 from os import getenv
 
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 
 from pre_award.config.envs.aws import AwsConfig
 
@@ -17,3 +17,10 @@ class DevConfig(AwsConfig):
 
     # assess dev config
     REDIS_INSTANCE_NAME = "funding-service-magic-links-dev"
+
+    FEATURE_CONFIG = {
+        "TAGGING": True,
+        "ASSESSMENT_ASSIGNMENT": True,
+        "UNCOMPETED_WORKFLOW": True,
+        **CommonConfig.dev_feature_configuration,
+    }

--- a/pre_award/config/envs/development.py
+++ b/pre_award/config/envs/development.py
@@ -5,7 +5,7 @@ import logging
 from distutils.util import strtobool
 from os import getenv
 
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 
 from pre_award.config.envs.default import DefaultConfig
 from pre_award.config.envs.default import DefaultConfig as Config
@@ -143,3 +143,10 @@ class DevelopmentConfig(Config):
         RSA256_PUBLIC_KEY = base64.b64decode(RSA256_PUBLIC_KEY_BASE64).decode()
 
     ASSETS_AUTO_BUILD = True
+
+    FEATURE_CONFIG = {
+        "TAGGING": True,
+        "ASSESSMENT_ASSIGNMENT": True,
+        "UNCOMPETED_WORKFLOW": False,
+        **CommonConfig.dev_feature_configuration,
+    }

--- a/pre_award/config/envs/test.py
+++ b/pre_award/config/envs/test.py
@@ -15,4 +15,9 @@ class TestConfig(AwsConfig):
     # LRU cache settings
     LRU_CACHE_TIME = 300  # in seconds
 
-    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": True, **CommonConfig.dev_feature_configuration}
+    FEATURE_CONFIG = {
+        "TAGGING": True,
+        "ASSESSMENT_ASSIGNMENT": True,
+        "UNCOMPETED_WORKFLOW": True,
+        **CommonConfig.dev_feature_configuration,
+    }

--- a/pre_award/config/envs/unit_test.py
+++ b/pre_award/config/envs/unit_test.py
@@ -79,7 +79,12 @@ class UnitTestConfig(Config):
     TOGGLES_URL = "redis://localhost:6379/0"
 
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
-    FEATURE_CONFIG = {"TAGGING": True, "ASSESSMENT_ASSIGNMENT": True, **CommonConfig.dev_feature_configuration}
+    FEATURE_CONFIG = {
+        "TAGGING": True,
+        "ASSESSMENT_ASSIGNMENT": True,
+        "UNCOMPETED_WORKFLOW": True,
+        **CommonConfig.dev_feature_configuration,
+    }
 
     SHOW_ALL_ROUNDS = True
 

--- a/tests/pre_award/assess_tests/api_data/test_data.py
+++ b/tests/pre_award/assess_tests/api_data/test_data.py
@@ -130,6 +130,8 @@ flagged_app = {
             "latest_allocation": "test_team",
             "application_id": flagged_app_id,
             "sections_to_flag": ["Test section"],
+            "field_ids": [],
+            "is_change_request": False,
             "updates": [
                 {
                     "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
@@ -188,6 +190,8 @@ resolved_app = {
             "latest_allocation": "test_team",
             "application_id": resolved_app_id,
             "sections_to_flag": ["Test section"],
+            "field_ids": [],
+            "is_change_request": False,
             "updates": [
                 {
                     "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
@@ -257,6 +261,8 @@ stopped_app = {
             "latest_allocation": "test_team",
             "application_id": stopped_app_id,
             "sections_to_flag": ["Test section"],
+            "field_ids": [],
+            "is_change_request": False,
             "updates": [
                 {
                     "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
@@ -329,6 +335,8 @@ flagged_qa_completed_app = {
             "application_id": flagged_qa_completed_app_id,
             "justification": "Test",
             "sections_to_flag": ["Test section"],
+            "field_ids": [],
+            "is_change_request": False,
             "updates": [
                 {
                     "id": "316f607a-03b7-4592-b927-5021a28b7d6b",

--- a/tests/pre_award/assess_tests/test_flag_teams.py
+++ b/tests/pre_award/assess_tests/test_flag_teams.py
@@ -19,6 +19,8 @@ class TestTeamsFlagData:
             latest_allocation=latest_allocation,
             application_id=application_id,
             updates=updates,
+            field_ids=[],
+            is_change_request=False,
         )
 
     def test_from_flags_with_empty_list(self):

--- a/tests/pre_award/assessment_store_tests/test_db_scores.py
+++ b/tests/pre_award/assessment_store_tests/test_db_scores.py
@@ -9,7 +9,10 @@ from pre_award.assessment_store.api.routes.score_routes import get_scoring_syste
 from pre_award.assessment_store.db.models import AssessmentFlag, AssessmentRecord, Score
 from pre_award.assessment_store.db.models.flags import FlagStatus
 from pre_award.assessment_store.db.queries.assessment_records.queries import check_all_change_requests_accepted
+from pre_award.assessment_store.db.models.assessment_record.enums import Status as ApplicationStatus
+from pre_award.assessment_store.db.queries.flags.queries import get_change_requests_for_application
 from pre_award.assessment_store.db.queries.scores.queries import (
+    approve_sub_criteria,
     create_score_for_app_sub_crit,
     get_scores_for_app_sub_crit,
     get_sub_criteria_to_latest_score_map,
@@ -311,7 +314,7 @@ def setup_application_with_requests_and_scores(_db):
             funding_amount_requested=0.0,
             round_id=uuid.uuid4(),
             fund_id=uuid.uuid4(),
-            workflow_status="IN_PROGRESS",
+            workflow_status=ApplicationStatus.CHANGE_REQUESTED,
             asset_type="an_asset_type",
             jsonb_blob={},
         )
@@ -430,3 +433,84 @@ def test_change_request_multiple_sections_all_accepted(_db, setup_application_wi
     )
     result = check_all_change_requests_accepted(application_id)
     assert result is True
+
+
+def test_approve_sub_criteria_resolves_change_request(_db, setup_application_with_requests_and_scores):
+    section_1 = str(uuid.uuid4())
+    application_id = setup_application_with_requests_and_scores(flag_data=[[section_1], [section_1]])
+
+    approve_sub_criteria(application_id=application_id, sub_criteria_id=section_1, user_id=str(uuid.uuid4()))
+
+    change_requests = get_change_requests_for_application(application_id)
+    assert all(cr.latest_status == FlagStatus.RESOLVED for cr in change_requests)
+
+
+def test_approve_sub_criteria_creates_score(_db, setup_application_with_requests_and_scores):
+    sub_criteria_id = str(uuid.uuid4())
+    application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id]])
+
+    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()))
+
+    scores = _db.session.query(Score).filter_by(application_id=application_id, sub_criteria_id=sub_criteria_id).all()
+    assert len(scores) == 1
+    assert scores[0].score == 1
+
+
+def test_approve_sub_criteria_updates_application_status(_db, setup_application_with_requests_and_scores):
+    sub_criteria_id = str(uuid.uuid4())
+    application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id]])
+
+    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()))
+
+    application = _db.session.query(AssessmentRecord).filter_by(application_id=application_id).first()
+    assert application.workflow_status == ApplicationStatus.IN_PROGRESS
+
+
+def test_approve_sub_criteria_multiple_change_requests_diff_subcriteria(
+    _db, setup_application_with_requests_and_scores
+):
+    sub_criteria_id_1 = str(uuid.uuid4())
+    sub_criteria_id_2 = str(uuid.uuid4())
+    application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id_1], [sub_criteria_id_2]])
+
+    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id_1, user_id=str(uuid.uuid4()))
+
+    change_requests = get_change_requests_for_application(application_id)
+    resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
+    unresolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RAISED]
+
+    assert len(resolved_requests) == 1
+    assert len(unresolved_requests) == 1
+    assert unresolved_requests[0].sections_to_flag == [sub_criteria_id_2]
+
+    application = _db.session.query(AssessmentRecord).filter_by(application_id=application_id).first()
+    assert application.workflow_status == ApplicationStatus.CHANGE_REQUESTED
+
+    # Approving last remaining sub-criteria should change application status
+    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id_2, user_id=str(uuid.uuid4()))
+
+    change_requests = get_change_requests_for_application(application_id)
+    resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
+    unresolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RAISED]
+
+    assert len(resolved_requests) == 2
+    assert len(unresolved_requests) == 0
+
+    application = _db.session.query(AssessmentRecord).filter_by(application_id=application_id).first()
+    assert application.workflow_status == ApplicationStatus.IN_PROGRESS
+
+
+def test_approve_sub_criteria_multiple_change_requests_same_subcriteria(
+    _db, setup_application_with_requests_and_scores
+):
+    sub_criteria_id = str(uuid.uuid4())
+    application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id], [sub_criteria_id]])
+
+    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()))
+
+    change_requests = get_change_requests_for_application(application_id)
+    resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
+    unresolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RAISED]
+
+    assert len(resolved_requests) == 2
+    assert len(unresolved_requests) == 0

--- a/tests/pre_award/assessment_store_tests/test_db_scores.py
+++ b/tests/pre_award/assessment_store_tests/test_db_scores.py
@@ -7,9 +7,9 @@ import pytest
 from pre_award.assessment_store.api.routes.progress_routes import get_progress_for_applications
 from pre_award.assessment_store.api.routes.score_routes import get_scoring_system_name_for_round_id
 from pre_award.assessment_store.db.models import AssessmentFlag, AssessmentRecord, Score
+from pre_award.assessment_store.db.models.assessment_record.enums import Status as ApplicationStatus
 from pre_award.assessment_store.db.models.flags import FlagStatus
 from pre_award.assessment_store.db.queries.assessment_records.queries import check_all_change_requests_accepted
-from pre_award.assessment_store.db.models.assessment_record.enums import Status as ApplicationStatus
 from pre_award.assessment_store.db.queries.flags.queries import get_change_requests_for_application
 from pre_award.assessment_store.db.queries.scores.queries import (
     approve_sub_criteria,


### PR DESCRIPTION
### Change description
This PR implements the ability to 'accept' a sub-criteria in the uncompeted workflow. Internally we provide a non-zero score for the sub-criteria, resolve open change requests, and check if the application status should be updated (i.e. if it is the last pending sub-criteria to be accepted). 

An accepted sub-criteria will display a banner on the sub-criteria page, with the information of who accepted it and when. (Although this is likely to change with new designs).
- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
In an uncompeted fund, the user can accept a sub-criteria and the page should be redirected to itself with a banner indicating that the sub-criteria has been approved.  

### Screenshots of UI changes (if applicable)
<img width="860" alt="Screenshot 2025-01-14 at 16 49 17" src="https://github.com/user-attachments/assets/6ff97a25-5ea4-44be-9423-c61ca4b042a3" />
