### PR TITLE
Upgrade govuk assess dependency and template

### DIFF
--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ def build_apply_assets():
 def build_some_assess_assets(static_dist_root="static/assess"):
     DIST_ROOT = "./" + static_dist_root
     GOVUK_DIR = "/govuk-frontend"
-    GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v4.7.0/release-v4.7.0.zip"
+    GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v4.8.0/release-v4.8.0.zip"
     ZIP_FILE = "./govuk_frontend.zip"
     DIST_PATH = DIST_ROOT + GOVUK_DIR
     ASSETS_DIR = "/assets"

--- a/pre_award/assess/assessments/templates/assessments/activity_trail.html
+++ b/pre_award/assess/assessments/templates/assessments/activity_trail.html
@@ -26,8 +26,8 @@
 {% block header %}
 {{ super() }}
 <header role="banner" data-module="govuk-header">
-    <nav class="govuk-width-container govuk-header__navigation">
-        <div class="govuk-phase-banner flex-parent-element">
+    <nav class="govuk-width-container govuk-header__navigation govuk-!-padding-top-3">
+        <div class="flex-parent-element">
             <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
                 {{ govukBackLink({'href': url_for("assessment_bp.application", application_id=application_id), 'html':
                 'Back to <b>assessment tasklist</b>', 'attributes': {'data-qa': 'back-to-assessment-tasklist'} }) }}
@@ -51,10 +51,8 @@
 {% endblock header %}
 
 {% block content %}
-
-<main class="govuk-main-wrapper" id="main-content" role="main">
     {% if migration_banner_enabled %}
-    {{ migration_banner() }}
+        {{ migration_banner() }}
     {% endif %}
     <div class="govuk-grid-row">
         <div>
@@ -201,11 +199,6 @@
                     </table>
                 </div>
             </div>
-
         </div>
-
     </div>
-
-</main>
-
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/all_uploaded_documents.html
+++ b/pre_award/assess/assessments/templates/assessments/all_uploaded_documents.html
@@ -9,6 +9,7 @@ All uploaded documents
 {% endset %}
 
 {% block header %}
+{{ super() }}
 {% include "assess/components/header.html" %}
 {% endblock header %}
 

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -25,8 +25,8 @@
 {% block header %}
 {{ super() }}
 <header role="banner" data-module="govuk-header">
-    <nav class="govuk-width-container govuk-header__navigation">
-        <div class="govuk-phase-banner flex-parent-element">
+    <nav class="govuk-width-container govuk-header__navigation govuk-!-padding-top-3">
+        <div class="flex-parent-element">
             <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
                 {{ govukBackLink({'href': url_for("assessment_bp.fund_dashboard", fund_short_name=state['fund_short_name'], round_short_name=state['round_short_name']), 'html': 'Back to <b>assessment dashboard</b>', 'attributes': {'data-qa': 'back-to-assessment-dashboard'} }) }}
             </p>

--- a/pre_award/assess/assessments/templates/assessments/assessor_tool_dashboard.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tool_dashboard.html
@@ -9,68 +9,72 @@
 {% from "assess/macros/migration_banner.html" import migration_banner %}
 
 {% set pageHeading %}Assessment tool dashboard{% endset %}
+
+{% block beforeContent %}
+    <nav class="govuk-header__navigation govuk-!-padding-top-3">
+        <div class="flex-parent-element">
+            {{ logout_partial(sso_logout_url) }}
+        </div>
+    </nav>
+{% endblock beforeContent %}
+
 {% block content %}
-    <div class="govuk-phase-banner flex-parent-element">
-        {{ logout_partial(sso_logout_url) }}
+    {% if migration_banner_enabled %}
+        {{ migration_banner() }}
+    {% endif %}
+
+    <h1 class="govuk-heading-xl">Funding service dashboard</h1>
+
+    <div class="govuk-grid-column">
+        {{ assessor_tool_dashboard_filters(landing_filters, has_any_assessor_role) }}
     </div>
 
-    <div class="govuk-width-container">
-        {% if migration_banner_enabled %}
-            {{ migration_banner() }}
-        {% endif %}
+    <h2 class="govuk-heading-l">
+        All funds ({{ funds | length }}), sorted A-Z
+    </h2>
 
-        <h1 class="govuk-heading-xl">Funding service dashboard</h1>
-
-        <div class="govuk-grid-column">
-            {{ assessor_tool_dashboard_filters(landing_filters, has_any_assessor_role) }}
-        </div>
-
-        <h2 class="govuk-heading-l">
-            All funds ({{ funds | length }}), sorted A-Z
-        </h2>
-
-        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-            <!-- {% if funds %} -->
-            <!-- "Show all sections" button being shown by the govuk-frontend automatically -->
-            <!-- {% endif %} -->
-            {% for fund_id in funds %}
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading">
-                            <button type="button" aria-controls="accordion-default-content-{{ loop.index }}"
-                                    class="govuk-accordion__section-button landing-accordion" data-qa="show"
-                                    aria-label="{{ funds[fund_id].name }} ({{ fund_summaries[fund_id] | length }}), Show this section">
-                                <span class="govuk-accordion__section-heading-text" id="accordion-default-heading-{{ loop.index }}">
-                                    <span class="govuk-accordion__section-heading-text-focus">
-                                      {{ funds[fund_id].name }} ({{ fund_summaries[fund_id] | length }})
-                                    </span>
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+        <!-- {% if funds %} -->
+        <!-- "Show all sections" button being shown by the govuk-frontend automatically -->
+        <!-- {% endif %} -->
+        {% for fund_id in funds %}
+            <div class="govuk-accordion__section">
+                <div class="govuk-accordion__section-header">
+                    <h2 class="govuk-accordion__section-heading">
+                        <button type="button" aria-controls="accordion-default-content-{{ loop.index }}"
+                                class="govuk-accordion__section-button landing-accordion" data-qa="show"
+                                aria-label="{{ funds[fund_id].name }} ({{ fund_summaries[fund_id] | length }}), Show this section">
+                            <span class="govuk-accordion__section-heading-text" id="accordion-default-heading-{{ loop.index }}">
+                                <span class="govuk-accordion__section-heading-text-focus">
+                                    {{ funds[fund_id].name }} ({{ fund_summaries[fund_id] | length }})
                                 </span>
-                            </button>
-                        </h2>
-                        <div id="accordion-default-content-{{ loop.index }}" class="govuk-accordion__section-content display-none"
-                             aria-labelledby="accordion-default-heading-{{ loop.index }}">
-                            {% if fund_summaries[fund_id] %}
-                                {% set chunk_size = 3 %}
-                                {% set summaries = fund_summaries[fund_id] %}
-                                {% for chunk in summaries|batch(chunk_size) %}
-                                    <div class="govuk-grid-row">
-                                        {% for summary in chunk %}
+                            </span>
+                        </button>
+                    </h2>
+                    <div id="accordion-default-content-{{ loop.index }}" class="govuk-accordion__section-content display-none"
+                            aria-labelledby="accordion-default-heading-{{ loop.index }}">
+                        {% if fund_summaries[fund_id] %}
+                            {% set chunk_size = 3 %}
+                            {% set summaries = fund_summaries[fund_id] %}
+                            {% for chunk in summaries|batch(chunk_size) %}
+                                <div class="govuk-grid-row">
+                                    {% for summary in chunk %}
+                                        <div class="govuk-grid-column-one-third">
                                             {{ fund_summary(summary) }}
-                                        {% endfor %}
-                                    </div>
-                                {% endfor %}
-                            {% endif %}
-                        </div>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            {% endfor %}
+                        {% endif %}
                     </div>
                 </div>
-            {% endfor %}
-        </div>
-
-        <p class="govuk-!-padding-top-6 govuk-body govuk-!-display-inline-block">
-            Information last updated: [{{ todays_date }}]<br/>
-            Refresh page for most up-to-date information.
-        </p>
-
+            </div>
+        {% endfor %}
     </div>
+
+    <p class="govuk-!-padding-top-6 govuk-body govuk-!-display-inline-block">
+        Information last updated: [{{ todays_date }}]<br/>
+        Refresh page for most up-to-date information.
+    </p>
 
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/comments_history.html
+++ b/pre_award/assess/assessments/templates/assessments/comments_history.html
@@ -4,44 +4,43 @@
 {% from "assess/macros/migration_banner.html" import migration_banner %}
 
 {% block header %}
+{{ super() }}
 {% include "assess/components/header.html" %}
 {% endblock header %}
 
 {% block content %}
+{% if migration_banner_enabled %}
+    {{ migration_banner()}}
+{% endif %}
 <div class="govuk-grid-row">
-    {% if migration_banner_enabled %}
-        {{ migration_banner()}}
-    {% endif %}
-    <div class="govuk-width-content-container">
-        <div class="govuk-grid-column-two-thirds">
-            <div>
-                <div class="govuk-button-group">
-                <a class="govuk-link" href="{{ back_href }}">Back to assessment</a>
-                </div>
-                <h1 class="govuk-heading-l">Comment edit history</h1>
+    <div class="govuk-grid-column-two-thirds">
+        <div>
+            <div class="govuk-button-group">
+            <a class="govuk-link" href="{{ back_href }}">Back to assessment</a>
             </div>
-
-            {% set updates_length = comment_data.updates|length %}
-
-            {% for data in comment_data.updates|reverse %}
-                {% if loop.index0 < updates_length-1 %}
-                    <div class="comment-group">
-                        <p class="govuk-body">{{ data['comment'] }}</p>
-                        <p class="govuk-body-s">{{ comment_data.full_name }} ({{ comment_data.highest_role|all_caps_to_human }}) {{ comment_data.email_address }}</p>
-                        <p class="govuk-body-s">{{ data.date_created|utc_to_bst }}</p>
-                    </div>
-                {% else %}
-                    <div class="govuk-!-padding-top-7">
-                        <h2 class="govuk-heading-s govuk-!-padding-bottom-0">Original comment</h2>
-                        <div class="comment-group">
-                        <p class="govuk-body">{{ data['comment'] }}</p>
-                        <p class="govuk-body-s">{{ comment_data.full_name }} ({{ comment_data.highest_role|all_caps_to_human }}) {{ comment_data.email_address }}</p>
-                        <p class="govuk-body-s">{{ data.date_created|utc_to_bst }}</p>
-                        </div>
-                    </div>
-                {% endif %}
-            {% endfor %}
+            <h1 class="govuk-heading-l">Comment edit history</h1>
         </div>
+
+        {% set updates_length = comment_data.updates|length %}
+
+        {% for data in comment_data.updates|reverse %}
+            {% if loop.index0 < updates_length-1 %}
+                <div class="comment-group">
+                    <p class="govuk-body">{{ data['comment'] }}</p>
+                    <p class="govuk-body-s">{{ comment_data.full_name }} ({{ comment_data.highest_role|all_caps_to_human }}) {{ comment_data.email_address }}</p>
+                    <p class="govuk-body-s">{{ data.date_created|utc_to_bst }}</p>
+                </div>
+            {% else %}
+                <div class="govuk-!-padding-top-7">
+                    <h2 class="govuk-heading-s govuk-!-padding-bottom-0">Original comment</h2>
+                    <div class="comment-group">
+                    <p class="govuk-body">{{ data['comment'] }}</p>
+                    <p class="govuk-body-s">{{ comment_data.full_name }} ({{ comment_data.highest_role|all_caps_to_human }}) {{ comment_data.email_address }}</p>
+                    <p class="govuk-body-s">{{ data.date_created|utc_to_bst }}</p>
+                    </div>
+                </div>
+            {% endif %}
+        {% endfor %}
     </div>
 </div>
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/fund_dashboard.html
+++ b/pre_award/assess/assessments/templates/assessments/fund_dashboard.html
@@ -15,47 +15,43 @@
 {% endblock header %}
 
 {% block content %}
-{# CLOSE THE GOVUK-WIDTH-CONTAINER AND OPEN A WIDER CONTAINER FOR THE TABLE VIEW #}
-
-
-<div class="govuk-grid-row">
     {% if migration_banner_enabled %}
-    {{ migration_banner() }}
+        {{ migration_banner() }}
     {% endif %}
     {% macro ApplicationsOverviewHtmlBase(heading_text) %}
-    <header class="govuk-body ">
+        <header class="govuk-body ">
             {% if user.highest_role_map[round_details.fund_short_name] == 'LEAD_ASSESSOR' and toggle_dict.get("ASSESSMENT_ASSIGNMENT") %}
-            <section class="govuk-phase-banner govuk-grid-row">
-                <span id="empty-positioning-child" class="govuk-grid-column-two-thirds empty-positioning-child">&nbsp;</span>
-                <span class="govuk-grid-column-one-third">
-                    <a href="{{ url_for('assessment_bp.assign_assessments',
-                      fund_short_name=round_details.fund_short_name,
-                      round_short_name=round_details.round_short_name)}}" class="govuk-link">
-                        Assign assessments
-                    </a>
-                </span>
-            </section>
+                <section class="govuk-grid-row">
+                    <span id="empty-positioning-child" class="govuk-grid-column-two-thirds empty-positioning-child">&nbsp;</span>
+                    <span class="govuk-grid-column-one-third">
+                        <a href="{{ url_for('assessment_bp.assign_assessments',
+                        fund_short_name=round_details.fund_short_name,
+                        round_short_name=round_details.round_short_name)}}" class="govuk-link">
+                            Assign assessments
+                        </a>
+                    </span>
+                </section>
             {% endif %}
-        <h1 class="govuk-heading-l">{{ heading_text }}</h1>
-    </header>
+            <h1 class="govuk-heading-l">{{ heading_text }}</h1>
+        </header>
     {% endmacro -%}
-    <section id="application-overview" class="govuk-width-container govuk-grid-column-full">
+    <section id="application-overview">
         {% set allApplicationsOverviewHtml %}
         {% set all_apps_display_config = display_config | add_to_dict({'tab_id': 'all-applications'}) %}
         {{ ApplicationsOverviewHtmlBase("All applications") }}
         {{ application_overviews_table.render(
-        application_overviews,
-        round_details,
-        query_params,
-        asset_types,
-        assessment_statuses,
-        all_apps_display_config,
-        sort_column,
-        sort_order,
-        tag_option_groups,
-        tags,
-        tagging_purpose_config,
-        users
+            application_overviews,
+            round_details,
+            query_params,
+            asset_types,
+            assessment_statuses,
+            all_apps_display_config,
+            sort_column,
+            sort_order,
+            tag_option_groups,
+            tags,
+            tagging_purpose_config,
+            users
         ) }}
         {% endset -%}
 
@@ -63,18 +59,18 @@
         {% set assigned_display_config = display_config | add_to_dict({'tab_id': 'assigned-to-you'}) %}
         {{ ApplicationsOverviewHtmlBase("Assigned to you") }}
         {{ application_overviews_table.render(
-        assigned_applications,
-        round_details,
-        query_params,
-        asset_types,
-        assessment_statuses,
-        assigned_display_config,
-        sort_column,
-        sort_order,
-        tag_option_groups,
-        tags,
-        tagging_purpose_config,
-        []
+            assigned_applications,
+            round_details,
+            query_params,
+            asset_types,
+            assessment_statuses,
+            assigned_display_config,
+            sort_column,
+            sort_order,
+            tag_option_groups,
+            tags,
+            tagging_purpose_config,
+            []
         ) }}
         {% endset -%}
 
@@ -82,56 +78,46 @@
         {% set reporting_display_config = display_config | add_to_dict({'tab_id': 'reporting-to-you'}) %}
         {{ ApplicationsOverviewHtmlBase("Reporting to you") }}
         {{ application_overviews_table.render(
-        reporting_to_user_applications,
-        round_details,
-        query_params,
-        asset_types,
-        assessment_statuses,
-        reporting_display_config,
-        sort_column,
-        sort_order,
-        tag_option_groups,
-        tags,
-        tagging_purpose_config,
-        users
+            reporting_to_user_applications,
+            round_details,
+            query_params,
+            asset_types,
+            assessment_statuses,
+            reporting_display_config,
+            sort_column,
+            sort_order,
+            tag_option_groups,
+            tags,
+            tagging_purpose_config,
+            users
         ) }}
         {% endset -%}
 
         {{ govukTabs({
-        "items": [
-            {
-            "label": "All applications",
-            "id": "all-applications",
-            "panel": {
-            "html": allApplicationsOverviewHtml
-            }
-        },
-        {
-            "label": "Assigned to you (" ~ assigned_applications | length ~ ")",
-            "id": "assigned-to-you",
-            "panel": {
-            "html": assignedApplicationsHtml
-            }
-        },
-        {
-            "label": "Reporting to you (" ~ reporting_to_user_applications | length ~ ")",
-            "id": "reporting-to-you",
-            "panel": {
-            "html": reportingToYouApplicationsOverviewHtml
-            }
-        },
-        ]
+            "items": [
+                {
+                    "label": "All applications",
+                    "id": "all-applications",
+                    "panel": {
+                    "html": allApplicationsOverviewHtml
+                    }
+                },
+                {
+                    "label": "Assigned to you (" ~ assigned_applications | length ~ ")",
+                    "id": "assigned-to-you",
+                    "panel": {
+                    "html": assignedApplicationsHtml
+                    }
+                },
+                {
+                    "label": "Reporting to you (" ~ reporting_to_user_applications | length ~ ")",
+                    "id": "reporting-to-you",
+                    "panel": {
+                    "html": reportingToYouApplicationsOverviewHtml
+                    }
+                },
+            ]
         }) }}
-        <!--
-        TODO: Add to tabs later
-        [
-            {
-            "label": "Scoring",
-            "id": "scoring",
-            "panel": {
-            "html": "TBC"
-            }
-        }] -->
     </section>
 </div>
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/view_entire_application.html
+++ b/pre_award/assess/assessments/templates/assessments/view_entire_application.html
@@ -10,8 +10,8 @@
 {% block header %}
 {{ super() }}
 <header role="banner" data-module="govuk-header">
-    <nav class="govuk-width-container govuk-header__navigation">
-        <div class="govuk-phase-banner flex-parent-element">
+    <nav class="govuk-width-container govuk-header__navigation govuk-!-padding-top-3">
+        <div class="flex-parent-element">
             <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
                 {{ govukBackLink({'href': url_for("assessment_bp.application", application_id=application_id), 'html':
                 'Back to <b>assessment tasklist</b>', 'attributes': {'data-qa': 'back-to-assessment-task-list'} }) }}

--- a/pre_award/assess/static/src/styles/govuk-overrides.css
+++ b/pre_award/assess/static/src/styles/govuk-overrides.css
@@ -1,17 +1,3 @@
-
-.govuk-main-wrapper {
-    padding: 0px;
-}
-
-.govuk-header {
-    padding-bottom: 0px;
-    border-bottom: 0px;
-}
-
-.govuk-header__container {
-    padding-top: 10px !important;
-}
-
 .govuk-table-no-bottom-border .govuk-table__body .govuk-table__row:last-child .govuk-table__cell {
     border-bottom: none;
 }
@@ -50,14 +36,6 @@
     margin-bottom: 0px;
 }
 
-.govuk-template__body {
-    background-color: white;
-}
-
-.govuk-phase-banner__content {
-    width: 100%
-}
-
 .govuk-heading-xl {
     margin-bottom: 30px;
 }
@@ -86,13 +64,6 @@
 .govuk-back-link {
     margin: 0px;
 }
-
-.govuk-phase-banner {
-    margin-top: 15px;
-    margin-bottom: 15px;
-    border-bottom: 0px;
-}
-
 
 .dashboard-label {
     text-transform: uppercase;
@@ -380,9 +351,19 @@ list-style-type: upper-roman;
 
 .govuk-width-container {
     max-width: 1600px;
-    padding: 0 2em;
-    margin: auto;
 }
+    @media (min-width: 1020px) {
+        .govuk-width-container {
+            margin-right: max(30px, calc(15px + env(safe-area-inset-right)));
+            margin-left: max(30px, calc(15px + env(safe-area-inset-right)));
+        }
+    }
+    @media (min-width: 1600px) {
+        .govuk-width-container {
+            margin-right: auto;
+            margin-left: auto;
+        }
+    }
 
 .govuk-link__white_font {
     color: white !important;

--- a/pre_award/assess/tagging/templates/tagging/change_tags.html
+++ b/pre_award/assess/tagging/templates/tagging/change_tags.html
@@ -9,67 +9,66 @@
 {% endblock header %}
 
 {% block content %}
-
+{% if migration_banner_enabled %}
+    {{ migration_banner()}}
+{% endif %}
 <div class="govuk-grid-row">
-    {% if migration_banner_enabled %}
-        {{ migration_banner()}}
-    {% endif %}
-        <div class="govuk-grid-column-two-thirds">
-            <form method="post">
-                {{ form.csrf_token }}
-                <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Change tags</h1>
-                {% if available_tags and (available_tags | length) > 0 %}
-                    <div class="govuk-hint govuk-!-margin-bottom-6">
-                        Select the tags you want to apply to this assessment
-                    </div>
-                    <a href="{{ url_for('tagging_bp.create_tag', fund_id=state.fund_id, round_id=state.round_id) }}"
-                       role="button"
-                       class="govuk-button govuk-button--secondary"
-                       data-qa="create-new-tag">
-                        Create new tag
-                    </a>
-                    <div class="govuk-form-group">
-                        <table class="govuk-table dluhc-table-checkboxes">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Tag name</th>
-                                    <th scope="col" class="govuk-table__header">Purpose</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                {% for tag in available_tags %}
-                                    <tr class-govuk-table__row>
-                                        <th scope="row" class="govuk-table__header">
-                                            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
-                                                <div class="govuk-checkboxes__item">
-                                                    <input class="govuk-checkboxes__input" data-qa="select-tag" id="{{ tag.id }}" name="{{ form.tags.id }}" type="checkbox" value="{{ tag.id }}" {% if tag.associated %} checked {% endif %}>
-                                                    <label class="govuk-label govuk-checkboxes__label" for="{{ tag.id }}">
-                                                        {{ tag.value }}
-                                                    </label>
-                                                </div>
-                                            </div>
-                                        </th>
-                                        <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--{{ tag_config[tag.purpose]['colour'] }} dluhc-tag">{{ tag.purpose }}</strong></td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                {% else %}
-                    <p class="govuk-body dluhc-body-empty">
-                        There are no tags available
-                    </p>
-                {% endif %}
-
-                <div class="govuk-button-group">
-                    <button class="govuk-button primary-button" data-module="govuk-button" data-qa="save-and-go-back">
-                        Save and go back
-                    </button>
-                    <a class="govuk-link" href="{{ url_for('assessment_bp.application', application_id=application_id) }}">
-                        Cancel
-                    </a>
+    <div class="govuk-grid-column-two-thirds">
+        <form method="post">
+            {{ form.csrf_token }}
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Change tags</h1>
+            {% if available_tags and (available_tags | length) > 0 %}
+                <div class="govuk-hint govuk-!-margin-bottom-6">
+                    Select the tags you want to apply to this assessment
                 </div>
-            </form>
-        </div>
+                <a href="{{ url_for('tagging_bp.create_tag', fund_id=state.fund_id, round_id=state.round_id) }}"
+                    role="button"
+                    class="govuk-button govuk-button--secondary"
+                    data-qa="create-new-tag">
+                    Create new tag
+                </a>
+                <div class="govuk-form-group">
+                    <table class="govuk-table dluhc-table-checkboxes">
+                        <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <th scope="col" class="govuk-table__header">Tag name</th>
+                                <th scope="col" class="govuk-table__header">Purpose</th>
+                            </tr>
+                        </thead>
+                        <tbody class="govuk-table__body">
+                            {% for tag in available_tags %}
+                                <tr class-govuk-table__row>
+                                    <th scope="row" class="govuk-table__header">
+                                        <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                                            <div class="govuk-checkboxes__item">
+                                                <input class="govuk-checkboxes__input" data-qa="select-tag" id="{{ tag.id }}" name="{{ form.tags.id }}" type="checkbox" value="{{ tag.id }}" {% if tag.associated %} checked {% endif %}>
+                                                <label class="govuk-label govuk-checkboxes__label" for="{{ tag.id }}">
+                                                    {{ tag.value }}
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </th>
+                                    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--{{ tag_config[tag.purpose]['colour'] }} dluhc-tag">{{ tag.purpose }}</strong></td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="govuk-body dluhc-body-empty">
+                    There are no tags available
+                </p>
+            {% endif %}
+
+            <div class="govuk-button-group">
+                <button class="govuk-button primary-button" data-module="govuk-button" data-qa="save-and-go-back">
+                    Save and go back
+                </button>
+                <a class="govuk-link" href="{{ url_for('assessment_bp.application', application_id=application_id) }}">
+                    Cancel
+                </a>
+            </div>
+        </form>
+    </div>
 </div>
 {% endblock content %}

--- a/pre_award/assess/tagging/templates/tagging/create_tag.html
+++ b/pre_award/assess/tagging/templates/tagging/create_tag.html
@@ -15,112 +15,113 @@ round_id=fund_round["round_id"]), fund_round, sso_logout_url) }}
 {% if migration_banner_enabled %}
   {{ migration_banner() }}
 {% endif %}
-
-<div class="govuk-grid-column-two-thirds">
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Create a new tag</h1>
-  <div id="contact-hint" class="govuk-hint govuk-!-margin-bottom-6">
-    General and lead assessors can use new tags you create to tag any {{ fund_round["fund_name"] }} assessments.
-  </div>
-
-  <form method="post">
-    {{ form.csrf_token }}
-
-    {% if errors %}
-    <div class="govuk-grid-row govuk-error-summary" data-module="govuk-error-summary">
-      <div role="alert">
-        <h2 class="govuk-error-summary__title" autofocus>
-          There is a problem
-        </h2>
-        {% for input, error in errors.items() %}
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <li>
-              <a href="#{{ input }}">{{ error[0] }}</a>
-            </li>
-          </ul>
-        </div>
-        {% endfor %}
-      </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Create a new tag</h1>
+    <div id="contact-hint" class="govuk-hint govuk-!-margin-bottom-6">
+      General and lead assessors can use new tags you create to tag any {{ fund_round["fund_name"] }} assessments.
     </div>
-    {% endif %}
 
-    {% if errors != None and form.value.id in errors.keys() %}
-    <div class="govuk-form-group govuk-form-group--error">
-      <label class="govuk-label govuk-label--s" for="{{ form.value.id }}">
-        Tag name
-      </label>
-      <div id="tag-value-hint" class="govuk-hint govuk-visually-hidden">
-        The name of the new tag.
-      </div>
-      <p id="tag-value-error" class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> {{ errors[form.value.id][0] }}
-      </p>
-      <input class="govuk-input govuk-input--error" id="{{ form.value.id }}" name="{{ form.value.id }}" type="text" value="{{ form.value.data or '' }}"
-        aria-describedby="tag-value-hint tag-value-error">
-    </div>
-    {% else %}
-    <div class="govuk-form-group">
-      <label class="govuk-label govuk-label--s" for="{{ form.value.id }}">
-        Tag name
-      </label>
-      <div id="tag-value-hint" class="govuk-hint govuk-visually-hidden">
-        The name of the new tag.
-      </div>
-      <input class="govuk-input" id="{{ form.value.id }}" name="{{ form.value.id }}" type="text" value="{{ form.value.data or '' }}"
-        aria-describedby="tag-value-hint">
-    </div>
-    {% endif %}
+    <form method="post">
+      {{ form.csrf_token }}
 
-    <div
-      class="govuk-form-group {% if errors != None and form.type.id in errors.keys() %}govuk-form-group--error{% endif %}">
-      <fieldset id="{{ form.type.id }}" class="govuk-fieldset" aria-describedby="tag-purpose-hint tag-purpose-error">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          <h1 class="govuk-fieldset__heading">
-            Tag purpose
-          </h1>
-        </legend>
-        <div id="tag-purpose-hint" class="govuk-hint">
-          Select the tag purpose that best describes your tag value.
-        </div>
-        {% if errors != None and form.type.id in errors.keys() %}
-        <p id="tag-purpose-error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span> {{ errors[form.type.id][0] }}
-        </p>
-        {% endif %}
-        {% for tag_type in tag_types %}
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="{{ form.type.id }}-{{ tag_type['purpose'] }}" name="{{ form.type.id }}"
-            type="radio" value="{{ tag_type['id'] }}" {% if tag_type['id']==form.type.data %} checked {% endif
-            %}aria-describedby="tag-item-hint">
-          <label class="govuk-label govuk-radios__label" for="{{ form.type.id }}-{{ tag_type['purpose'] }}">
-            {{ tag_type['purpose'].title() }}
-            <strong
-              class="govuk-tag govuk-!-margin-left-2 govuk-tag--{{ tag_config[tag_type['purpose']]['colour'] }} dluhc-tag">{{
-              tag_config[tag_type['purpose']]['colour'].title() if tag_config[tag_type['purpose']]['colour'].lower() !=
-              "grey" else "White" }}</strong>
-          </label>
-          <div id="tag-item-hint-{{ tag_type['purpose'] }}" class="govuk-hint govuk-radios__hint">
-            {{ tag_type['description'] }}
+      {% if errors %}
+      <div class="govuk-grid-row govuk-error-summary" data-module="govuk-error-summary">
+        <div role="alert">
+          <h2 class="govuk-error-summary__title" autofocus>
+            There is a problem
+          </h2>
+          {% for input, error in errors.items() %}
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>
+                <a href="#{{ input }}">{{ error[0] }}</a>
+              </li>
+            </ul>
           </div>
+          {% endfor %}
         </div>
-        {% endfor %}
+      </div>
+      {% endif %}
 
-      </fieldset>
-    </div>
+      {% if errors != None and form.value.id in errors.keys() %}
+      <div class="govuk-form-group govuk-form-group--error">
+        <label class="govuk-label govuk-label--s" for="{{ form.value.id }}">
+          Tag name
+        </label>
+        <div id="tag-value-hint" class="govuk-hint govuk-visually-hidden">
+          The name of the new tag.
+        </div>
+        <p id="tag-value-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ errors[form.value.id][0] }}
+        </p>
+        <input class="govuk-input govuk-input--error" id="{{ form.value.id }}" name="{{ form.value.id }}" type="text" value="{{ form.value.data or '' }}"
+          aria-describedby="tag-value-hint tag-value-error">
+      </div>
+      {% else %}
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-label--s" for="{{ form.value.id }}">
+          Tag name
+        </label>
+        <div id="tag-value-hint" class="govuk-hint govuk-visually-hidden">
+          The name of the new tag.
+        </div>
+        <input class="govuk-input" id="{{ form.value.id }}" name="{{ form.value.id }}" type="text" value="{{ form.value.data or '' }}"
+          aria-describedby="tag-value-hint">
+      </div>
+      {% endif %}
 
-    <div class="govuk-button-group">
-      <button class="govuk-button" data-module="govuk-button" data-qa="save-and-add-another"
-        formaction="{{ url_for('tagging_bp.create_tag', fund_id = fund_round['fund_id'], round_id = fund_round['round_id']) }}">
-        Save and add another
-      </button>
-      <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-qa="save-and-add-another"
-        formaction="{{ url_for('tagging_bp.create_tag', fund_id=fund_round['fund_id'], round_id=fund_round['round_id'], go_back=True) }}">
-        Save and go back
-      </button>
-      <a class="govuk-link" href="{{ url_for("tagging_bp.load_fund_round_tags", fund_id=fund_round['fund_id'], round_id=fund_round['round_id']) }}">
-        Cancel
-      </a>
-    </div>
-  </form>
+      <div
+        class="govuk-form-group {% if errors != None and form.type.id in errors.keys() %}govuk-form-group--error{% endif %}">
+        <fieldset id="{{ form.type.id }}" class="govuk-fieldset" aria-describedby="tag-purpose-hint tag-purpose-error">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            <h1 class="govuk-fieldset__heading">
+              Tag purpose
+            </h1>
+          </legend>
+          <div id="tag-purpose-hint" class="govuk-hint">
+            Select the tag purpose that best describes your tag value.
+          </div>
+          {% if errors != None and form.type.id in errors.keys() %}
+          <p id="tag-purpose-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ errors[form.type.id][0] }}
+          </p>
+          {% endif %}
+          {% for tag_type in tag_types %}
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="{{ form.type.id }}-{{ tag_type['purpose'] }}" name="{{ form.type.id }}"
+              type="radio" value="{{ tag_type['id'] }}" {% if tag_type['id']==form.type.data %} checked {% endif
+              %}aria-describedby="tag-item-hint">
+            <label class="govuk-label govuk-radios__label" for="{{ form.type.id }}-{{ tag_type['purpose'] }}">
+              {{ tag_type['purpose'].title() }}
+              <strong
+                class="govuk-tag govuk-!-margin-left-2 govuk-tag--{{ tag_config[tag_type['purpose']]['colour'] }} dluhc-tag">{{
+                tag_config[tag_type['purpose']]['colour'].title() if tag_config[tag_type['purpose']]['colour'].lower() !=
+                "grey" else "White" }}</strong>
+            </label>
+            <div id="tag-item-hint-{{ tag_type['purpose'] }}" class="govuk-hint govuk-radios__hint">
+              {{ tag_type['description'] }}
+            </div>
+          </div>
+          {% endfor %}
+
+        </fieldset>
+      </div>
+
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button" data-qa="save-and-add-another"
+          formaction="{{ url_for('tagging_bp.create_tag', fund_id = fund_round['fund_id'], round_id = fund_round['round_id']) }}">
+          Save and add another
+        </button>
+        <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-qa="save-and-add-another"
+          formaction="{{ url_for('tagging_bp.create_tag', fund_id=fund_round['fund_id'], round_id=fund_round['round_id'], go_back=True) }}">
+          Save and go back
+        </button>
+        <a class="govuk-link" href="{{ url_for("tagging_bp.load_fund_round_tags", fund_id=fund_round['fund_id'], round_id=fund_round['round_id']) }}">
+          Cancel
+        </a>
+      </div>
+    </form>
+  </div>
 </div>
 {% endblock content %}

--- a/pre_award/assess/tagging/templates/tagging/manage_tags.html
+++ b/pre_award/assess/tagging/templates/tagging/manage_tags.html
@@ -12,148 +12,151 @@
 {% if migration_banner_enabled %}
     {{ migration_banner() }}
 {% endif %}
-{# djlint:off #}<div class="govuk-grid-column-two-thirds">{# djlint:on #}
-                <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">{{ pageHeading }}</h1>
-                <div id="contact-hint" class="govuk-hint govuk-!-margin-bottom-6">
-                    <p>View and edit the existing tags for this assessment round, create new ones, or deactivate and
-                        reactivate tags.</p>
-                    <p>Note that you cannot edit people tags which have been imported.</p>
-                </div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">{{ pageHeading }}</h1>
+        <div id="contact-hint" class="govuk-hint govuk-!-margin-bottom-6">
+            <p>View and edit the existing tags for this assessment round, create new ones, or deactivate and
+                reactivate tags.</p>
+            <p>Note that you cannot edit people tags which have been imported.</p>
+        </div>
 
-                <div class="govuk-grid-row govuk-!-text-align-left">
-                    <div class="govuk-grid-column-two-thirds">
-                        <a href="{{ url_for('tagging_bp.create_tag', fund_id = fund_round['fund_id'], round_id = fund_round['round_id']) }}"
-                        class="govuk-button govuk-button--secondary" data-module="govuk-button" data-qa="create-new-tag">
-                            Create new tag
-                        </a>
-                    </div>
-                </div>
-
-                <nav class="search-bar-flex-container">
-                    <form method="get" class="govuk-!-width-full">
-                        <fieldset class="govuk-fieldset">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-one-half">
-                                    <div class="govuk-form-group">
-                                        <label for="application_search" class="govuk-label">Search by tag name</label>
-                                        <input class="govuk-input" type="text" spellcheck="false"
-                                            aria-label="Search by tag name" id="tag_search" name="search_term" ,=""
-                                            value={{ search_params['search_term'] }}>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="govuk-grid-row govuk-!-text-align-left">
-                                <div class="govuk-grid-column-one-quarter">
-                                    <div class="govuk-form-group govuk-!-display-inline-block">
-                                        <label class="govuk-label" for="tag_purpose">
-                                            Filter by tag purpose
-                                        </label>
-                                        {{ query_params }}
-                                        <select class="govuk-select" name="tag_purpose" id="tag_purpose">
-                                            {% for tag_type in tag_types %}
-                                            <option value={{ tag_type.purpose }} {% if
-                                                search_params['tag_purpose']==tag_type.purpose %} selected{% endif %}>
-                                                {{ tag_type.purpose.title() }}
-                                            </option>
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="govuk-grid-column-one-quarter">
-                                    <div class="govuk-form-group govuk-!-display-inline-block">
-                                        <label class="govuk-label" for="tag_status">
-                                            Display
-                                        </label>
-                                        <select class="govuk-select" name="tag_status" id="tag_status">
-                                            {% for tag_status_config in tag_status_configs %}
-                                        {# djlint:off #}
-                                        <option value={{ tag_status_config['value'] }} {% if
-                                            search_params['tag_status']==tag_status_config['value'] %} selected{%
-                                            endif %}>
-                                            {{ tag_status_config["text"] }}
-                                        </option>
-                                        {# djlint:on #}
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="govuk-grid-column-one-quarter">
-                                    <div class="govuk-button-group govuk-!-margin-top-6">
-                                        <button class="govuk-button primary-button search-button" data-qa="search-tag" type="submit">
-                                            Search
-                                        </button>
-                                        {% if show_clear_filters %}
-                                        <a class="govuk-link" href="{{ url_for('tagging_bp.load_fund_round_tags',
-                                fund_id=fund_round['fund_id'],
-                                round_id=fund_round['round_id'],
-                                clear_filters=true) }}" aria-label="Clear Filters">Clear search</a>
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            </div>
-
-                        </fieldset>
-                    </form>
-                </nav>
-
-                {% if tags %}
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <div class="govuk-form-group">
-                            <table class="govuk-table">
-                                <caption class="govuk-table__caption govuk-table__caption--m">Active tags</caption>
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Tag name</th>
-                                        <th scope="col" class="govuk-table__header">Colour</th>
-                                        <th scope="col" class="govuk-table__header">Purpose</th>
-                                        <th scope="col" class="govuk-table__header"></th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    {% for tag in tags %}
-                                    <tr class="govuk-table__row">
-                                        <td class="govuk-table__cell">
-                                            {{ tag.value }}
-                                        </td>
-                                        <td class="govuk-table__cell">
-                                            <strong
-                                                class="govuk-tag--{{ tag_config[tag.purpose]['colour'] }} govuk-tag dluhc-tag">{{ tag.value }}</strong>
-                                        </td>
-                                        <td class="govuk-table__cell">
-                                            {{ tag.purpose.capitalize() }}
-                                        </td>
-                                        {% if tag.active %}
-                                            <td class="govuk-table__cell">
-                                                <a class="govuk-link" data-qa="edit-tag" href="{{ url_for ('tagging_bp.edit_tag',
-                                                fund_id = fund_round['fund_id'],
-                                                round_id = fund_round['round_id'],
-                                                tag_id=tag.id) }}">
-                                                    Edit
-                                                </a>
-                                            </td>
-                                        {% else %}
-                                            <td class="govuk-table__cell">
-                                                <a class="govuk-link" ata-qa="reactivate" href="{{ url_for('tagging_bp.reactivate_tag',
-                                                fund_id=fund_round['fund_id'],
-                                                round_id=fund_round['round_id'],
-                                                tag_id=tag.id) }}">
-                                                    Reactivate
-                                                </a>
-                                            </td>
-                                        {% endif %}
-                                    </tr>
-                                    {% endfor %}
-                                </tbody>
-
-                            </table>
-                        </div>
-                        {% else %}
-                        <p class="govuk-body dluhc-body-empty">
-                            There are no tags available
-                        </p>
-                        {% endif %}
-                    </div>
+        <div class="govuk-grid-row govuk-!-text-align-left">
+            <div class="govuk-grid-column-two-thirds">
+                <a href="{{ url_for('tagging_bp.create_tag', fund_id = fund_round['fund_id'], round_id = fund_round['round_id']) }}"
+                class="govuk-button govuk-button--secondary" data-module="govuk-button" data-qa="create-new-tag">
+                    Create new tag
+                </a>
             </div>
-        {% endblock content %}
+        </div>
+
+        <nav class="search-bar-flex-container">
+            <form method="get" class="govuk-!-width-full">
+                <fieldset class="govuk-fieldset">
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-one-half">
+                            <div class="govuk-form-group">
+                                <label for="application_search" class="govuk-label">Search by tag name</label>
+                                <input class="govuk-input" type="text" spellcheck="false"
+                                    aria-label="Search by tag name" id="tag_search" name="search_term" ,=""
+                                    value={{ search_params['search_term'] }}>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="govuk-grid-row govuk-!-text-align-left">
+                        <div class="govuk-grid-column-one-quarter">
+                            <div class="govuk-form-group govuk-!-display-inline-block">
+                                <label class="govuk-label" for="tag_purpose">
+                                    Filter by tag purpose
+                                </label>
+                                {{ query_params }}
+                                <select class="govuk-select" name="tag_purpose" id="tag_purpose">
+                                    {% for tag_type in tag_types %}
+                                    <option value={{ tag_type.purpose }} {% if
+                                        search_params['tag_purpose']==tag_type.purpose %} selected{% endif %}>
+                                        {{ tag_type.purpose.title() }}
+                                    </option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="govuk-grid-column-one-quarter">
+                            <div class="govuk-form-group govuk-!-display-inline-block">
+                                <label class="govuk-label" for="tag_status">
+                                    Display
+                                </label>
+                                <select class="govuk-select" name="tag_status" id="tag_status">
+                                    {% for tag_status_config in tag_status_configs %}
+                                {# djlint:off #}
+                                <option value={{ tag_status_config['value'] }} {% if
+                                    search_params['tag_status']==tag_status_config['value'] %} selected{%
+                                    endif %}>
+                                    {{ tag_status_config["text"] }}
+                                </option>
+                                {# djlint:on #}
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="govuk-grid-column-one-quarter">
+                            <div class="govuk-button-group govuk-!-margin-top-6">
+                                <button class="govuk-button primary-button search-button" data-qa="search-tag" type="submit">
+                                    Search
+                                </button>
+                                {% if show_clear_filters %}
+                                <a class="govuk-link" href="{{ url_for('tagging_bp.load_fund_round_tags',
+                        fund_id=fund_round['fund_id'],
+                        round_id=fund_round['round_id'],
+                        clear_filters=true) }}" aria-label="Clear Filters">Clear search</a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+
+                </fieldset>
+            </form>
+        </nav>
+
+        {% if tags %}
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <div class="govuk-form-group">
+                        <table class="govuk-table">
+                            <caption class="govuk-table__caption govuk-table__caption--m">Active tags</caption>
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Tag name</th>
+                                    <th scope="col" class="govuk-table__header">Colour</th>
+                                    <th scope="col" class="govuk-table__header">Purpose</th>
+                                    <th scope="col" class="govuk-table__header"></th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                {% for tag in tags %}
+                                <tr class="govuk-table__row">
+                                    <td class="govuk-table__cell">
+                                        {{ tag.value }}
+                                    </td>
+                                    <td class="govuk-table__cell">
+                                        <strong
+                                            class="govuk-tag--{{ tag_config[tag.purpose]['colour'] }} govuk-tag dluhc-tag">{{ tag.value }}</strong>
+                                    </td>
+                                    <td class="govuk-table__cell">
+                                        {{ tag.purpose.capitalize() }}
+                                    </td>
+                                    {% if tag.active %}
+                                        <td class="govuk-table__cell">
+                                            <a class="govuk-link" data-qa="edit-tag" href="{{ url_for ('tagging_bp.edit_tag',
+                                            fund_id = fund_round['fund_id'],
+                                            round_id = fund_round['round_id'],
+                                            tag_id=tag.id) }}">
+                                                Edit
+                                            </a>
+                                        </td>
+                                    {% else %}
+                                        <td class="govuk-table__cell">
+                                            <a class="govuk-link" ata-qa="reactivate" href="{{ url_for('tagging_bp.reactivate_tag',
+                                            fund_id=fund_round['fund_id'],
+                                            round_id=fund_round['round_id'],
+                                            tag_id=tag.id) }}">
+                                                Reactivate
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+
+                        </table>
+                    </div>
+                </div>
+            </div>
+        {% else %}
+            <p class="govuk-body dluhc-body-empty">
+                There are no tags available
+            </p>
+        {% endif %}
+    </div>
+</div>
+{% endblock content %}

--- a/pre_award/assess/templates/assess/base.html
+++ b/pre_award/assess/templates/assess/base.html
@@ -2,10 +2,10 @@
 
 {% from "govuk_frontend_jinja/components/header/macro.html" import govukHeader %}
 
-{% set serviceName = get_service_title() %}
 {% set assetPath = url_for('static', filename='assess').rstrip('/') %}
 
-{% block pageTitle %}{{ [pageHeading.rstrip('\n'), serviceName]|join(' – ') if pageHeading else serviceName }}{% endblock pageTitle %}
+{% set title = [pageHeading.rstrip('\n'), service_title]|join(' – ') if pageHeading else service_title %}
+{% block pageTitle %}{{ title }}{% endblock pageTitle %}
 
 {% block head %}
   {% include "assess/head.html" %}
@@ -14,7 +14,7 @@
 {% block header %}
   {{ govukHeader({
     "homepageUrl": "/",
-    "serviceName": serviceName,
+    "serviceName": title,
     "useTudorCrown": true,
   }) }}
 {% endblock header %}
@@ -40,7 +40,7 @@
   <!-- Google Tag Manager (noscript) -->
   {# djlint:off #}
   <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5J9Q8HV" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      <iframe title="Google Tag Manager" src="https://www.googletagmanager.com/ns.html?id=GTM-M5J9Q8HV" height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </noscript>
   {# djlint:on #}
   <!-- End Google Tag Manager (noscript) -->

--- a/pre_award/assess/templates/assess/base.html
+++ b/pre_award/assess/templates/assess/base.html
@@ -1,10 +1,11 @@
 {% extends "govuk_frontend_jinja/template.html" %}
-{% from "govuk_frontend_jinja/components/header/macro.html" import govukHeader %}
-{% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter %}
 
+{% from "govuk_frontend_jinja/components/header/macro.html" import govukHeader %}
+
+{% set serviceName = get_service_title() %}
 {% set assetPath = url_for('static', filename='assess').rstrip('/') %}
 
-{% block pageTitle %}{{ [pageHeading.rstrip('\n'), service_title]|join(' – ') if pageHeading else service_title }}{% endblock pageTitle %}
+{% block pageTitle %}{{ [pageHeading.rstrip('\n'), serviceName]|join(' – ') if pageHeading else serviceName }}{% endblock pageTitle %}
 
 {% block head %}
   {% include "assess/head.html" %}
@@ -12,18 +13,20 @@
 
 {% block header %}
   {{ govukHeader({
-    homepageUrl: "#"
+    "homepageUrl": "/",
+    "serviceName": serviceName,
+    "useTudorCrown": true,
   }) }}
 {% endblock header %}
 
 {% block main %}
-<div class="govuk-width-container {{ containerClasses }}">
-  {% block beforeContent %}{% endblock beforeContent %}
-  <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
-    {% block content %}{% endblock content %}
-  </main>
-</div>
-{% endblock main %}
+  <div class="govuk-width-container {%- if containerClasses %} {{ containerClasses }}{% endif %}">
+    {% block beforeContent %}{% endblock beforeContent %}
+    <main class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}" id="main-content" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
+      {% block content %}{% endblock content %}
+    </main>
+  </div>
+{% endblock %}
 
 {% block footer %}
   {% include "assess/footer.html" %}
@@ -31,15 +34,14 @@
 
 {% block bodyEnd %}
   <!--[if gt IE 8]><!-->
-    <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='assess/govuk-frontend/govuk-frontend-4.7.0.min.js') }}"></script>
+    <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='assess/govuk-frontend/govuk-frontend-4.8.0.min.js') }}"></script>
     <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='assess/js/main.min.js') }}"></script>
   <!--<![endif]-->
-    <!-- Google Tag Manager (noscript) -->
-    {# djlint:off #}
-    <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5J9Q8HV"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    {# djlint:on #}
-    <!-- End Google Tag Manager (noscript) -->
+  <!-- Google Tag Manager (noscript) -->
+  {# djlint:off #}
+  <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5J9Q8HV" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  {# djlint:on #}
+  <!-- End Google Tag Manager (noscript) -->
 {% endblock bodyEnd %}

--- a/pre_award/assess/templates/assess/base.html
+++ b/pre_award/assess/templates/assess/base.html
@@ -4,8 +4,7 @@
 
 {% set assetPath = url_for('static', filename='assess').rstrip('/') %}
 
-{% set title = [pageHeading.rstrip('\n'), service_title]|join(' – ') if pageHeading else service_title %}
-{% block pageTitle %}{{ title }}{% endblock pageTitle %}
+{% block pageTitle %}{{ [pageHeading.rstrip('\n'), service_title]|join(' – ') if pageHeading else service_title }}{% endblock pageTitle %}
 
 {% block head %}
   {% include "assess/head.html" %}
@@ -14,7 +13,7 @@
 {% block header %}
   {{ govukHeader({
     "homepageUrl": "/",
-    "serviceName": title,
+    "serviceName": "Assess grant applications",
     "useTudorCrown": true,
   }) }}
 {% endblock header %}

--- a/pre_award/assess/templates/assess/components/header.html
+++ b/pre_award/assess/templates/assess/components/header.html
@@ -3,8 +3,8 @@
 {% from "assess/macros/banner_summary.html" import banner_summary %}
 
 <header role="banner" data-module="govuk-header">
-    <nav class="govuk-width-container govuk-header__navigation">
-        <div class="govuk-phase-banner flex-parent-element">
+    <nav class="govuk-width-container govuk-header__navigation govuk-!-padding-top-3">
+        <div class="flex-parent-element">
             <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
                 {{ govukBackLink({'href': url_for("assessment_bp.application", application_id=application_id), 'html': 'Back to <b>assessment tasklist</b>', 'attributes': {'data-qa': 'back-to-assessment-tasklist'} }) }}
             </p>

--- a/pre_award/assess/templates/assess/get_help.html
+++ b/pre_award/assess/templates/assess/get_help.html
@@ -7,8 +7,8 @@
 
 {% block header %}
     {{ super()}}
-<nav class="govuk-header__navigation govuk-width-container">
-    <div class="govuk-phase-banner flex-parent-element">
+<nav class="govuk-header__navigation govuk-width-container govuk-!-padding-top-3">
+    <div class="flex-parent-element">
         {% if request.referrer %}
         <p class="govuk-!-text-align-left flex-parent-element flexed-element-margins-collapse">
             {{ govukBackLink({'href': request.referrer, 'html': 'Back'}) }}

--- a/pre_award/assess/templates/assess/head.html
+++ b/pre_award/assess/templates/assess/head.html
@@ -1,8 +1,8 @@
 <meta name="description" content="{{ service_meta_description }}">
 <meta name="keywords" content="{{ service_meta_keywords }}">
 <meta name="author" content="{{ service_meta_author }}">
-<!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assess/govuk-frontend/govuk-frontend-4.7.0.min.css') }}" /><!--<![endif]-->
-<!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assess/govuk-frontend/govuk-frontend-ie8-4.7.0.min.css') }}" /><![endif]-->
+<!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assess/govuk-frontend/govuk-frontend-4.8.0.min.css') }}" /><!--<![endif]-->
+<!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='assess/govuk-frontend/govuk-frontend-ie8-4.8.0.min.css') }}" /><![endif]-->
 {% assets "default_styles" %}
     <!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}"><!--<![endif]-->
 {% endassets %}

--- a/pre_award/assess/templates/assess/macros/fund_dashboard_summary.html
+++ b/pre_award/assess/templates/assess/macros/fund_dashboard_summary.html
@@ -58,7 +58,7 @@ assessment_tracker_href, round_status) %}
 
 {% macro fund_summary(summary) %}
 <div
-    class="govuk-!-padding-0 govuk-!-padding-right-2 govuk-!-padding-bottom-3 govuk-!-margin-bottom-6 govuk-grid-column-one-third content-container">
+    class="govuk-!-padding-0 govuk-!-padding-right-2 govuk-!-padding-bottom-3 govuk-!-margin-bottom-6 content-container">
 
     <div class="govuk-summary-card__title-wrapper">
         <h3 class="govuk-body govuk_summary-card__title govuk-!-font-size-24">{{ summary.round_name }}</h3>

--- a/pre_award/assess/templates/assess/macros/logout_partial.html
+++ b/pre_award/assess/templates/assess/macros/logout_partial.html
@@ -1,14 +1,12 @@
 {% macro logout_partial(sso_logout_url, show_get_help=True) %}
 <p class="flex-parent-element flexed-element-margins-collapse govuk-!-text-align-right">
     {% if g.is_debug_user %}
-        <div class="govuk-body-s govuk-!-margin-right-5 debug-user-info">
-            You are logged in as {{ g.user.email }} ({{ g.account_id }}) with roles {{ g.user.roles }}
-        </div>
+        <span class="govuk-body-s govuk-!-margin-right-5 debug-user-info">
+            You are logged in as {{ g.user.email }}
+        </span>
     {% endif %}
     {% if show_get_help %}
-    <a href="{{ url_for('shared_bp.get_help') }}"
-       class="govuk-link govuk-link--no-underline govuk-!-margin-right-5">
-        Get help</a>
+        <a href="{{ url_for('shared_bp.get_help') }}" class="govuk-link govuk-link--no-underline govuk-!-margin-right-5">Get help</a>
     {% endif %}
     <form method="post" action="{{ sso_logout_url }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/pre_award/assess/templates/assess/macros/tag_header.html
+++ b/pre_award/assess/templates/assess/macros/tag_header.html
@@ -2,8 +2,8 @@
 {% from "assess/macros/logout_partial.html" import logout_partial %}
 {% macro tag_header(backLinkTitle, backLinkHref, fund_round, sso_logout_url) %}
     <header role="banner" data-module="govuk-header">
-        <nav class="govuk-width-container govuk-header__navigation">
-            <div class="govuk-phase-banner flex-parent-element">
+        <nav class="govuk-width-container govuk-header__navigation govuk-!-padding-top-3">
+            <div class="flex-parent-element">
                 <p class="govuk-!-text-align-left govuk-!-margin-left-3 flex-parent-element flexed-element-margins-collapse">
                     {{ govukBackLink({'href': backLinkHref, 'html': 'Back to <b>'+backLinkTitle+'</b>', 'attributes': {'data-qa': 'back-to-assessment-dashboard'} }) }}
                 </p>

--- a/pre_award/assess/templates/assess/macros/team_dashboard_header.html
+++ b/pre_award/assess/templates/assess/macros/team_dashboard_header.html
@@ -4,8 +4,8 @@
 {% macro render(round_details, stats, team_flag_stats, is_active_status, sso_logout_url) %}
 
 <header role="banner" data-module="govuk-header">
-    <nav class="govuk-width-container govuk-header__navigation">
-        <div class="govuk-phase-banner flex-parent-element">
+    <nav class="govuk-width-container govuk-header__navigation govuk-!-padding-top-3">
+        <div class="flex-parent-element">
             <p class="govuk-!-text-align-left govuk-!-margin-left-3 flex-parent-element flexed-element-margins-collapse">
                 {{ govukBackLink({'href': url_for("assessment_bp.landing"), 'html': 'Back to <b>assessment landing</b>',
                 'attributes': {'data-qa': 'back-to-assessment-overview-link'} }) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "flask-talisman==1.1.0",
     "flask-wtf==1.2.2",
     "flask==3.0.3",
-    "govuk-frontend-jinja==2.7.0",
+    "govuk-frontend-jinja==2.8.0",
     "greenlet==3.1.1",
     "gunicorn[gevent]==23.0.0",
     "invoke==2.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -868,7 +868,7 @@ requires-dist = [
     { name = "flask-talisman", specifier = "==1.1.0" },
     { name = "flask-wtf", specifier = "==1.2.2" },
     { name = "funding-service-design-utils", extras = ["toggles"], specifier = "==6.0.2" },
-    { name = "govuk-frontend-jinja", specifier = "==2.7.0" },
+    { name = "govuk-frontend-jinja", specifier = "==2.8.0" },
     { name = "greenlet", specifier = "==3.1.1" },
     { name = "gunicorn", extras = ["gevent"], specifier = "==23.0.0" },
     { name = "invoke", specifier = "==2.2.0" },
@@ -946,14 +946,14 @@ wheels = [
 
 [[package]]
 name = "govuk-frontend-jinja"
-version = "2.7.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/671963409e31896b68a6a583495d7192ee82c0943cccd24425e4cd9f62be/govuk-frontend-jinja-2.7.0.tar.gz", hash = "sha256:de797f6a1247da50c70677a9b50197e3198e0001dbabe9e17703f33e72818646", size = 27375 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/06/9b7d66f5dd98daa230262f58d6d071df7115d68828e54ac3d7bed4b05524/govuk-frontend-jinja-2.8.0.tar.gz", hash = "sha256:0c67e8df4069848acd614253b0d618f4052941baa5eec6835756d05d061a14dc", size = 28103 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/6f/374edae79c5cdb47fa31b2ec386d47dc54f8e29fec6019f056162d0bfbe6/govuk_frontend_jinja-2.7.0-py3-none-any.whl", hash = "sha256:94ee83e6c766922204c2b26005779cd4a44c2e9d6f1c7d9a0c2868a41785be39", size = 39369 },
+    { url = "https://files.pythonhosted.org/packages/81/4d/18c773f5192176b18c292f8e8244df6c416d31686b2be369c713a2fc1c8e/govuk_frontend_jinja-2.8.0-py3-none-any.whl", hash = "sha256:e7202be806ec99657ef152f7c6c7c80e16e949a1cc3caddda4b97f54fb32b00e", size = 39988 },
 ]
 
 [[package]]


### PR DESCRIPTION
Update Assess govuk-jinja-compoents dependency to 2.8.0 and refresh the template.

Refreshing the template includes following changes:
- aligning Header - Content/Main - Footer on the left
- removing some govuk system overrides:
  - make spacing between header and back link/logout nav consistent across site
  - make spacing between back link/logout nav and masthead consistent across site
  - make spacing between content and footer consistent across site

### Screenshots of UI changes (if applicable)

1. Login page
- Before:
![image](https://github.com/user-attachments/assets/6df4f590-0d1a-4969-855d-317f91d54567)
- After:
![image](https://github.com/user-attachments/assets/40673763-6087-46e5-bc5e-114156f50ba8)

2. Funding service dashboard
- Before:
![image](https://github.com/user-attachments/assets/185174a1-e697-4e52-8e3f-d121d789f471)
- After:
![image](https://github.com/user-attachments/assets/5136c5dd-5fd2-41a8-a08b-733ad387a444)

3. Team dashboard
- Before:
![image](https://github.com/user-attachments/assets/b0a8efd5-6e1d-4daf-bd71-5a5c86b9c306)
- After:
![image](https://github.com/user-attachments/assets/27bc3862-c5ae-47df-a633-b3e033a45c30)

4. Assessment page
- Before:
![image](https://github.com/user-attachments/assets/a48933e2-f16e-4add-aef1-c8ebcfab964d)
-After: 
![image](https://github.com/user-attachments/assets/aad4bc75-3041-4aec-9660-48c118c6619d)
