### PR TITLE
Change buttons to gov-uk standard buttons

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -112,14 +112,14 @@
 
             <div class="gov-uk-table__cell--align-right">
             <span class="left govuk-!-padding-right-4">
-                <div class="govuk-grid-row govuk-!-text-align-right">
+                <div class="govuk-grid-row govuk-!-text-align-right govuk-!-margin-bottom-4">
                     <div class="govuk-grid-column-full govuk-!-margin-bottom-7">
                         <a class="govuk-body govuk-link--no-visited-state" href="{{ url_for('assessment_bp.activity_trail', application_id=application_id) }}">View activity trail</a>
                     </div>
                 </div>
             </span>
 
-            <span class="left govuk-!-padding-right-4 govuk-!-margin-bottom-2">
+            <span class="left govuk-!-padding-right-4">
                 {% if is_flaggable %}
                 {{ flag_application_button(application_id) }}
                 {% endif %}

--- a/pre_award/assess/flagging/templates/flagging/flag_application.html
+++ b/pre_award/assess/flagging/templates/flagging/flag_application.html
@@ -1,5 +1,6 @@
 {% extends "assess/base.html" %}
 {% from "assess/macros/theme.html" import theme %}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% from "govuk_frontend_jinja/components/label/macro.html" import govukLabel %}
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 {%- from "govuk_frontend_jinja/components/fieldset/macro.html" import govukFieldset -%}
@@ -274,10 +275,14 @@
                                 data-qa="submit-flag-button">
                             Submit
                         </button>
-                        <a href="{{ url_for('assessment_bp.application', application_id=application_id)}}"
-                            class="govuk-button secondary-button">
-                            Cancel
-                        </a>
+                        {% set cancel_flag_url = url_for(
+                            'assessment_bp.application', application_id=application_id
+                        ) %}
+                        {{ govukButton({
+                            "text": "Cancel",
+                            "classes": "govuk-button--secondary",
+                            "href": cancel_flag_url
+                        }) }}
                     </div>
                 </form>
             </div>

--- a/pre_award/assess/flagging/templates/flagging/resolve_flag.html
+++ b/pre_award/assess/flagging/templates/flagging/resolve_flag.html
@@ -1,4 +1,5 @@
 {% extends "assess/base.html" %}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/fieldset/macro.html" import govukFieldset -%}
 {%- from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
@@ -113,7 +114,14 @@
           <button class="govuk-button primary-button" data-module="govuk-button">
             Submit
           </button>
-          <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-button secondary-button govuk-link--no-visited-state">Cancel</a>
+          {% set cancel_flag_url = url_for(
+            'assessment_bp.application', application_id=application_id
+          ) %}
+          {{ govukButton({
+              "text": "Cancel",
+              "classes": "govuk-button--secondary",
+              "href": cancel_flag_url
+          }) }}
         </div>
       </form>
     </div>

--- a/pre_award/assess/static/src/styles/govuk-overrides.css
+++ b/pre_award/assess/static/src/styles/govuk-overrides.css
@@ -144,24 +144,6 @@
     font-weight: 400
 }
 
-.primary-button {
-    margin-bottom: 0;
-    background-color: #1d70b8;
-}
-
-.primary-button:hover {
-    background-color: #003078;
-}
-
-.govuk-button.secondary-button {
-    background-color: #ffffff;
-    color: #0b0c0c;
-}
-
-.secondary-button:hover {
-    background-color: #b1b4b6;
-}
-
 .assessment-alert {
     border: 2px solid #003078;
     border-left: 10px solid #003078;
@@ -316,11 +298,11 @@
 
 ul.list-type-square {
     list-style-type: square;
-  }
+}
 
 ul.list-type-circle {
     list-style-type: circle;
-  }
+}
 
 ol.list-type-lower-alpha {
 list-style-type: lower-alpha;
@@ -368,23 +350,7 @@ list-style-type: upper-roman;
 .govuk-link__white_font {
     color: white !important;
 }
-body .govuk-button,
-body .govuk-button--primary {
-  margin-right: 1.5em;
-  background-color: #1d70b8;
-}
-body .govuk-button:hover,
-body .govuk-button--primary:hover {
-  background-color: #003078;
-}
-body .govuk-button--secondary,
-body .govuk-button--secondary:link {
-  background-color: #d2e2f1;
-  color: #144e81;
-}
-body .govuk-button--secondary:hover {
-  background-color: #a5bbdc;
-}
+
 body .govuk-button--warning {
   background-color: #d4351c;
   box-shadow: 0 2px 0 #55150b;

--- a/pre_award/assess/static/src/styles/landing.css
+++ b/pre_award/assess/static/src/styles/landing.css
@@ -14,15 +14,9 @@
 }
 
 .search-button {
-    color: #fff;
-    background-color: #1d70b8;
     margin-bottom: 0;
     margin-left: 8px;
     vertical-align: baseline;
-}
-
-.search-button:hover {
-    background-color: #003078;
 }
 
 .search-input {

--- a/pre_award/assess/templates/assess/macros/application_feedback.html
+++ b/pre_award/assess/templates/assess/macros/application_feedback.html
@@ -15,17 +15,20 @@
                     sub_criteria_id=sub_criteria.id) }}">
             {{ approval_form.csrf_token }}
             <input type="hidden" name="approve" value="1" />
-            <button type="submit" class="govuk-button primary-button">Approve</button>
-            <a
-                href="{{ url_for(
-                    'assessment_bp.request_changes',
-                    application_id=application_id,
-                    sub_criteria_id=sub_criteria.id,
-                    theme_id=current_theme_id,
-                )}}"
-                class="govuk-button secondary-button">
-                Request changes
-            </a>
+            {{ govukButton({
+                "text": "Approve"
+            }) }}
+            {% set request_changes_url = url_for(
+                'assessment_bp.request_changes',
+                application_id=application_id,
+                sub_criteria_id=sub_criteria.id,
+                theme_id=current_theme_id
+            ) %}
+            {{ govukButton({
+                "text": "Request changes",
+                "classes": "govuk-button--secondary",
+                "href": request_changes_url
+            }) }}
         </form>
         </div>
     </div>

--- a/pre_award/assess/templates/assess/macros/comments_box.html
+++ b/pre_award/assess/templates/assess/macros/comments_box.html
@@ -4,40 +4,45 @@
 {% macro comment_box(comment_form, html_text, placeholder, application_id) %}
 
 <form method="post">
-<div class="govuk-grid-row">
-    {{ comment_form.csrf_token }}
-    <div class="govuk-grid-column-full">
-    {{ govukTextarea({
-    "name": comment_form.comment.id,
-    "id": comment_form.comment.id,
-    "rows": 8,
-    "label": {
-      "text": "" if html_text else "Add a comment",
-      "html": html_text if html_text else "",
-      "classes": "govuk-label--m",
-      isPageHeading: true
-    },
-    "value": placeholder if placeholder else "",
-    "errorMessage": {
-      "text": comment_form.comment.errors.0
-  } if comment_form.comment.errors
-  }) }}
+    <div class="govuk-grid-row">
+        {{ comment_form.csrf_token }}
+        <div class="govuk-grid-column-full">
+            {{ govukTextarea({
+                "name": comment_form.comment.id,
+                "id": comment_form.comment.id,
+                "rows": 8,
+                "label": {
+                    "text": "" if html_text else "Add a comment",
+                    "html": html_text if html_text else "",
+                    "classes": "govuk-label--m",
+                    isPageHeading: true
+            },
+            "value": placeholder if placeholder else "",
+            "errorMessage": {
+                "text": comment_form.comment.errors.0
+            } if comment_form.comment.errors
+            }) }}
 
-  {{ govukButton({
-    "text": "Save comment",
-    "type": "submit",
-    "classes": "primary-button govuk-!-margin-bottom-9",
-    "data-qa": "save-comment-button"
-  }) }}
+            {{ govukButton({
+                "text": "Save comment",
+                "type": "submit",
+                "classes": "primary-button govuk-!-margin-bottom-9 govuk-!-margin-right-3",
+                "data-qa": "save-comment-button"
+            }) }}
 
-  {% if application_id %}
-    <a class="govuk-link govuk-!-padding-top-2 govuk-!-display-inline-block" href="{{ url_for(
-    'assessment_bp.application',
-    application_id=application_id) }}">Cancel</a>
-  {% endif %}
+            {% if application_id %}
+                {% set cancel_flag_url = url_for(
+                  'assessment_bp.application', application_id=application_id
+                ) %}
+                {{ govukButton({
+                    "text": "Cancel",
+                    "classes": "govuk-button--secondary",
+                    "href": cancel_flag_url
+                }) }}
+            {% endif %}
 
+        </div>
     </div>
-</div>
 </form>
 
 {% endmacro %}


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-919


Description:
Changes buttons on Assess to standard gov-uk buttons (green, instead of the custom blue ones). 
Updates secondary buttons.

Screenshots:
![Screenshot 2025-01-29 at 12 39 22](https://github.com/user-attachments/assets/1fdac3c9-d608-4ecf-8742-146c713a468f)

![Screenshot 2025-01-27 at 16 10 01](https://github.com/user-attachments/assets/72417e23-ed1f-4a63-a1a5-a2aec290b30d)

<img width="1065" alt="Screenshot 2025-01-28 at 10 46 35" src="https://github.com/user-attachments/assets/613d6be9-cfbd-4c6b-904a-cbe0a71c4970" />

<img width="1314" alt="Screenshot 2025-01-28 at 11 01 07" src="https://github.com/user-attachments/assets/2ba4732b-1e68-42ee-8814-625e590a9d47" />

<img width="1313" alt="Screenshot 2025-01-28 at 11 02 45" src="https://github.com/user-attachments/assets/4d6f0196-9b9a-4840-b688-4a7a97affde8" />

<img width="1329" alt="Screenshot 2025-01-28 at 11 09 01" src="https://github.com/user-attachments/assets/74666b49-74c4-46a9-8aca-ebe992acc80c" />

<img width="883" alt="Screenshot 2025-01-28 at 11 10 09" src="https://github.com/user-attachments/assets/42f8471a-e60c-48c8-b27e-29de0d65a23e" />

<img width="892" alt="Screenshot 2025-01-28 at 11 11 27" src="https://github.com/user-attachments/assets/b1994e00-ac82-4297-81b8-36f84b741bcb" />

<img width="342" alt="Screenshot 2025-01-28 at 11 12 38" src="https://github.com/user-attachments/assets/c8e9cc65-de40-404f-b33f-51906d8b8605" />

