### PR TITLE
Add a single bootstrap command for docker compose

### DIFF
--- a/account_store/tasks.py
+++ b/account_store/tasks.py
@@ -31,58 +31,60 @@ def bootstrap_dev_db(c, database_host="localhost"):
     print(stylize(f"{DB_NAME} db created...", ECHO_STYLE))
 
 
+def seed_local_account_store_impl():
+    from db import db
+
+    accounts_to_seed = [
+        {
+            "email": "lead_assessor@example.com",
+            "account_id": uuid4(),
+            "roles": [
+                "CTDF_LEAD_ASSESSOR",
+                "CTDF_ASSESSOR",
+                "CTDF_COMMENTER",
+                "FFW_LEAD_ASSESSOR",
+                "FFW_ASSESSOR",
+                "FFW_COMMENTER",
+            ],
+        },
+        {
+            "email": "dev@example.com",
+            "account_id": "00000000-0000-0000-0000-000000000000",
+            "roles": [],
+        },
+    ]  # seed this in the db so it exists in account_store
+    for account_to_create in accounts_to_seed:
+        account_from_db = db.session.query(Account).where(Account.email == account_to_create["email"]).one_or_none()
+        if not account_from_db:
+            # Create account
+            account = Account(id=account_to_create["account_id"], email=account_to_create["email"])
+            db.session.add(account)
+            db.session.commit()
+            print(f"Created account for {account_to_create['email']}")
+
+        else:
+            print(f"Account {account_to_create['email']} already exists")
+            account_to_create["account_id"] = account_from_db.id
+
+        existing_roles = db.session.scalars(
+            select(Role.role).where(Role.account_id == account_to_create["account_id"])
+        ).all()
+
+        roles_to_add = []
+
+        for required_role in account_to_create["roles"]:
+            if required_role not in existing_roles:
+                req_role = Role(id=uuid4(), account_id=account_to_create["account_id"], role=required_role)
+                roles_to_add.append(req_role)
+                print(f"Creating role {required_role} for {account_to_create['email']}")
+
+        db.session.bulk_save_objects(roles_to_add)
+        db.session.commit()
+
+
 @task
 def seed_local_account_store(c):
     with _env_var("FLASK_ENV", "development"):
         app = create_app()
         with app.app_context():
-            from db import db
-
-            accounts_to_seed = [
-                {
-                    "email": "lead_assessor@example.com",
-                    "account_id": uuid4(),
-                    "roles": [
-                        "CTDF_LEAD_ASSESSOR",
-                        "CTDF_ASSESSOR",
-                        "CTDF_COMMENTER",
-                        "FFW_LEAD_ASSESSOR",
-                        "FFW_ASSESSOR",
-                        "FFW_COMMENTER",
-                    ],
-                },
-                {
-                    "email": "dev@example.com",
-                    "account_id": "00000000-0000-0000-0000-000000000000",
-                    "roles": [],
-                },
-            ]  # seed this in the db so it exists in account_store
-            for account_to_create in accounts_to_seed:
-                account_from_db = (
-                    db.session.query(Account).where(Account.email == account_to_create["email"]).one_or_none()
-                )
-                if not account_from_db:
-                    # Create account
-                    account = Account(id=account_to_create["account_id"], email=account_to_create["email"])
-                    db.session.add(account)
-                    db.session.commit()
-                    print(f"Created account for {account_to_create['email']}")
-
-                else:
-                    print(f"Account {account_to_create['email']} already exists")
-                    account_to_create["account_id"] = account_from_db.id
-
-                existing_roles = db.session.scalars(
-                    select(Role.role).where(Role.account_id == account_to_create["account_id"])
-                ).all()
-
-                roles_to_add = []
-
-                for required_role in account_to_create["roles"]:
-                    if required_role not in existing_roles:
-                        req_role = Role(id=uuid4(), account_id=account_to_create["account_id"], role=required_role)
-                        roles_to_add.append(req_role)
-                        print(f"Creating role {required_role} for {account_to_create['email']}")
-
-                db.session.bulk_save_objects(roles_to_add)
-                db.session.commit()
+            seed_local_account_store_impl()

--- a/common/tasks.py
+++ b/common/tasks.py
@@ -1,8 +1,17 @@
 import glob
 import os
 import re
+from contextlib import contextmanager
 
+from alembic import command
+from alembic.config import Config
 from invoke import task
+
+from account_store.tasks import seed_local_account_store_impl
+from app import create_app
+from assessment_store.tasks.db_tasks import seed_assessment_store_db_impl
+from fund_store.scripts.fund_round_loaders.load_fund_round_from_fab import load_fund_from_fab_impl
+from fund_store.scripts.load_all_fund_rounds import load_all_fund_rounds
 
 _VALID_JINJA_EXTENSIONS = (".html", ".jinja", ".jinja2", ".j2")
 
@@ -107,3 +116,24 @@ def pybabel_update(c):
 @task
 def pybabel_compile(c):
     c.run("pybabel compile -d translations")
+
+
+@task
+def full_bootstrap(c):
+    @contextmanager
+    def _env_var(key, value):
+        old_val = os.environ.get(key, "")
+        os.environ[key] = value
+        yield
+        os.environ[key] = old_val
+
+    with _env_var("FLASK_ENV", "development"):
+        with create_app().app_context():
+            alembic_cfg = Config("db/migrations/alembic.ini")
+            alembic_cfg.set_main_option("script_location", "db/migrations")
+            command.upgrade(alembic_cfg, "head")
+
+            load_all_fund_rounds()
+            load_fund_from_fab_impl(seed_all_funds=True)
+            seed_assessment_store_db_impl("local")
+            seed_local_account_store_impl()

--- a/fund_store/scripts/fund_round_loaders/load_fund_round_from_fab.py
+++ b/fund_store/scripts/fund_round_loaders/load_fund_round_from_fab.py
@@ -13,17 +13,7 @@ from fund_store.db.queries import (
 )
 
 
-@click.command()
-@click.option("--fund_short_code", default="", help="Fund short code")
-@click.option("--seed_all_funds", default=False, help="See all funds")
-def load_fund_from_fab(fund_short_code, seed_all_funds) -> None:
-    """
-    Insert the FAB fund and round data into the database.
-    See required schema for import here: file_location
-
-    Accept comma separated funds too.
-    """
-
+def load_fund_from_fab_impl(fund_short_code="", seed_all_funds=False):
     if fund_short_code == "" and seed_all_funds == False:
         print(f"Nothing to seed.")
 
@@ -81,6 +71,19 @@ def load_fund_from_fab(fund_short_code, seed_all_funds) -> None:
         print(f"All config has been successfully prepared, now committing to the database.")
         db.session.commit()
         print(f"Config has now been committed to the database.")
+
+
+@click.command()
+@click.option("--fund_short_code", default="", help="Fund short code")
+@click.option("--seed_all_funds", default=False, help="See all funds")
+def load_fund_from_fab(fund_short_code, seed_all_funds) -> None:
+    """
+    Insert the FAB fund and round data into the database.
+    See required schema for import here: file_location
+
+    Accept comma separated funds too.
+    """
+    load_fund_from_fab_impl(fund_short_code, seed_all_funds)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a short-term patch to improve startup speed for the pre-award service when running locally.

At the moment the docker-compose service does all of these things as separate commands:

```
flask -A app:create_app db upgrade
python build.py
python -m fund_store.scripts.load_all_fund_rounds
python -m fund_store.scripts.fund_round_loaders.load_fund_round_from_fab --seed_all_funds True
python -m invoke assessment.seed-assessment-store-db
python -m invoke account.seed-local-account-store
```

This results in a lot of overhead with app startup, so collapsing 5 of these into one command should mean we get to running the actual server faster.

This is low hanging fruit and I've avoided thinking about refactoring/etc