### PR TITLE
Revert "BAU: disable proxy buffering on sidecar"

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -112,8 +112,6 @@ environments:
         variables:
           FORWARD_PORT: 8080
           CLIENT_MAX_BODY_SIZE: 10m
-          PROXY_REQUEST_BUFFERING: off
-          PROXY_BUFFERING: off
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
@@ -139,8 +137,6 @@ environments:
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-          PROXY_REQUEST_BUFFERING: off
-          PROXY_BUFFERING: off
     http:
       target_container: nginx
       healthcheck:
@@ -172,8 +168,6 @@ environments:
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-          PROXY_REQUEST_BUFFERING: off
-          PROXY_BUFFERING: off
     http:
       target_container: nginx
       healthcheck:


### PR DESCRIPTION
Reverts communitiesuk/funding-service-pre-award#221

Reverting as appears to possibly be breaking the deployment with a permissions error:

```
- [df1923db]: ResourceInitializationError: unable to pull secrets or reg                                      
        istry auth: execution resource retrieval failed: unable to retrieve se                                      
        crets from ssm: service call has been retried 1 time(s): AccessDeniedE                                      
        xception: User: arn:aws:sts::***:assumed-role/pre-award-test-                                      
        fsd-pre-award-ExecutionRole-pwSOw7kH0b5E/df1923db2117426cbb60a6b8c1dfe                                      
        e7a is not authorized to perform: ssm:GetParameters on resource: arn:a                                      
        ws:ssm:eu-west-2:***:parameter/false because no identity-base                                      
        d policy allows the ssm:GetParameters action status code: 400, request                                      
         id: f9fcc056-617f-4a85-9c75-1805e3a297b4               
``` 