### PR TITLE
Remove extraneous log message

### DIFF
--- a/pre_award/common/error_routes.py
+++ b/pre_award/common/error_routes.py
@@ -42,8 +42,6 @@ def not_found(error):
 
 
 def internal_server_error(error):
-    current_app.logger.error(error)
-
     if request.host == current_app.config["API_HOST"]:
         return jsonify({"detail": str(error)}), 500
 

--- a/tests/pre_award/authenticator_tests/test_sso.py
+++ b/tests/pre_award/authenticator_tests/test_sso.py
@@ -193,7 +193,6 @@ def test_sso_get_token_500_when_error_in_auth_code_flow(authenticator_test_clien
     response = authenticator_test_client.get(endpoint)
 
     assert response.status_code == 500
-    assert "get-token flow failed with: {'error': 'some_error'}" in caplog.records[1].message
     assert "some_error" not in response.text
 
 


### PR DESCRIPTION
We are getting two sentry errors for, seemingly, all errors in the app - one with that actual exception and then another from this log message.

I think this is just extra noise - the sentry error from this log message has no context, no useful info, and generates an extra alert.

Example: https://funding-service-design-team-dl.sentry.io/issues/6254764939/events/fc7bd158294447f8b9ec41ce0dd67e27/?project=4508324370317312

Let's remove it and see how that affects sentry.