### PR TITLE
FLS-939 Changes received banner

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,22 @@
                 }
             ],
             "justMyCode": true
+        },
+        {
+        "name": "Run Tests: Current Function (debug)",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "pytest",
+        "console": "integratedTerminal",
+        "cwd": "${workspaceFolder}",
+        "envFile": "${workspaceFolder}/.env.development",
+        "args": [
+            "-c",
+            "pytest.ini",
+            "-k",
+            "test_change_received_notification_banner" // test to debug, modify this accordingly
+        ],
+        "justMyCode": false
         }
     ]
 }

--- a/app.py
+++ b/app.py
@@ -117,10 +117,9 @@ def create_app() -> Flask:  # noqa: C901
     flask_app.config.from_object("pre_award.config.Config")
 
     toggle_client = None
-    if getenv("FLASK_ENV") != "unit_test":
-        initialise_toggles_redis_store(flask_app)
-        toggle_client = create_toggles_client()
-        load_toggles(Config.FEATURE_CONFIG, toggle_client)
+    initialise_toggles_redis_store(flask_app)
+    toggle_client = create_toggles_client()
+    load_toggles(Config.FEATURE_CONFIG, toggle_client)
 
     Babel(flask_app, locale_selector=get_lang)
     LanguageSelector(flask_app)
@@ -204,6 +203,7 @@ def create_app() -> Flask:  # noqa: C901
     # These are required to associated errorhandlers and before/after request decorators with their blueprints
     import pre_award.apply.default.error_routes  # noqa
     import pre_award.assess.blueprint_middleware  # noqa
+    from apply.routes import apply_bp
     from pre_award.apply.default.account_routes import account_bp
     from pre_award.apply.default.application_routes import application_bp
     from pre_award.apply.default.content_routes import content_bp
@@ -222,7 +222,6 @@ def create_app() -> Flask:  # noqa: C901
     from pre_award.authenticator.frontend.sso.routes import sso_bp
     from pre_award.authenticator.frontend.user.routes import user_bp
     from pre_award.common.error_routes import internal_server_error, not_found
-    from apply.routes import apply_bp
 
     flask_app.register_error_handler(404, not_found)
     flask_app.register_error_handler(500, internal_server_error)

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1490,7 +1490,7 @@ def application(application_id):
     state = get_state_for_tasklist_banner(application_id)
 
     scoring_form = get_scoring_class(state.round_id)()
-    fund = (get_fund(state.fund_id),)
+    fund = get_fund(state.fund_id)
     fund_round = get_round(
         state.fund_id,
         state.round_id,

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -10,17 +10,7 @@ from collections import OrderedDict
 from datetime import datetime
 from urllib.parse import quote_plus, unquote_plus
 
-from flask import (
-    Response,
-    abort,
-    current_app,
-    g,
-    redirect,
-    render_template,
-    request,
-    session,
-    url_for,
-)
+from flask import Response, abort, current_app, g, redirect, render_template, request, session, url_for
 from fsd_utils import extract_questions_and_answers
 from fsd_utils.sqs_scheduler.context_aware_executor import ContextAwareExecutor
 from markupsafe import escape
@@ -1500,7 +1490,7 @@ def application(application_id):
     state = get_state_for_tasklist_banner(application_id)
 
     scoring_form = get_scoring_class(state.round_id)()
-
+    fund = (get_fund(state.fund_id),)
     fund_round = get_round(
         state.fund_id,
         state.round_id,
@@ -1638,6 +1628,7 @@ def application(application_id):
         comment_id=comment_id,
         comment_form=comment_form,
         comments=theme_matched_comments,
+        fund=fund,
     )
 
 

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -19,6 +19,7 @@
 {% from "assess/macros/migration_banner.html" import migration_banner %}
 {% from "assess/macros/link_to_download_contract_docs.html" import link_to_download_contract_docs %}
 {% from "assess/macros/assessment_actions.html" import assessment_actions %}
+{% from "assess/macros/assessment_change_received.html" import assessment_change_received %}
 
 {% set pageHeading = state.project_name %}
 
@@ -172,6 +173,10 @@
             application_id,
             show_caption=False,
         ) }}
+        {% endif %}
+
+        {% if toggle_dict.get("UNCOMPETED_WORKFLOW") and fund[0].funding_type == 'UNCOMPETED' and assessment_status == "Change received" %}
+        {{ assessment_change_received() }}
         {% endif %}
 
         {% if state.criterias|length > 0 %}<h2 class="govuk-heading-l govuk-!-margin-top-8">Unscored</h2>{% endif %}

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -176,7 +176,7 @@
         {% endif %}
 
         {% if toggle_dict.get("UNCOMPETED_WORKFLOW") and fund[0].funding_type == 'UNCOMPETED' and assessment_status == "Change received" %}
-        {{ assessment_change_received() }}
+            {{ assessment_change_received() }}
         {% endif %}
 
         {% if state.criterias|length > 0 %}<h2 class="govuk-heading-l govuk-!-margin-top-8">Unscored</h2>{% endif %}

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -175,7 +175,7 @@
         ) }}
         {% endif %}
 
-        {% if toggle_dict.get("UNCOMPETED_WORKFLOW") and fund[0].funding_type == 'UNCOMPETED' and assessment_status == "Change received" %}
+        {% if toggle_dict.get("UNCOMPETED_WORKFLOW") and fund.funding_type == 'UNCOMPETED' and assessment_status == "Change received" %}
             {{ assessment_change_received() }}
         {% endif %}
 

--- a/pre_award/assess/templates/assess/macros/assessment_change_received.html
+++ b/pre_award/assess/templates/assess/macros/assessment_change_received.html
@@ -1,0 +1,15 @@
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
+{% macro assessment_change_received() %}
+
+    {% set notification_banner_html %}
+    <p class="govuk-notification-banner__heading">
+        The applicant has made changes following your change request.<br>
+        Review the changes
+    </p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+        "html": notification_banner_html,
+    }) }}
+{% endmacro %}

--- a/pre_award/assess/templates/assess/macros/assessment_change_received.html
+++ b/pre_award/assess/templates/assess/macros/assessment_change_received.html
@@ -4,8 +4,7 @@
 
     {% set notification_banner_html %}
     <p class="govuk-notification-banner__heading">
-        The applicant has made changes following your change request.<br>
-        Review the changes
+        The applicant has made changes following your change request. Review the changes
     </p>
     {% endset %}
 

--- a/pre_award/assess/templates/assess/macros/assessment_subcriteria_accepted.html
+++ b/pre_award/assess/templates/assess/macros/assessment_subcriteria_accepted.html
@@ -14,7 +14,11 @@
     {% set notification_banner_html %}
     <p class="govuk-body">
         <strong>Approved by</strong><br>
-        {{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}
+        {% if user_info %}
+            {{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}
+        {% else %}
+            N/A
+        {% endif %}
     </p>
     {% endset %}
 

--- a/pre_award/assess/templates/assess/macros/assessment_subcriteria_accepted.html
+++ b/pre_award/assess/templates/assess/macros/assessment_subcriteria_accepted.html
@@ -14,11 +14,7 @@
     {% set notification_banner_html %}
     <p class="govuk-body">
         <strong>Approved by</strong><br>
-        {% if user_info %}
-            {{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}
-        {% else %}
-            N/A
-        {% endif %}
+        {{ user_info["full_name"] or "N/A" }} ({{ user_info["highest_role"] | all_caps_to_human }}) {{ user_info["email_address"] }}
     </p>
     {% endset %}
 

--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -332,7 +332,7 @@ class DefaultConfig(object):
     FEATURE_CONFIG = {
         "TAGGING": True,
         "ASSESSMENT_ASSIGNMENT": False,
-        "UNCOMPETED_WORKFLOW": True,
+        "UNCOMPETED_WORKFLOW": False,
         **CommonConfig.dev_feature_configuration,
     }
 

--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -13,9 +13,7 @@ import redis
 from fsd_utils import CommonConfig, configclass
 from fsd_utils.authentication.config import SupportedApp
 
-from pre_award.assessment_store.config.mappings.assessment_mapping_fund_round import (
-    fund_round_to_assessment_mapping,
-)
+from pre_award.assessment_store.config.mappings.assessment_mapping_fund_round import fund_round_to_assessment_mapping
 
 SafeAppConfig = namedtuple("SafeAppConfig", ("login_url", "logout_endpoint", "service_title"))
 
@@ -334,7 +332,7 @@ class DefaultConfig(object):
     FEATURE_CONFIG = {
         "TAGGING": True,
         "ASSESSMENT_ASSIGNMENT": False,
-        "UNCOMPETED_WORKFLOW": False,
+        "UNCOMPETED_WORKFLOW": True,
         **CommonConfig.dev_feature_configuration,
     }
 

--- a/tests/pre_award/assess_tests/api_data/test_data.py
+++ b/tests/pre_award/assess_tests/api_data/test_data.py
@@ -257,7 +257,7 @@ uncompeted_app = {
             "id": "1c5e8bea-f5ed-4b74-8823-e64fec27a7dc",
             "latest_status": FlagType.RESOLVED.value,
             "latest_allocation": "test_team",
-            "application_id": resolved_app_id,
+            "application_id": uncompeted_app_id,
             "sections_to_flag": ["Test section"],
             "field_ids": [],
             "is_change_request": False,

--- a/tests/pre_award/assess_tests/api_data/test_data.py
+++ b/tests/pre_award/assess_tests/api_data/test_data.py
@@ -246,6 +246,75 @@ resolved_app = {
     },
 }
 
+uncompeted_app_id = "uncompeted_app"
+uncompeted_app = {
+    "id": uncompeted_app_id,
+    "workflow_status": "CHANGE_RECEIVED",
+    "project_name": "Project In prog and Res",
+    "short_id": "INP",
+    "flags": [
+        {
+            "id": "1c5e8bea-f5ed-4b74-8823-e64fec27a7dc",
+            "latest_status": FlagType.RESOLVED.value,
+            "latest_allocation": "test_team",
+            "application_id": resolved_app_id,
+            "sections_to_flag": ["Test section"],
+            "field_ids": [],
+            "is_change_request": False,
+            "updates": [
+                {
+                    "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
+                    "user_id": test_user_id_lead_assessor,
+                    "date_created": "2023-02-20 12:00:00",
+                    "justification": "Test",
+                    "status": FlagType.RAISED.value,
+                    "allocation": None,
+                },
+                {
+                    "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
+                    "user_id": test_user_id_lead_assessor,
+                    "date_created": "2023-02-20 12:00:00",
+                    "justification": "Test",
+                    "status": FlagType.RESOLVED.value,
+                    "allocation": None,
+                },
+            ],
+        },
+    ],
+    "tag_associations": [
+        {
+            "associated": True,
+            "id": "f908512a-25ef-4ec8-9850-b5a9c867992f",
+            "user_id": test_user_id_lead_assessor,
+            "tag": {
+                "active": True,
+                "creator_user_id": test_user_id_lead_assessor,
+                "id": "62ea161d-8593-4943-8676-baae283cd979",
+                "value": "Tag one red",
+                "tag_type": {
+                    "id": "7e7ecf78-9239-498a-9086-008043230a69",
+                    "purpose": "NEGATIVE",
+                },
+            },
+        }
+    ],
+    "user_associations": [],
+    "qa_complete": [],
+    "is_qa_complete": False,
+    "criteria_sub_criteria_name": "test_sub_criteria",
+    "criteria_sub_criteria_id": "test_sub_criteria_id",
+    "theme_id": "test_theme_id",
+    "theme_name": "test_theme_name",
+    "mock_field": {
+        "answer": "Yes",
+        "field_id": "JCACTy",
+        "field_type": "yesNoField",
+        "form_name": "community-engagement",
+        "presentation_type": "text",
+        "question": "Have you done any fundraising in the community?",
+    },
+}
+
 stopped_app_id = "stopped_app"
 stopped_app = {
     "id": stopped_app_id,
@@ -387,6 +456,7 @@ mock_api_results = {
         # "assessment_start": None,
         # "assessment_deadline": "2124-01-01 12:00:00",
         # "deadline": "2024-01-01 12:00:00"
+        "funding_type": "UNCOMPETED",
     },
     "fund_store/funds/NSTF": {
         "id": "NSTF",
@@ -646,6 +716,37 @@ mock_api_results = {
         "fund_id": test_fund_id,
         "round_id": test_round_id,
         "qa_complete": resolved_app["qa_complete"],
+    },
+    "assessment_store/application_overviews/uncompeted_app": {
+        "criterias": [
+            {
+                "name": "string",
+                "sub_criterias": [
+                    {
+                        "id": uncompeted_app["criteria_sub_criteria_id"],
+                        "name": uncompeted_app["criteria_sub_criteria_name"],
+                        "theme_count": 1,
+                        "score": 4,
+                        "status": "string",
+                    }
+                ],
+                "total_criteria_score": 4,
+                "number_of_scored_sub_criteria": 5,
+                "weighting": 0,
+            }
+        ],
+        "sections": [
+            {
+                "name": "string",
+                "sub_criterias": [{"id": "string", "name": "A fixed sub criteria"}],
+            }
+        ],
+        "project_name": uncompeted_app["project_name"],
+        "short_id": uncompeted_app["short_id"],
+        "workflow_status": uncompeted_app["workflow_status"],
+        "fund_id": test_fund_id,
+        "round_id": test_round_id,
+        "qa_complete": uncompeted_app["qa_complete"],
     },
     "assessment_store/application_overviews/flagged_app": {
         "criterias": [

--- a/tests/pre_award/assess_tests/api_data/test_data.py
+++ b/tests/pre_award/assess_tests/api_data/test_data.py
@@ -250,69 +250,12 @@ uncompeted_app_id = "uncompeted_app"
 uncompeted_app = {
     "id": uncompeted_app_id,
     "workflow_status": "CHANGE_RECEIVED",
-    "project_name": "Project In prog and Res",
-    "short_id": "INP",
-    "flags": [
-        {
-            "id": "1c5e8bea-f5ed-4b74-8823-e64fec27a7dc",
-            "latest_status": FlagType.RESOLVED.value,
-            "latest_allocation": "test_team",
-            "application_id": uncompeted_app_id,
-            "sections_to_flag": ["Test section"],
-            "field_ids": [],
-            "is_change_request": False,
-            "updates": [
-                {
-                    "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
-                    "user_id": test_user_id_lead_assessor,
-                    "date_created": "2023-02-20 12:00:00",
-                    "justification": "Test",
-                    "status": FlagType.RAISED.value,
-                    "allocation": None,
-                },
-                {
-                    "id": "316f607a-03b7-4592-b927-5021a28b7d6a",
-                    "user_id": test_user_id_lead_assessor,
-                    "date_created": "2023-02-20 12:00:00",
-                    "justification": "Test",
-                    "status": FlagType.RESOLVED.value,
-                    "allocation": None,
-                },
-            ],
-        },
-    ],
-    "tag_associations": [
-        {
-            "associated": True,
-            "id": "f908512a-25ef-4ec8-9850-b5a9c867992f",
-            "user_id": test_user_id_lead_assessor,
-            "tag": {
-                "active": True,
-                "creator_user_id": test_user_id_lead_assessor,
-                "id": "62ea161d-8593-4943-8676-baae283cd979",
-                "value": "Tag one red",
-                "tag_type": {
-                    "id": "7e7ecf78-9239-498a-9086-008043230a69",
-                    "purpose": "NEGATIVE",
-                },
-            },
-        }
-    ],
-    "user_associations": [],
+    "project_name": "Uncompeted project In prog and Res",
+    "short_id": "UNCMP-INP",
     "qa_complete": [],
     "is_qa_complete": False,
-    "criteria_sub_criteria_name": "test_sub_criteria",
-    "criteria_sub_criteria_id": "test_sub_criteria_id",
-    "theme_id": "test_theme_id",
-    "theme_name": "test_theme_name",
-    "mock_field": {
-        "answer": "Yes",
-        "field_id": "JCACTy",
-        "field_type": "yesNoField",
-        "form_name": "community-engagement",
-        "presentation_type": "text",
-        "question": "Have you done any fundraising in the community?",
-    },
+    "criteria_sub_criteria_name": "test_uncomp_sub_criteria",
+    "criteria_sub_criteria_id": "test_uncomp_sub_criteria_id",
 }
 
 stopped_app_id = "stopped_app"

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -1407,6 +1407,29 @@ class TestRoutes:
         assert sample_1 in response.text
         assert sample_2 in response.text
 
+    @pytest.mark.application_id("uncompeted_app")
+    def test_application(
+        self,
+        assess_test_client,
+        mock_get_funds,
+        mock_get_fund,
+        mock_get_round,
+        mock_get_application_metadata,
+        mock_get_application_json,
+        mocks_for_file_export_download,
+        mock_get_assessor_tasklist_state,
+        mock_get_scoring_system,
+    ):
+        token = create_valid_token(test_lead_assessor_claims)
+        assess_test_client.set_cookie("fsd_user_token", token)
+        response = assess_test_client.get("/assess/application/uncompeted_app")
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert any(
+            "The applicant has made changes following your change request." in p.text
+            for p in soup.find_all("p", class_="govuk-notification-banner__heading")
+        ), "Text does not match"
+
     def test_get_file_with_short_id(
         self,
         assess_test_client,

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -1408,20 +1408,16 @@ class TestRoutes:
         assert sample_2 in response.text
 
     @pytest.mark.application_id("uncompeted_app")
-    def test_application(
+    def test_change_received_notification_banner(
         self,
         assess_test_client,
         mock_get_funds,
         mock_get_fund,
         mock_get_round,
         mock_get_application_metadata,
-        mock_get_application_json,
-        mocks_for_file_export_download,
         mock_get_assessor_tasklist_state,
         mock_get_scoring_system,
     ):
-        token = create_valid_token(test_lead_assessor_claims)
-        assess_test_client.set_cookie("fsd_user_token", token)
         response = assess_test_client.get("/assess/application/uncompeted_app")
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-939

### Change description
- Added changes received banner
- Added test
- Refactor toggle setup for unit_tests, using in-memory feature flag client for unit tests instead of redis

- [X] Unit tests and other appropriate tests added or updated
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Request changes as an Assessor
- Send changes back as an Applicant
- Once changes are received, the banner should appear on the assessor tasklist page

### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/af2448ef-20f5-4c3b-aa71-c05c7f9c93a1)
