### PR TITLE
Move banner below main heading

### DIFF
--- a/pre_award/apply/templates/apply/dashboard_single_fund.html
+++ b/pre_award/apply/templates/apply/dashboard_single_fund.html
@@ -30,11 +30,15 @@ Your applications
     {% for fund in display_data["funds"] %}
         {% for round in fund["rounds"] %}
             {% if "CHANGE_REQUESTED" in round["applications"]|map(attribute="status") %}
-                {{
-                    govukNotificationBanner({
-                        "text": "Please review updates from the Assessor"
-                    })
-                }}
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-two-thirds">
+                        {{
+                            govukNotificationBanner({
+                                "text": "The assessor has requested changes to your application. Select 'Continue application' to make changes."
+                            })
+                        }}
+                    </div>
+                </div>
             {% endif %}
         {% endfor %}
     {% endfor %}

--- a/pre_award/apply/templates/apply/dashboard_single_fund.html
+++ b/pre_award/apply/templates/apply/dashboard_single_fund.html
@@ -27,6 +27,18 @@ Your applications
 {% endif %}
     <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
 
+    {% for fund in display_data["funds"] %}
+        {% for round in fund["rounds"] %}
+            {% if "CHANGE_REQUESTED" in round["applications"]|map(attribute="status") %}
+                {{
+                    govukNotificationBanner({
+                        "text": "Please review updates from the Assessor"
+                    })
+                }}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+
     <p class="govuk-body">
         {% set application_count=display_data["total_applications_to_display"] %}
         {% trans %}You have started{% endtrans %}&nbsp;{% trans count=application_count %} {{ application_count }} application{% pluralize %}{{ application_count }} applications{% endtrans %}&nbsp;{% trans %}using this email address{% endtrans %}.
@@ -54,14 +66,7 @@ Your applications
                 {% if round["is_past_submission_deadline"] %}
                     {{ round_closed_warning(fund["fund_data"]["name"], round["round_details"]["title"], round["round_details"]["deadline"]) }}
                 {% endif %}
-                {% if "CHANGE_REQUESTED" in round["applications"]|map(attribute="status") %}
-                {{
-                    govukNotificationBanner({
-                        "text": "Please review updates from the Assessor"
-                    })
-                }}
-                {% endif %}
-                    {{ applications_table(round["applications"], round["is_past_submission_deadline"], show_language_column, fund["fund_data"]["short_name"], round["round_details"]["is_expression_of_interest"]) }}
+                {{ applications_table(round["applications"], round["is_past_submission_deadline"], show_language_column, fund["fund_data"]["short_name"], round["round_details"]["is_expression_of_interest"]) }}
                 {% if not round["is_past_submission_deadline"] %}
                     {% if round["round_details"]["has_eligibility"] %}
                         {{ eligibilityCheckButton(form, url_for('eligibility_routes.launch_eligibility', fund_id=fund["fund_data"]["id"], round_id=round["round_details"]["id"])) }}

--- a/tests/pre_award/apply_tests/test_uncompeted_fund.py
+++ b/tests/pre_award/apply_tests/test_uncompeted_fund.py
@@ -57,7 +57,7 @@ def test_changes_requested_notification(apply_test_client, mocker, templates_ren
     rendered_html = template.render(
         display_data=display_data,
     )
-    assert "Please review updates from the Assessor" in rendered_html
+    assert "The assessor has requested changes to your application." in rendered_html
 
 
 @pytest.mark.usefixtures("mock_login", "mock_get_fund_round")


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-968

Description:
This PR moves the "Review updates" banner below the "h1" element of the page.

Before:
<img width="920" alt="Screenshot 2025-02-05 at 11 48 53" src="https://github.com/user-attachments/assets/60d06632-3ff6-44a1-9bb4-63ee6fe0f46b" />

After:
<img width="886" alt="Screenshot 2025-02-05 at 15 07 04" src="https://github.com/user-attachments/assets/8598bd25-6442-48e6-884d-5f8ef5fedc35" />
