### PR TITLE
FLS-940 acceptance flow

### DIFF
--- a/pre_award/assess/assessments/forms/change_request_form.py
+++ b/pre_award/assess/assessments/forms/change_request_form.py
@@ -1,0 +1,15 @@
+from flask_wtf import FlaskForm
+from wtforms import TextAreaField
+from wtforms.validators import InputRequired, length
+
+from pre_award.config import Config
+
+
+class ChangeRequestForm(FlaskForm):
+    comment = TextAreaField(
+        "Change Request Comment",
+        validators=[
+            length(max=Config.TEXT_AREA_INPUT_MAX_CHARACTERS),
+            InputRequired(),
+        ],
+    )

--- a/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
@@ -14,6 +14,7 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% block header %}
+    {{ super() }}
     {% include "assess/components/header.html" %}
 {% endblock header %}
 {% block content %}

--- a/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
@@ -18,34 +18,38 @@
 {% endblock header %}
 {% block content %}
     <h1 class="govuk-heading-l">{{ sub_criteria.name }}: Accepted</h1>
-    <form method="post">
-        <div class="govuk-grid-row">
-            {{ change_request_form.csrf_token }}
-            <div class="govuk-grid-column-full">
-                {{ govukTextarea({
-                                "name": change_request_form.comment.id,
-                                "id": change_request_form.comment.id,
-                                "rows": 8,
-                                "label": {
-                                "text": "Why has the change been accepted?",
-                                "classes": "govuk-label--m",
-                                isPageHeading: true
-                                },
-                                "value": "This submission meets the required criteria",
-                                "errorMessage": {
-                                "text": change_request_form.comment.errors.0
-                                } if change_request_form.comment.errors
-                                }) }}
-                {{ govukButton({"text": "Save and continue", "type": "submit", "data-qa": "save-comment-button"}) }}
-                {{ govukButton({
-                                "text": "Cancel",
-                                "classes": "govuk-button--secondary",
-                                "href": url_for(
-                                'assessment_bp.display_sub_criteria',
-                                application_id=application_id,
-                                sub_criteria_id=sub_criteria.id)
-                }) }}
-            </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+            <form method="post">
+                <div class="govuk-grid-row">
+                    {{ change_request_form.csrf_token }}
+                    <div class="govuk-grid-column-full">
+                        {{ govukTextarea({
+                                        "name": change_request_form.comment.id,
+                                        "id": change_request_form.comment.id,
+                                        "rows": 8,
+                                        "label": {
+                                        "text": "Why has the change been accepted?",
+                                        "classes": "govuk-label--m",
+                                        isPageHeading: true
+                                        },
+                                        "value": "This submission meets the required criteria",
+                                        "errorMessage": {
+                                        "text": change_request_form.comment.errors.0
+                                        } if change_request_form.comment.errors
+                                        }) }}
+                        {{ govukButton({"text": "Save and continue", "type": "submit", "data-qa": "save-comment-button"}) }}
+                        {{ govukButton({
+                                        "text": "Cancel",
+                                        "classes": "govuk-button--secondary",
+                                        "href": url_for(
+                                        'assessment_bp.display_sub_criteria',
+                                        application_id=application_id,
+                                        sub_criteria_id=sub_criteria.id)
+                        }) }}
+                    </div>
+                </div>
+            </form>
         </div>
-    </form>
+    </div>
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
@@ -1,0 +1,62 @@
+{% extends "assess/base.html" %}
+{% from "assess/macros/theme.html" import theme %}
+{% from "assess/macros/sub_criteria_navbar.html" import navbar %}
+{% from "assess/macros/banner_summary.html" import banner_summary %}
+{% from "assess/macros/flag_application_button.html" import flag_application_button %}
+{% from "assess/macros/comments.html" import comment %}
+{% from "assess/macros/application_feedback.html" import application_feedback %}
+{% from "assess/macros/comments_edit_box.html" import edit_comment_box %}
+{% from "assess/macros/comments_box.html" import comment_box %}
+{% from "assess/macros/sub_criteria_heading.html" import sub_criteria_heading %}
+{% from "assess/macros/migration_banner.html" import migration_banner %}
+{% from "assess/macros/assessment_change_request.html" import assessment_change_request %}
+{% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
+{%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
+
+{% block header %}
+{% include "assess/components/header.html" %}
+{% endblock header %}
+
+{% block content %}
+    <h1 class="govuk-heading-l">
+        {{sub_criteria.name}}: Accepted
+    </h1>
+
+    <form method="post">
+        <div class="govuk-grid-row">
+            {{ change_request_form.csrf_token }}
+            <div class="govuk-grid-column-full">
+            {{ govukTextarea({
+            "name": change_request_form.comment.id,
+            "id": change_request_form.comment.id,
+            "rows": 8,
+            "label": {
+              "text": "Why has the change been accepted?",
+              "classes": "govuk-label--m",
+              isPageHeading: true
+            },
+            "value": "This submission meets the required criteria",
+            "errorMessage": {
+              "text": change_request_form.comment.errors.0
+          } if change_request_form.comment.errors
+          }) }}
+
+          {{ govukButton({
+            "text": "Save and continue",
+            "type": "submit",
+            "data-qa": "save-comment-button"
+          }) }}
+          {{ govukButton({
+            "text": "Cancel",
+            "classes": "govuk-button--secondary",
+            "href": url_for(
+            'assessment_bp.display_sub_criteria',
+            application_id=application_id,
+            sub_criteria_id=sub_criteria.id)
+          }) }}
+            </div>
+        </div>
+    </form>
+{% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
@@ -13,49 +13,38 @@
 {% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
-
-
 {% block header %}
-{% include "assess/components/header.html" %}
+    {% include "assess/components/header.html" %}
 {% endblock header %}
-
 {% block content %}
-    <h1 class="govuk-heading-l">
-        {{sub_criteria.name}}: Accepted
-    </h1>
-
+    <h1 class="govuk-heading-l">{{ sub_criteria.name }}: Accepted</h1>
     <form method="post">
         <div class="govuk-grid-row">
             {{ change_request_form.csrf_token }}
             <div class="govuk-grid-column-full">
-            {{ govukTextarea({
-            "name": change_request_form.comment.id,
-            "id": change_request_form.comment.id,
-            "rows": 8,
-            "label": {
-              "text": "Why has the change been accepted?",
-              "classes": "govuk-label--m",
-              isPageHeading: true
-            },
-            "value": "This submission meets the required criteria",
-            "errorMessage": {
-              "text": change_request_form.comment.errors.0
-          } if change_request_form.comment.errors
-          }) }}
-
-          {{ govukButton({
-            "text": "Save and continue",
-            "type": "submit",
-            "data-qa": "save-comment-button"
-          }) }}
-          {{ govukButton({
-            "text": "Cancel",
-            "classes": "govuk-button--secondary",
-            "href": url_for(
-            'assessment_bp.display_sub_criteria',
-            application_id=application_id,
-            sub_criteria_id=sub_criteria.id)
-          }) }}
+                {{ govukTextarea({
+                                "name": change_request_form.comment.id,
+                                "id": change_request_form.comment.id,
+                                "rows": 8,
+                                "label": {
+                                "text": "Why has the change been accepted?",
+                                "classes": "govuk-label--m",
+                                isPageHeading: true
+                                },
+                                "value": "This submission meets the required criteria",
+                                "errorMessage": {
+                                "text": change_request_form.comment.errors.0
+                                } if change_request_form.comment.errors
+                                }) }}
+                {{ govukButton({"text": "Save and continue", "type": "submit", "data-qa": "save-comment-button"}) }}
+                {{ govukButton({
+                                "text": "Cancel",
+                                "classes": "govuk-button--secondary",
+                                "href": url_for(
+                                'assessment_bp.display_sub_criteria',
+                                application_id=application_id,
+                                sub_criteria_id=sub_criteria.id)
+                }) }}
             </div>
         </div>
     </form>

--- a/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
@@ -25,27 +25,27 @@
                     {{ change_request_form.csrf_token }}
                     <div class="govuk-grid-column-full">
                         {{ govukTextarea({
-                                        "name": change_request_form.comment.id,
-                                        "id": change_request_form.comment.id,
-                                        "rows": 8,
-                                        "label": {
-                                        "text": "Why has the change been accepted?",
-                                        "classes": "govuk-label--m",
-                                        isPageHeading: true
-                                        },
-                                        "value": "This submission meets the required criteria",
-                                        "errorMessage": {
-                                        "text": change_request_form.comment.errors.0
-                                        } if change_request_form.comment.errors
-                                        }) }}
+                            "name": change_request_form.comment.id,
+                            "id": change_request_form.comment.id,
+                            "rows": 8,
+                            "label": {
+                                "text": "Why has the change been accepted?",
+                                "classes": "govuk-label--m",
+                                isPageHeading: true
+                            },
+                            "value": "This submission meets the required criteria",
+                            "errorMessage": {
+                                "text": change_request_form.comment.errors.0
+                            } if change_request_form.comment.errors
+                        }) }}
                         {{ govukButton({"text": "Save and continue", "type": "submit", "data-qa": "save-comment-button"}) }}
                         {{ govukButton({
-                                        "text": "Cancel",
-                                        "classes": "govuk-button--secondary",
-                                        "href": url_for(
-                                        'assessment_bp.display_sub_criteria',
-                                        application_id=application_id,
-                                        sub_criteria_id=sub_criteria.id)
+                            "text": "Cancel",
+                            "classes": "govuk-button--secondary",
+                            "href": url_for(
+                            'assessment_bp.display_sub_criteria',
+                            application_id=application_id,
+                            sub_criteria_id=sub_criteria.id)
                         }) }}
                     </div>
                 </div>

--- a/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
@@ -14,6 +14,7 @@
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% block header %}
+    {{ super() }}
     {% include "assess/components/header.html" %}
 {% endblock header %}
 {% block content %}

--- a/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
@@ -17,14 +17,18 @@
     {% include "assess/components/header.html" %}
 {% endblock header %}
 {% block content %}
-    <div class="govuk-panel govuk-panel--confirmation">
-        <h1 class="govuk-panel__title">Your change has been accepted</h1>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+            <div class="govuk-panel govuk-panel--confirmation">
+                <h1 class="govuk-panel__title">Your change has been accepted</h1>
+            </div>
+            <h2 class="govuk-heading-l">What happens next</h2>
+            <p class="govuk-body">Your acceptance has been sent to the applicant by email.</p>
+            <p class="govuk-body">The applicant will no longer be able to make changes to this section.</p>
+            <p class="govuk-body">
+                The status for this criteria will now be marked as <strong>Reviewed</strong>.
+            </p>
+            <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">Back to application</a>
+        </div>
     </div>
-    <h2 class="govuk-heading-l">What happens next</h2>
-    <p class="govuk-body">Your acceptance has been sent to the applicant by email.</p>
-    <p class="govuk-body">The applicant will no longer be able to make changes to this section.</p>
-    <p class="govuk-body">
-        The status for this criteria will now be marked as <strong>Reviewed</strong>.
-    </p>
-    <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">Back to application</a>
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
@@ -1,0 +1,44 @@
+{% extends "assess/base.html" %}
+{% from "assess/macros/theme.html" import theme %}
+{% from "assess/macros/sub_criteria_navbar.html" import navbar %}
+{% from "assess/macros/banner_summary.html" import banner_summary %}
+{% from "assess/macros/flag_application_button.html" import flag_application_button %}
+{% from "assess/macros/comments.html" import comment %}
+{% from "assess/macros/application_feedback.html" import application_feedback %}
+{% from "assess/macros/comments_edit_box.html" import edit_comment_box %}
+{% from "assess/macros/comments_box.html" import comment_box %}
+{% from "assess/macros/sub_criteria_heading.html" import sub_criteria_heading %}
+{% from "assess/macros/migration_banner.html" import migration_banner %}
+{% from "assess/macros/assessment_change_request.html" import assessment_change_request %}
+{% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
+{%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
+
+{% block header %}
+{% include "assess/components/header.html" %}
+{% endblock header %}
+
+{% block content %}
+    <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">
+            Your change has been accepted
+        </h1>
+    </div>
+
+    <h2 class="govuk-heading-l">What happens next</h2>
+
+    <p class="govuk-body">
+        Your acceptance has been sent to the applicant by email.
+    </p>
+    <p class="govuk-body">
+        The applicant will no longer be able to make changes to this section.
+    </p>
+    <p class="govuk-body">
+        The status for this criteria will now be marked as <strong>Reviewed</strong>.
+    </p>
+
+    <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">
+        Back to application
+    </a>
+{% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
@@ -13,32 +13,18 @@
 {% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
 {%- from 'govuk_frontend_jinja/components/textarea/macro.html' import govukTextarea -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
-
-
 {% block header %}
-{% include "assess/components/header.html" %}
+    {% include "assess/components/header.html" %}
 {% endblock header %}
-
 {% block content %}
     <div class="govuk-panel govuk-panel--confirmation">
-        <h1 class="govuk-panel__title">
-            Your change has been accepted
-        </h1>
+        <h1 class="govuk-panel__title">Your change has been accepted</h1>
     </div>
-
     <h2 class="govuk-heading-l">What happens next</h2>
-
-    <p class="govuk-body">
-        Your acceptance has been sent to the applicant by email.
-    </p>
-    <p class="govuk-body">
-        The applicant will no longer be able to make changes to this section.
-    </p>
+    <p class="govuk-body">Your acceptance has been sent to the applicant by email.</p>
+    <p class="govuk-body">The applicant will no longer be able to make changes to this section.</p>
     <p class="govuk-body">
         The status for this criteria will now be marked as <strong>Reviewed</strong>.
     </p>
-
-    <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">
-        Back to application
-    </a>
+    <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">Back to application</a>
 {% endblock content %}

--- a/pre_award/assessment_store/db/queries/scores/queries.py
+++ b/pre_award/assessment_store/db/queries/scores/queries.py
@@ -185,11 +185,11 @@ def insert_scoring_system_for_round_id(round_id: str, scoring_system_id: str) ->
     return inserted_assessment_round
 
 
-def approve_sub_criteria(application_id, sub_criteria_id, user_id):
+def approve_sub_criteria(application_id, sub_criteria_id, user_id, message):
     # Temporary solution to "accept" a sub-criteria is to provide it a non-zero score
     create_score_for_app_sub_crit(
         score=1,
-        justification="Approved by assessor",
+        justification=message,
         application_id=application_id,
         user_id=user_id,
         sub_criteria_id=sub_criteria_id,

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -869,6 +869,89 @@ class TestRoutes:
             response.location == f"https://authenticator.levellingup.gov.localhost:4004/service/user?{encoded_params}"  # noqa
         )
 
+    @pytest.mark.application_id("resolved_app")
+    @pytest.mark.sub_criteria_id("test_sub_criteria_id")
+    def test_route_sub_criteria_acceptance_comment(
+        self,
+        assess_test_client,
+        request,
+        mock_get_sub_criteria,
+        mock_get_fund,
+        mock_get_funds,
+        mock_get_round,
+        mock_get_application_metadata,
+        mock_get_comments,
+        mock_get_flags,
+        mock_get_scores,
+        mock_get_bulk_accounts,
+        mock_get_assessor_tasklist_state,
+        mock_get_scoring_system,
+    ):
+        application_id = request.node.get_closest_marker("application_id").args[0]
+        sub_criteria_id = request.node.get_closest_marker("sub_criteria_id").args[0]
+
+        token = create_valid_token(test_lead_assessor_claims)
+        assess_test_client.set_cookie("fsd_user_token", token)
+
+        response = assess_test_client.get(
+            f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}/accept_changes"  # noqa
+        )
+        assert 200 == response.status_code
+        soup = BeautifulSoup(response.data, "html.parser")
+
+        # Page should contain a form with a textarea
+        forms = soup.find_all("form")
+        assert forms, "No forms found in the response"
+
+        form_with_textarea = any(form.find("textarea") for form in forms)
+        assert form_with_textarea, "No form with a comment box found in the response"
+
+    @pytest.mark.application_id("resolved_app")
+    @pytest.mark.sub_criteria_id("test_sub_criteria_id")
+    def test_route_sub_criteria_acceptance(
+        self,
+        assess_test_client,
+        request,
+        mock_get_sub_criteria,
+        mock_get_fund,
+        mock_get_funds,
+        mock_get_round,
+        mock_get_application_metadata,
+        mock_get_comments,
+        mock_get_flags,
+        mock_get_scores,
+        mock_get_bulk_accounts,
+        mock_get_assessor_tasklist_state,
+        mock_get_scoring_system,
+    ):
+        application_id = request.node.get_closest_marker("application_id").args[0]
+        sub_criteria_id = request.node.get_closest_marker("sub_criteria_id").args[0]
+
+        token = create_valid_token(test_lead_assessor_claims)
+        assess_test_client.set_cookie("fsd_user_token", token)
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        form_data = {
+            "comment": "some justification",
+        }
+        with mock.patch("pre_award.assess.assessments.routes.approve_sub_criteria") as mock_approve_sub_criteria:
+            response = assess_test_client.post(
+                f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}/accept_changes",
+                headers=headers,
+                data=form_data,
+                follow_redirects=True,
+            )
+        assert 200 == response.status_code
+        assert "Your change has been accepted" in str(response.data)
+        mock_approve_sub_criteria.assert_called_once_with(
+            application_id="resolved_app",
+            sub_criteria_id="test_sub_criteria_id",
+            user_id="lead",
+            message="some justification",
+        )
+
     def test_homepage_route_accessible(self, assess_test_client, mock_get_funds):
         # Remove fsd-user-token cookie
         assess_test_client.set_cookie("fsd_user_token", "")

--- a/tests/pre_award/assessment_store_tests/test_db_scores.py
+++ b/tests/pre_award/assessment_store_tests/test_db_scores.py
@@ -439,7 +439,9 @@ def test_approve_sub_criteria_resolves_change_request(_db, setup_application_wit
     section_1 = str(uuid.uuid4())
     application_id = setup_application_with_requests_and_scores(flag_data=[[section_1], [section_1]])
 
-    approve_sub_criteria(application_id=application_id, sub_criteria_id=section_1, user_id=str(uuid.uuid4()))
+    approve_sub_criteria(
+        application_id=application_id, sub_criteria_id=section_1, user_id=str(uuid.uuid4()), message="test"
+    )
 
     change_requests = get_change_requests_for_application(application_id)
     assert all(cr.latest_status == FlagStatus.RESOLVED for cr in change_requests)
@@ -449,18 +451,23 @@ def test_approve_sub_criteria_creates_score(_db, setup_application_with_requests
     sub_criteria_id = str(uuid.uuid4())
     application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id]])
 
-    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()))
+    approve_sub_criteria(
+        application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()), message="test"
+    )
 
     scores = _db.session.query(Score).filter_by(application_id=application_id, sub_criteria_id=sub_criteria_id).all()
     assert len(scores) == 1
     assert scores[0].score == 1
+    assert scores[0].justification == "test"
 
 
 def test_approve_sub_criteria_updates_application_status(_db, setup_application_with_requests_and_scores):
     sub_criteria_id = str(uuid.uuid4())
     application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id]])
 
-    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()))
+    approve_sub_criteria(
+        application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()), message="test"
+    )
 
     application = _db.session.query(AssessmentRecord).filter_by(application_id=application_id).first()
     assert application.workflow_status == ApplicationStatus.IN_PROGRESS
@@ -473,7 +480,9 @@ def test_approve_sub_criteria_multiple_change_requests_diff_subcriteria(
     sub_criteria_id_2 = str(uuid.uuid4())
     application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id_1], [sub_criteria_id_2]])
 
-    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id_1, user_id=str(uuid.uuid4()))
+    approve_sub_criteria(
+        application_id=application_id, sub_criteria_id=sub_criteria_id_1, user_id=str(uuid.uuid4()), message="test"
+    )
 
     change_requests = get_change_requests_for_application(application_id)
     resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
@@ -487,7 +496,9 @@ def test_approve_sub_criteria_multiple_change_requests_diff_subcriteria(
     assert application.workflow_status == ApplicationStatus.CHANGE_REQUESTED
 
     # Approving last remaining sub-criteria should change application status
-    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id_2, user_id=str(uuid.uuid4()))
+    approve_sub_criteria(
+        application_id=application_id, sub_criteria_id=sub_criteria_id_2, user_id=str(uuid.uuid4()), message="test"
+    )
 
     change_requests = get_change_requests_for_application(application_id)
     resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
@@ -506,7 +517,9 @@ def test_approve_sub_criteria_multiple_change_requests_same_subcriteria(
     sub_criteria_id = str(uuid.uuid4())
     application_id = setup_application_with_requests_and_scores(flag_data=[[sub_criteria_id], [sub_criteria_id]])
 
-    approve_sub_criteria(application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()))
+    approve_sub_criteria(
+        application_id=application_id, sub_criteria_id=sub_criteria_id, user_id=str(uuid.uuid4()), message="test"
+    )
 
     change_requests = get_change_requests_for_application(application_id)
     resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]


### PR DESCRIPTION
### Change description
This PR introduces two new pages in the acceptance flow for a sub-criteria: the comment page and the success confirmation page. It provides the ability for an assessor to give a reason as to why they have accepted a sub-criteria.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
On the sub-criteria page, click the 'approve' button to initiate the flow. (Note that the feature toggle must be activated to see this option)

### Screenshots of UI changes (if applicable)
![Screenshot 2025-01-30 at 09 54 28](https://github.com/user-attachments/assets/0cdfa107-08f1-461d-8b62-73d4c58177ed)
![Screenshot 2025-01-30 at 09 54 45](https://github.com/user-attachments/assets/246bd2d8-274f-4ecf-bc88-2023c5445453)
