### PR TITLE
FLS-961 bugfix

### DIFF
--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -307,7 +307,8 @@ def submit_application(application_id) -> Applications:  # noqa: C901
 
             # updating row json blob
             update_application_fields(existing_application.jsonb_blob, row["jsonb_blob"])
-            row["workflow_status"] = WorkflowStatus.CHANGE_RECEIVED
+            if existing_application.workflow_status == WorkflowStatus.CHANGE_REQUESTED:
+                row["workflow_status"] = WorkflowStatus.CHANGE_RECEIVED
 
             stmt = postgres_insert(AssessmentRecord).values(row)
 

--- a/tests/pre_award/application_store_tests/test_submit.py
+++ b/tests/pre_award/application_store_tests/test_submit.py
@@ -521,6 +521,8 @@ def test_derive_values_script(
 def test_fields_resubmitted_uncompeted_application(setup_submitted_application, mocker, _db):
     application_id = str(setup_submitted_application)
     application = get_application(application_id, include_forms=True)
+    resubmitted_assessment = _db.session.get(AssessmentRecord, application_id)
+    resubmitted_assessment.workflow_status = Status.CHANGE_REQUESTED
 
     # Modify answer to a question
     test_field = application.forms[0].json[0]["fields"][0]
@@ -546,7 +548,7 @@ def test_fields_resubmitted_uncompeted_application(setup_submitted_application, 
                     except ValueError:
                         raise AssertionError("History log key is not an isoformat datetime") from None
                     assert list(field["history_log"][0].values())[0] == original_answer
-
+    # breakpoint()
     assert resubmitted_assessment.project_name == application.project_name
     assert resubmitted_assessment.workflow_status == Status.CHANGE_RECEIVED
 

--- a/tests/pre_award/application_store_tests/test_submit.py
+++ b/tests/pre_award/application_store_tests/test_submit.py
@@ -548,7 +548,7 @@ def test_fields_resubmitted_uncompeted_application(setup_submitted_application, 
                     except ValueError:
                         raise AssertionError("History log key is not an isoformat datetime") from None
                     assert list(field["history_log"][0].values())[0] == original_answer
-    # breakpoint()
+
     assert resubmitted_assessment.project_name == application.project_name
     assert resubmitted_assessment.workflow_status == Status.CHANGE_RECEIVED
 


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net/browse/FLS-961

Description:
Set assessment_records.workflow_status correctly: To change that to CHANGE_RECEIVED only if that previously was CHANGE_REQUESTED. 
So now, when re-submitting an already submitted application as explained in the ticket, a SUBMITTED workflow status shouldn't be changed to CHANGE_REQUESTED, but left as is. 


Test:
Unit test added.

