### PR TITLE
Fix dict access on None

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -178,4 +178,7 @@ class Round(BaseModel):
 
     @property
     def round_instructions(self):
-        return self.instructions_json[get_lang()] or self.instructions_json["en"] or None
+        if not self.instructions_json:
+            return None
+
+        return self.instructions_json.get(get_lang(), self.instructions_json.get("en"))


### PR DESCRIPTION
`instructions_json` is nullable; we've seen sentry errors trying to read from this attribute.

Add a guard clause.

https://funding-service-design-team-dl.sentry.io/issues/6254764939/events/fc7bd158294447f8b9ec41ce0dd67e27/?project=4508324370317312