### PR TITLE
Fls 957 email notification change request

### DIFF
--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -7,7 +7,7 @@ import json
 import time
 import zipfile
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import quote_plus, unquote_plus
 
 from flask import Response, abort, current_app, g, redirect, render_template, request, session, url_for
@@ -114,6 +114,7 @@ from pre_award.assess.services.data_services import (
     get_tags_for_fund_round,
     get_users_for_fund,
     match_comment_to_theme,
+    notify_applicant_changes_requested,
     submit_change_request,
     submit_comment,
     update_assessment_record_status,
@@ -139,6 +140,7 @@ from pre_award.assess.themes.deprecated_theme_mapper import (
     order_entire_application_by_themes,
 )
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as WorkflowStatus
+from pre_award.assessment_store.db.queries.flags.queries import is_first_change_request_for_date
 from pre_award.assessment_store.db.queries.scores.queries import approve_sub_criteria
 from pre_award.common.blueprints import Blueprint
 from pre_award.config import Config
@@ -1342,6 +1344,8 @@ def request_changes(application_id, sub_criteria_id, theme_id):
     field_ids = [question["field_id"] for question in theme_answers_response]
     form = build_request_changes_form(field_ids)
     if request.method == "POST" and form.validate_on_submit():
+        today_date = datetime.now(tz=timezone.utc).date()
+        send_notification = is_first_change_request_for_date(application_id=application_id, date=today_date)
         justification_data = {field_id: getattr(form, f"reason_{field_id}").data for field_id in field_ids}
         for field_id, justification in justification_data.items():
             if not justification.strip():
@@ -1360,6 +1364,10 @@ def request_changes(application_id, sub_criteria_id, theme_id):
                 application_id=application_id,
                 status=WorkflowStatus.CHANGE_REQUESTED,
             )
+            
+            if send_notification:
+                notify_applicant_changes_requested(application_id=application_id)
+                send_notification = False
 
         mark_application_with_requested_changes(application_id=application_id, field_ids=form.field_ids.data)
 

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1364,7 +1364,7 @@ def request_changes(application_id, sub_criteria_id, theme_id):
                 application_id=application_id,
                 status=WorkflowStatus.CHANGE_REQUESTED,
             )
-            
+
             if send_notification:
                 notify_applicant_changes_requested(application_id=application_id)
                 send_notification = False

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -7,6 +7,10 @@ import requests
 from flask import abort, current_app
 from sqlalchemy import select
 
+from data.models import Fund as FundModel
+from data.models import Round as RoundModel
+from pre_award.account_store.db.models.account import Account
+from pre_award.application_store.db.queries.application.queries import get_application
 from pre_award.assess.scoring.models.score import Score
 from pre_award.assess.services.models.application import Application
 from pre_award.assess.services.models.banner import Banner
@@ -25,6 +29,7 @@ from pre_award.assessment_store.db.models.assessment_record.enums import Status 
 from pre_award.common.locale_selector.get_lang import get_lang
 from pre_award.config import Config
 from pre_award.db import db
+from services.notify import get_notification_service
 
 
 def get_data(endpoint: str, payload: Dict = None):
@@ -855,6 +860,27 @@ def get_scoring_system(round_id: str) -> List[Flag]:
     current_app.logger.info("Calling endpoint '%(scoring_endpoint)s'.", dict(scoring_endpoint=scoring_endpoint))
     scoring_system = get_data(scoring_endpoint)["scoring_system"]
     return scoring_system
+
+
+def notify_applicant_changes_requested(application_id: str):
+    application = get_application(app_id=application_id)
+    language = application.language
+    account = db.session.query(Account).filter(Account.id == application.account_id).one()
+    fund = db.session.query(FundModel).filter(FundModel.id == application.fund_id).one()
+    round = db.session.query(RoundModel).filter(RoundModel.id == application.round_id).one()
+    round_deadline = round.deadline.strftime("%-d %B %Y")
+    apply_fund_url = Config.APPLY_HOST + Config.FUND_APPLICATION_ENDPOINT.format(
+        fund_short_name=fund.short_name, round_short_name=round.short_name
+    )
+    get_notification_service().send_requested_changes_email(
+        email_address=account.email,
+        application_reference=application.reference,
+        fund_name=fund.name_json[language.name],
+        round_name=round.title_json[language.name],
+        apply_fund_url=apply_fund_url,
+        application_deadline=round_deadline,
+        contact_email=round.contact_email,
+    )
 
 
 def assign_user_to_assessment(

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -869,9 +869,8 @@ def notify_applicant_changes_requested(application_id: str):
     fund = db.session.query(FundModel).filter(FundModel.id == application.fund_id).one()
     round = db.session.query(RoundModel).filter(RoundModel.id == application.round_id).one()
     round_deadline = round.deadline.strftime("%-d %B %Y")
-    apply_fund_url = Config.APPLY_HOST + Config.FUND_APPLICATION_ENDPOINT.format(
-        fund_short_name=fund.short_name, round_short_name=round.short_name
-    )
+    apply_fund_url = Config.APPLY_HOST + f"/funding-round/{fund.short_name}/{round.short_name}"
+
     get_notification_service().send_requested_changes_email(
         email_address=account.email,
         application_reference=application.reference,

--- a/pre_award/assessment_store/db/queries/flags/queries.py
+++ b/pre_award/assessment_store/db/queries/flags/queries.py
@@ -22,8 +22,10 @@ def get_change_requests_for_application(application_id, only_raised=False, sort_
         application_id (UUID or str): The unique identifier of the application.
         only_raised (bool, optional): If True, filters the results to include only change requests
                                       with a status of 'RAISED'
-        sort_descending (bool, optional): If True, sorts the change requests in descending order
+        sort_by_update (bool, optional): If True, sorts the change requests in descending order
                                           based on the latest update date.
+        sort_by_raised (bool, optional): TODO: If True, sorts the change requests in descending order
+                                          based on when they were raised (created).
 
     Returns:
         list: A list of AssessmentFlag representing the change requests for the application.

--- a/pre_award/assessment_store/db/queries/flags/queries.py
+++ b/pre_award/assessment_store/db/queries/flags/queries.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from sqlalchemy import select
+from sqlalchemy import desc, func, select
 from sqlalchemy.orm import contains_eager
 
 from pre_award.assessment_store.db.models.flags.assessment_flag import AssessmentFlag
@@ -14,12 +14,42 @@ def get_flags_for_application(application_id):
     return results
 
 
-def get_change_requests_for_application(application_id):
+def get_change_requests_for_application(application_id, only_raised=False, sort_by_update=False, sort_by_raised=False):
+    """
+    Retrieves change requests for a specific application.
+
+    Args:
+        application_id (UUID or str): The unique identifier of the application.
+        only_raised (bool, optional): If True, filters the results to include only change requests
+                                      with a status of 'RAISED'
+        sort_descending (bool, optional): If True, sorts the change requests in descending order
+                                          based on the latest update date.
+
+    Returns:
+        list: A list of AssessmentFlag representing the change requests for the application.
+    """
     stmt = select(AssessmentFlag).where(
         AssessmentFlag.application_id == application_id, AssessmentFlag.is_change_request.is_(True)
     )
+    if only_raised:
+        stmt = stmt.where(AssessmentFlag.latest_status == FlagStatus.RAISED)
+    if sort_by_update:
+        # Order change requests according to their latest update
+        stmt = stmt.join(FlagUpdate).group_by(AssessmentFlag.id).order_by(desc(func.max(FlagUpdate.date_created)))
+    elif sort_by_raised:
+        pass
+
     results = db.session.scalars(stmt).all()
     return results
+
+
+def is_first_change_request_for_date(application_id, date):
+    change_requests = get_change_requests_for_application(
+        application_id=application_id, only_raised=True, sort_by_update=True
+    )
+    return not change_requests or all(
+        date > flag_update.date_created.date() for flag_update in change_requests[0].updates
+    )
 
 
 def get_flag_by_id(flag_id):

--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -195,7 +195,7 @@ class DefaultConfig(object):
 
     # Applicant Frontend
     APPLICANT_FRONTEND_HOST = environ.get("APPLICANT_FRONTEND_HOST", "frontend")
-
+    FUND_APPLICATION_ENDPOINT = "/funding-round/{fund_short_name}/{round_short_name}"
     # Assessment Frontend
     FSD_ASSESSMENT_SESSION_TIMEOUT_SECONDS = CommonConfig.FSD_SESSION_TIMEOUT_SECONDS
     FUND_STORE_FUND_ENDPOINT = CommonConfig.FUND_ENDPOINT

--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -195,7 +195,7 @@ class DefaultConfig(object):
 
     # Applicant Frontend
     APPLICANT_FRONTEND_HOST = environ.get("APPLICANT_FRONTEND_HOST", "frontend")
-    FUND_APPLICATION_ENDPOINT = "/funding-round/{fund_short_name}/{round_short_name}"
+
     # Assessment Frontend
     FSD_ASSESSMENT_SESSION_TIMEOUT_SECONDS = CommonConfig.FSD_SESSION_TIMEOUT_SECONDS
     FUND_STORE_FUND_ENDPOINT = CommonConfig.FUND_ENDPOINT

--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -121,6 +121,7 @@ class NotificationService:
     )
 
     CHANGE_RECEIVED_TEMPLATE_ID = os.environ.get("CHANGE_RECEIVED_TEMPLATE_ID", "cc1a6287-7d70-4264-84aa-0f8dbf9341dc")
+    CHANGE_REQUEST_TEMPLATE_ID = os.environ.get("CHANGE_REQUEST_TEMPLATE_ID", "272d50bf-88f1-4a2c-9e38-02ea54bd389c")
 
     FUNDING_SERVICE_SUPPORT_EMAIL_ADDRESS = "FundingService@communities.gov.uk"
 
@@ -442,7 +443,32 @@ class NotificationService:
                 "contact email": contact_help_email,
             },
             email_reply_to_id=self.REPLY_TO_EMAILS_WITH_NOTIFY_ID.get(self.FUNDING_SERVICE_SUPPORT_EMAIL_ADDRESS),
+            govuk_notify_reference=govuk_notify_reference,)
+        
+    def send_requested_changes_email(
+        self,
+        email_address: str,
+        application_reference: str,
+        fund_name: str,
+        round_name: str,
+        application_deadline: str,
+        apply_fund_url: str,
+        contact_email: str,
+        govuk_notify_reference: str | None = None,
+    ) -> Notification:
+        return self._send_email(
+            email_address,
+            self.CHANGE_REQUEST_TEMPLATE_ID,
+            personalisation={
+                "name of fund": fund_name,
+                "application reference": application_reference,
+                "round name": round_name,
+                "contact email": contact_email,
+                "sign in link": apply_fund_url,
+                "application deadline": application_deadline,
+            },
             govuk_notify_reference=govuk_notify_reference,
+            email_reply_to_id=self.REPLY_TO_EMAILS_WITH_NOTIFY_ID.get(self.FUNDING_SERVICE_SUPPORT_EMAIL_ADDRESS),
         )
 
 

--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -443,8 +443,9 @@ class NotificationService:
                 "contact email": contact_help_email,
             },
             email_reply_to_id=self.REPLY_TO_EMAILS_WITH_NOTIFY_ID.get(self.FUNDING_SERVICE_SUPPORT_EMAIL_ADDRESS),
-            govuk_notify_reference=govuk_notify_reference,)
-        
+            govuk_notify_reference=govuk_notify_reference,
+        )
+
     def send_requested_changes_email(
         self,
         email_address: str,

--- a/tests/pre_award/application_store_tests/test_reports.py
+++ b/tests/pre_award/application_store_tests/test_reports.py
@@ -215,13 +215,10 @@ def test_get_applications_report_by_round_is_and_fund_id(
         + "geography,capital,revenue,organisation_name_nstf"
     ) == lines[0]
     row1 = lines[1].split(",")
-    assert row1[1] == "Test Org Name 1"
-    assert row1[0] == "Test Reference Number"
-    assert row1[4] == "W1A 1AA"
     row2 = lines[2].split(",")
-    assert row2[1] == "Test Org Name 2cy"
-    assert row2[0] == "Test Reference Number Welsh"
-    assert row2[4] == "CF10 3NQ"
+    result = [(row1[1], row1[0], row1[4]), (row2[1], row2[0], row2[4])]
+    assert ("Test Org Name 1", "Test Reference Number", "W1A 1AA") in result
+    assert ("Test Org Name 2cy", "Test Reference Number Welsh", "CF10 3NQ") in result
 
 
 @pytest.mark.fund_round_config(

--- a/tests/pre_award/assessment_store_tests/test_db_flags.py
+++ b/tests/pre_award/assessment_store_tests/test_db_flags.py
@@ -258,13 +258,13 @@ def create_change_request(db, application_id, status, updates=None, is_change_re
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_get_all_change_requests(_db, seed_application_records):
+def test_get_all_change_requests(db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     create_change_request(
-        _db, app_id, FlagStatus.RAISED, updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}]
+        db, app_id, FlagStatus.RAISED, updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}]
     )
     create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RESOLVED,
         updates=[{"status": FlagStatus.RESOLVED, "date_created": datetime(2025, 2, 4) - timedelta(days=1)}],
@@ -275,13 +275,13 @@ def test_get_all_change_requests(_db, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_get_only_raised_change_requests(_db, seed_application_records):
+def test_get_only_raised_change_requests(db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     create_change_request(
-        _db, app_id, FlagStatus.RAISED, updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}]
+        db, app_id, FlagStatus.RAISED, updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}]
     )
     create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RESOLVED,
         updates=[{"status": FlagStatus.RESOLVED, "date_created": datetime(2025, 2, 4) - timedelta(days=1)}],
@@ -293,12 +293,12 @@ def test_get_only_raised_change_requests(_db, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_sort_by_update(_db, seed_application_records):
+def test_sort_by_update(db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     base_date = datetime(2025, 2, 4)
 
     flag1 = create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RAISED,
         updates=[
@@ -308,7 +308,7 @@ def test_sort_by_update(_db, seed_application_records):
         ],
     )
     flag2 = create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RAISED,
         updates=[
@@ -317,7 +317,7 @@ def test_sort_by_update(_db, seed_application_records):
         ],
     )
     flag3 = create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RESOLVED,
         updates=[
@@ -336,12 +336,12 @@ def test_sort_by_update(_db, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_sort_by_update_only_raised(_db, seed_application_records):
+def test_sort_by_update_only_raised(db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     base_date = datetime(2025, 2, 4)
 
     flag1 = create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RAISED,
         updates=[
@@ -351,7 +351,7 @@ def test_sort_by_update_only_raised(_db, seed_application_records):
         ],
     )
     create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RESOLVED,
         updates=[
@@ -360,7 +360,7 @@ def test_sort_by_update_only_raised(_db, seed_application_records):
         ],
     )
     flag3 = create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RAISED,
         updates=[
@@ -370,7 +370,7 @@ def test_sort_by_update_only_raised(_db, seed_application_records):
         ],
     )
     flag4 = create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RAISED,
         updates=[
@@ -386,24 +386,24 @@ def test_sort_by_update_only_raised(_db, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_no_change_requests(_db, seed_application_records):
+def test_no_change_requests(db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     results = get_change_requests_for_application(app_id)
     assert len(results) == 0
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_exclude_non_change_requests(_db, seed_application_records):
+def test_exclude_non_change_requests(db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     create_change_request(
-        _db,
+        db,
         app_id,
         FlagStatus.RAISED,
         updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}],
         is_change_request=False,
     )
     create_change_request(
-        _db, app_id, FlagStatus.RAISED, updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}]
+        db, app_id, FlagStatus.RAISED, updates=[{"status": FlagStatus.RAISED, "date_created": datetime(2025, 2, 4)}]
     )
 
     results = get_change_requests_for_application(app_id)

--- a/tests/pre_award/assessment_store_tests/test_db_flags.py
+++ b/tests/pre_award/assessment_store_tests/test_db_flags.py
@@ -293,7 +293,7 @@ def test_get_only_raised_change_requests(_db, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_sort_descending(_db, seed_application_records):
+def test_sort_by_update(_db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     base_date = datetime(2025, 2, 4)
 
@@ -328,7 +328,7 @@ def test_sort_descending(_db, seed_application_records):
         ],
     )
 
-    results = get_change_requests_for_application(app_id, sort_descending=True)
+    results = get_change_requests_for_application(app_id, sort_by_update=True)
     assert len(results) == 3
     assert results[0].id == flag1.id and results[1].id == flag3.id and results[2].id == flag2.id, (
         "Flags returned in wrong order"
@@ -336,7 +336,7 @@ def test_sort_descending(_db, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([{**test_input_data[0]}])
-def test_sort_descending_only_raised(_db, seed_application_records):
+def test_sort_by_update_only_raised(_db, seed_application_records):
     app_id = seed_application_records[0]["application_id"]
     base_date = datetime(2025, 2, 4)
 
@@ -379,7 +379,7 @@ def test_sort_descending_only_raised(_db, seed_application_records):
         ],
     )
 
-    results = get_change_requests_for_application(app_id, only_raised=True, sort_descending=True)
+    results = get_change_requests_for_application(app_id, only_raised=True, sort_by_update=True)
     assert len(results) == 3
 
     assert flag4.id == results[0].id and flag3.id == results[1].id and flag1.id == results[2].id

--- a/tests/pre_award/assessment_store_tests/test_db_scores.py
+++ b/tests/pre_award/assessment_store_tests/test_db_scores.py
@@ -490,7 +490,6 @@ def test_approve_sub_criteria_multiple_change_requests_diff_subcriteria(setup_ap
     )
 
     change_requests = get_change_requests_for_application(application_id, only_raised=False, sort_descending=True)
-    breakpoint()
     resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
     unresolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RAISED]
 

--- a/tests/pre_award/assessment_store_tests/test_db_scores.py
+++ b/tests/pre_award/assessment_store_tests/test_db_scores.py
@@ -489,7 +489,7 @@ def test_approve_sub_criteria_multiple_change_requests_diff_subcriteria(setup_ap
         application_id=application_id, sub_criteria_id=sub_criteria_id_1, user_id=str(uuid.uuid4()), message="test"
     )
 
-    change_requests = get_change_requests_for_application(application_id, only_raised=False, sort_descending=True)
+    change_requests = get_change_requests_for_application(application_id, only_raised=False, sort_by_update=True)
     resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
     unresolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RAISED]
 

--- a/tests/pre_award/assessment_store_tests/test_db_scores.py
+++ b/tests/pre_award/assessment_store_tests/test_db_scores.py
@@ -8,7 +8,7 @@ from pre_award.assessment_store.api.routes.progress_routes import get_progress_f
 from pre_award.assessment_store.api.routes.score_routes import get_scoring_system_name_for_round_id
 from pre_award.assessment_store.db.models import AssessmentFlag, AssessmentRecord, Score
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as ApplicationStatus
-from pre_award.assessment_store.db.models.flags import FlagStatus
+from pre_award.assessment_store.db.models.flags import FlagStatus, FlagUpdate
 from pre_award.assessment_store.db.queries.assessment_records.queries import check_all_change_requests_accepted
 from pre_award.assessment_store.db.queries.flags.queries import get_change_requests_for_application
 from pre_award.assessment_store.db.queries.scores.queries import (
@@ -342,7 +342,14 @@ def setup_application_with_requests_and_scores(db):
                         sections_to_flag=sections,
                         latest_allocation=[],
                         latest_status=FlagStatus.RAISED,
-                        updates=[],
+                        updates=[
+                            FlagUpdate(
+                                justification="None",
+                                user_id=user_id,
+                                status=FlagStatus.RAISED,
+                                allocation=None,
+                            )
+                        ],
                         field_ids=["some_id"],
                         is_change_request=True,
                     )
@@ -482,7 +489,8 @@ def test_approve_sub_criteria_multiple_change_requests_diff_subcriteria(setup_ap
         application_id=application_id, sub_criteria_id=sub_criteria_id_1, user_id=str(uuid.uuid4()), message="test"
     )
 
-    change_requests = get_change_requests_for_application(application_id)
+    change_requests = get_change_requests_for_application(application_id, only_raised=False, sort_descending=True)
+    breakpoint()
     resolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RESOLVED]
     unresolved_requests = [cr for cr in change_requests if cr.latest_status == FlagStatus.RAISED]
 


### PR DESCRIPTION

### Change description
This PR implements an email notification when a change request is submitted by an assessor. It will only be sent if it is the first change request of the day (to prevent spamming)

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Create a change request. The first change request should trigger an email, the second should not.

### Screenshots of UI changes (if applicable)
