### PR TITLE
Split out CI and deployment pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Build and unit test
+
+on:
+  push:
+
+jobs:
+  setup:
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/determine-jobs.yml@main
+    with:
+      environment: ${{ inputs.environment }}
+
+  pre_deploy_tests:
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
+    with:
+      postgres_unit_testing: true
+      check_db_migrations: true
+      assets_required: true
+
+  type_checks:
+    if: ${{ ! contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') }}
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        with:
+          python-version: 3.10.x
+      - name: Install uv
+        uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5
+        with:
+          enable-cache: true
+      - name: install dependencies
+        run: uv sync
+      - name: run type checking
+        run: uv run mypy
+
+  paketo_build:
+    needs: [ setup ]
+    permissions:
+      packages: write
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
+    with:
+      version_to_build: ${{ github.sha }}
+      owner: ${{ github.repository_owner }}
+      application: funding-service-pre-award
+      assets_required: true

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy to AWS
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-UAT-Prod' || 'Build & Unit Test') }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-UAT-Prod') }}
 
 on:
   workflow_dispatch:
@@ -29,6 +29,7 @@ on:
         type: boolean
         description: Run e2e tests (application)
   push:
+    branches: [ main ]
 
 jobs:
   setup:
@@ -40,7 +41,7 @@ jobs:
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:
       postgres_unit_testing: true
-      check_db_migrations: true
+      check_db_migrations: false
       assets_required: true
 
   type_checks:


### PR DESCRIPTION
### Change description
This should do a few things:

1) Make it easier to see only the pipeline runs that are doing actual deployments to environments. Currently these are intermingled with CI test runs.

2) Disable the DB migrations check on the deployment pipeline. This check is used for CI only, because in some situations we might expect (and want) it to fail.