### PR TITLE
Using macro with tudor crown now jinja updated

### DIFF
--- a/apply/static/src/styles/apply.css
+++ b/apply/static/src/styles/apply.css
@@ -1,4 +1,4 @@
-/* TODO Remove once frontend jinja macros updated and we can use macros for headers - see apply-base.html */
-.header-pointer-events-none {
+/* Custom CSS for Apply */
+a.govuk-header__link--homepage {
     pointer-events: none;
   }

--- a/apply/templates/apply/apply-base.html
+++ b/apply/templates/apply/apply-base.html
@@ -29,57 +29,12 @@
   })
 }}
 {% endblock skipLink %}
-
-{# TODO use the macro instead once the library is updated to use tudor crown #}
 {% block header %}
-<header class="govuk-header " role="banner" data-module="govuk-header">
-    <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-            <a class="govuk-header__link govuk-header__link--homepage header-pointer-events-none">
-                <span class="govuk-header__logotype">
-                    <!--[if gt IE 8]><!-->
-                        <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown"
-                             xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30" height="30" width="36">
-                            <path fill="currentColor" fill-rule="evenodd"
-                            d="M20.16 9.4c-.39-.94.06-2.03 1.01-2.41.93-.38 2.01.07 2.4 1.01.39.94-.06 2.01-.99 2.4-.95.39-2.03-.06-2.41-1Zm-4.86 4.25c-.95.39-1.39 1.48-1.01 2.41.39.94 1.46 1.39 2.41 1 .93-.38 1.38-1.46.99-2.4-.39-.94-1.47-1.4-2.4-1.01Zm12.22-.31c.93-.38 1.38-1.46.99-2.4-.39-.94-1.47-1.4-2.4-1.01-.95.39-1.39 1.48-1.01 2.41.39.94 1.46 1.39 2.41.99Zm.86 3.87c.39.94 1.46 1.39 2.41.99.93-.38 1.38-1.46.99-2.4-.39-.94-1.47-1.4-2.4-1.01-.95.39-1.39 1.48-1.01 2.41ZM15.02 4.68c.07.09.15.17.24.24l-1.34 4.04v.02c-.06.2-.1.42-.1.64 0 1.09.81 2 1.86 2.15h.05c.09.01.18.02.27.02.09 0 .18 0 .27-.02h.05c1.05-.16 1.86-1.06 1.86-2.15 0-.22-.03-.44-.1-.64v-.02l-1.34-4.04c.09-.07.17-.15.24-.24s2.33 1.22 2.33 1.22V2.46l-2.33.74c-.06-.09-.14-.17-.23-.24S17.69 0 17.69 0h-3.36l.94 2.95c-.08.07-.16.15-.23.24s-2.33-.73-2.33-.73V5.9l2.33-1.23ZM9.39 10.4c.95.39 2.03-.06 2.41-1 .39-.94-.06-2.03-1.01-2.41-.93-.38-2.01.07-2.4 1.01-.39.94.06 2.01.99 2.4Zm-4.94 2.95c.95.39 2.03-.06 2.41-.99.39-.94-.06-2.03-1.01-2.41-.93-.38-2.01.07-2.4 1.01-.39.94.06 2.01.99 2.4Zm-3.27 4.87c.95.39 2.03-.06 2.41-.99.39-.94-.06-2.03-1.01-2.41-.93-.38-2.01.07-2.4 1.01-.39.94.06 2.01.99 2.4ZM29.5 20.3c.25 1.27.29 1.86.01 2.68-.41-.4-.8-1.15-1.11-2.28l-1.21 4.04c.74-.51 1.31-.84 1.96-.85-1.15 2.49-2.6 3.13-3.53 2.95-1.14-.21-1.67-1.23-1.49-2.09.26-1.22 1.52-1.54 2.1-.12 1.12-2.29-.78-3-2-2.32 1.88-1.88 2.09-3.54.58-5.56-2.11 1.62-2.14 3.22-1.19 5.47-1.23-1.41-3.16-.65-2.46 1.63.89-1.38 2.07-.51 1.88.8-.16 1.14-1.66 2.06-3.54 1.9-2.69-.24-2.85-2.1-2.92-3.63.66-.12 1.85.49 2.87 1.92l.37-4.28c-1.1 1.15-2.11 1.37-3.22 1.4.37-1.16 2.08-3.05 2.08-3.05h-5.35s1.7 1.9 2.08 3.05c-1.11-.04-2.12-.25-3.22-1.4l.37 4.28c1.02-1.42 2.2-2.04 2.87-1.92-.07 1.54-.23 3.39-2.92 3.63-1.88.16-3.38-.76-3.54-1.9-.19-1.31.99-2.18 1.88-.8.69-2.28-1.23-3.04-2.46-1.63.95-2.25.93-3.85-1.19-5.47-1.52 2.02-1.3 3.68.58 5.56-1.22-.68-3.13.04-2 2.32.59-1.42 1.84-1.1 2.1.12.18.86-.35 1.88-1.49 2.09-.93.17-2.38-.47-3.53-2.95.65.02 1.22.34 1.96.85L3.61 20.7c-.31 1.13-.7 1.88-1.11 2.28-.28-.82-.24-1.41 0-2.68l-2.5.89C1.33 23 2.62 25.55 3.67 30c3.73-.53 7.91-.83 12.32-.83s8.6.3 12.33.83c1.06-4.45 2.35-7 3.67-8.81l-2.5-.89Z">
-                            </path>
-                        </svg>
-                    <!--<![endif]--> <!--[if IE 8]>
-                        <img src="{{ url_for('static', filename='apply/images/govuk-logotype-crown.png') }}" class="govuk-header__logotype-crown-fallback-image"
-                             width="36"height="32">
-                    <![endif]-->
-                    <span class="govuk-header__logotype-text">
-                        GOV.UK
-                    </span>
-                </span>
-            </a>
-        </div>
-        <div class="govuk-header__content">
-            <span class="app-service-name govuk-header__link--service-name">{{ serviceName }}</span>
-            {% if g.is_authenticated and g.logout_url %}
-            <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu" aria-expanded="true">Menu</button>
-            <nav>
-              <ul id="navigation" class="signout govuk-header__navigation app-navigation" aria-label="Navigation menu">
-
-                {% if toggle_dict.get("MULTIFUND_DASHBOARD") %}
-                <li class="govuk-header__navigation-item">
-                    <a class="govuk-header__link" href="{{ url_for('account_routes.dashboard')}}">{% trans %}View all applications{% endtrans %}</a>
-                </li>
-                {% endif %}
-                <li class="govuk-header__navigation-item">
-                    <form method="post" action="{{ g.logout_url }}">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="govuk-header__link signout_button">
-                            {% trans %}Sign out{% endtrans %}
-                        </button>
-                    </form>
-                </li>
-              </ul>
-            </nav>
-            {% endif %}
-        </div>
-    </div>
-</header>
+  {{ govukHeader({
+    "homepageUrl": "",
+    "serviceName": serviceName,
+    "useTudorCrown": true,
+  }) }}
 {% endblock header %}
 
 {% set mainClasses = "app-main-class" %}

--- a/apply/templates/apply/apply-base.html
+++ b/apply/templates/apply/apply-base.html
@@ -21,6 +21,11 @@
   {% endif %}
 {% endblock pageTitle %}
 
+{% block head %}
+
+  {{super()}}
+  <link rel="stylesheet" href="{{ url_for('static', filename='fs/styles/apply.css' ) }}"> </link>
+{% endblock head%}
 
 {% block skipLink %}
 {{ govukSkipLink({
@@ -31,7 +36,6 @@
 {% endblock skipLink %}
 {% block header %}
   {{ govukHeader({
-    "homepageUrl": "",
     "serviceName": serviceName,
     "useTudorCrown": true,
   }) }}

--- a/apply/templates/apply/landing.html
+++ b/apply/templates/apply/landing.html
@@ -4,7 +4,6 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% block head %}
     {{super()}}
-  <link rel="stylesheet" href="{{ url_for('static', filename='fs/styles/apply.css' ) }}"> </link>
 {% endblock head %}
 
 

--- a/build.py
+++ b/build.py
@@ -195,7 +195,7 @@ def build_assess_authenticator_assets(remove_existing=False):
 def build_monolith_assets(static_dist_root="static/fs", remove_existing=False) -> None:
     MONOLITH_DIST_PATH = "./" + static_dist_root
     MAIN_DIST_PATH = "./static"
-    GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v4.7.0/release-v4.7.0.zip"
+    GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v4.8.0/release-v4.8.0.zip"
     ZIP_FILE = "./monolith_govuk_frontend.zip"
 
     ASSETS_DIR = "/assets"

--- a/common/templates/common/fs-base.html
+++ b/common/templates/common/fs-base.html
@@ -2,7 +2,7 @@
 
 
 {% block head %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='fs/govuk-frontend-4.7.0.min.css' ) }}"> </link>
+  <link rel="stylesheet" href="{{ url_for('static', filename='fs/govuk-frontend-4.8.0.min.css' ) }}"> </link>
   <meta name="description" content="Access Funding" />
   <meta name="keywords" content="Access Funding" />
   <meta name="author" content="Ministry of Housing, Communities and Local Government" />
@@ -26,7 +26,7 @@
 {# Run JavaScript at end of the
 
 <body>, to avoid blocking the initial render. #}
-  <script src="{{ url_for('static', filename='apply/govuk-frontend-4.0.0.min.js') }}"> </script>
+  <script src="{{ url_for('static', filename='fs/govuk-frontend-4.8.0.min.js') }}"> </script>
   <script>window.GOVUKFrontend.initAll()</script>
     <!-- Google Tag Manager -->
   <script nonce="{{ csp_nonce() }}">(function (w, d, s, l, i) {


### PR DESCRIPTION
Removing TODO from the vertical slice work and using the `govukHeader` jinja macro on the new `apply-base.html`.
Also updates the version of the css and js that is brought in to the new apply to `4.8.0` as that matches the new jinja macro version.

It's only used by the landing page so doesn't need to the sign out bit yet, will add that in the future when this page is used more widely