### PR TITLE
bugfix: Add historylog key with None value if doesn't exist

### DIFF
--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -261,8 +261,9 @@ def update_application_fields(existing_json_blob, new_json_blob) -> set:
                             {datetime.now(tz=timezone.utc).isoformat(): field_map[field["key"]]}
                         )
                     else:
-                        field["history_log"] = [{datetime.now(tz=timezone.utc).isoformat(): field_map[field["key"]]}]
-
+                        field["history_log"] = [
+                            {datetime.now(tz=timezone.utc).isoformat(): field_map.get(field["key"], None)}
+                        ]
     return changed_fields
 
 


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net/browse/FLS-960

Description:
Bugfix: Add historylog key with None value if doesn't exist

How to test:
1. Do what's described in the ticket, to generate the error (before the fix).
2. After submitting the application (and not getting an error), check the database, that a history log exists in the assessment_records table for the changed field, which should show the datetime of the change and the original value (null).
Something like this:
"history_log": [
                {
                  "2025-01-29T15:01:33.225043+00:00": null
                }
              ]
