### PR TITLE
Hide "Score the subcriteria" link

### DIFF
--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -24,6 +24,7 @@ from pre_award.application_store.external_services.aws import FileData, list_fil
 from pre_award.assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as WorkflowStatus
 from pre_award.assessment_store.db.models.flags.flag_update import FlagStatus, FlagUpdate
+from pre_award.assessment_store.db.models.score.scores import AssessmentRound, ScoringSystem
 from pre_award.assessment_store.db.queries.assessment_records._helpers import derive_application_values
 from pre_award.config import Config
 from pre_award.db import db
@@ -451,3 +452,16 @@ def mark_application_with_requested_changes(application_id: str, field_ids: list
         application.status = ApplicationStatus.IN_PROGRESS
 
     db.session.commit()
+
+
+def get_application_scoring_system_name(app_id) -> str:
+    scoring_system_name = (
+        db.session.query(ScoringSystem.scoring_system_name)
+        .select_from(AssessmentRound)
+        .join(ScoringSystem, AssessmentRound.scoring_system_id == ScoringSystem.id)
+        .join(AssessmentRecord, AssessmentRecord.round_id == AssessmentRound.round_id)
+        .filter(AssessmentRecord.application_id == app_id)
+        .scalar()
+    )
+
+    return scoring_system_name.name

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -16,7 +16,10 @@ from fsd_utils.sqs_scheduler.context_aware_executor import ContextAwareExecutor
 from markupsafe import escape
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 
-from pre_award.application_store.db.queries.application.queries import mark_application_with_requested_changes
+from pre_award.application_store.db.queries.application.queries import (
+    get_application_scoring_system_name,
+    mark_application_with_requested_changes,
+)
 from pre_award.assess.assessments.activity_trail import (
     AssociatedTags,
     CheckboxForm,
@@ -1249,6 +1252,9 @@ def display_sub_criteria(
             )
         )
 
+    scoring_system_name = get_application_scoring_system_name(application_id)
+    is_zero_to_one_scoring = scoring_system_name == "ZeroToOne"
+
     common_template_config = {
         "sub_criteria": sub_criteria,
         "score": score[0] if score else None,
@@ -1267,6 +1273,7 @@ def display_sub_criteria(
         "flag_status": flag_status,
         "assessment_status": assessment_status,
         "pagination": state.get_pagination_from_sub_criteria_id(sub_criteria_id),
+        "is_zero_to_one_scoring": is_zero_to_one_scoring,
     }
 
     theme_answers_response = get_sub_criteria_theme_answers_all(application_id, theme_id)

--- a/pre_award/assess/assessments/templates/assessments/sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/sub_criteria.html
@@ -59,7 +59,7 @@ Error:
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-        {{ navbar(application_id, sub_criteria, current_theme.id) }}
+        {{ navbar(application_id=application_id, sub_criteria=sub_criteria, current_theme_id=current_theme.id, is_zero_to_one_scoring=is_zero_to_one_scoring) }}
     </div>
     <div class="theme govuk-grid-column-two-thirds">
         {% for change_request in change_requests %}

--- a/pre_award/assess/templates/assess/macros/sub_criteria_navbar.html
+++ b/pre_award/assess/templates/assess/macros/sub_criteria_navbar.html
@@ -1,4 +1,4 @@
-{% macro navbar(application_id, sub_criteria, current_theme_id, is_score_page=False) %}
+{% macro navbar(application_id, sub_criteria, current_theme_id, is_score_page=False, is_zero_to_one_scoring=False ) %}
 <nav class="assessment-navigation">
     <ul class="govuk-list">
         {% for theme in sub_criteria.themes %}
@@ -16,18 +16,18 @@
         {% endfor %}
     </ul>
 
-{% if g.access_controller.has_any_assessor_role and sub_criteria.is_scored %}
-    <ul class="govuk-list">
-        <li>
-            {% if not is_score_page %}
-            <a id="score-subcriteria-link" class="govuk-link govuk-link--no-visited-state" href="{{ url_for('scoring_bp.score',application_id=application_id,sub_criteria_id=sub_criteria.id) }}">
-            {% endif %}
-            Score the subcriteria
-            {% if not is_score_page %}
-            </a>
-            {% endif %}
-        </li>
-    </ul>
+{% if g.access_controller.has_any_assessor_role and sub_criteria.is_scored and not is_zero_to_one_scoring %}
+        <ul class="govuk-list">
+            <li>
+                {% if not is_score_page %}
+                <a id="score-subcriteria-link" class="govuk-link govuk-link--no-visited-state" href="{{ url_for('scoring_bp.score',application_id=application_id,sub_criteria_id=sub_criteria.id) }}">
+                {% endif %}
+                Score the subcriteria
+                {% if not is_score_page %}
+                </a>
+                {% endif %}
+            </li>
+        </ul>
 {% endif %}
 </nav>
 

--- a/tests/pre_award/assess_tests/conftest.py
+++ b/tests/pre_award/assess_tests/conftest.py
@@ -642,6 +642,10 @@ def mock_get_comments(mocker):
             return_value=mock_comments,
         ),
     )
+    mocker.patch(
+        "pre_award.assess.assessments.routes.get_application_scoring_system_name",
+        return_value="OneToFive",
+    )
     yield
 
 
@@ -651,6 +655,10 @@ def mock_get_scores(mocker):
     mocker.patch(
         "pre_award.assess.scoring.routes.get_score_and_justification",
         return_value=mock_scores,
+    )
+    mocker.patch(
+        "pre_award.assess.assessments.routes.get_application_scoring_system_name",
+        return_value="OneToFive",
     )
     yield
 


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-979

Description:
This removes the “Score the subcriteria” link if the Round’s ScoringSystem scoring_system_name == “ZeroToOne”.
Unit tests are updated.

### Screenshot WITH NOT ZeroToOne scoring system:
<img width="1495" alt="Screenshot 2025-02-07 at 13 21 44" src="https://github.com/user-attachments/assets/688d44e2-d449-465e-abcf-f978018010ba" />

### Screenshot WITH ZeroToOne scoring system:
<img width="1504" alt="Screenshot 2025-02-07 at 13 22 02" src="https://github.com/user-attachments/assets/151b19d6-617c-465c-8956-87a4f6740909" />
