### PR TITLE
Updating pipeline to only run checks on a ci run, not a deploy

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -37,14 +37,15 @@ jobs:
       environment: ${{ inputs.environment }}
 
   pre_deploy_tests:
+    needs: [setup]
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:
       postgres_unit_testing: true
-      check_db_migrations: true
+      check_db_migrations: ${{ needs.setup.outputs.jobs_to_run == '[]'}}
       assets_required: true
 
   type_checks:
-    if: ${{ ! contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') }}
+    if: ${{ needs.setup.outputs.jobs_to_run == '[]' }}
     needs: [setup]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Change description
Updating our pipeline to skip the following checks on a deployment (but keep them on a CI run):
- type_checking
- check_db_migrations

This is to prevent the issue we saw [here](https://funding-service-design-team-dl.sentry.io/issues/6237646332/?referrer=slack&alert_rule_id=15583726&alert_type=issue) deploying database changes whereby the DB column is removed before the code is updated. Only running `check_db_migrations` on a CI run means that we can deploy column removal DB changes as follows:
1. PR to make the column nullable (with migration) and remove the column from the model (no migration, just a change in the model file). Also remove any references to that column or field.
2. PR with the migrations that remove the columns (by this point no code references that column so it won't produce errors)
