### PR TITLE
Deployment pipeline tweaks

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -23,6 +23,11 @@ on:
         default: true
         type: boolean
         description: Run apply (node) e2e tests
+      run_e2e_tests_python:
+        required: false
+        default: true
+        type: boolean
+        description: Run python e2e tests
   push:
 
 jobs:
@@ -146,6 +151,9 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       alert_slack_on_failure: false
       notify_slack_on_deployment: false
+      run_e2e_tests_assessment: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_assessment }}
+      run_e2e_tests_application: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_application }}
+      run_e2e_tests_python: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_python }}
 
   test_deploy:
     needs: [ setup, unit_tests, type_checking, paketo_build ]
@@ -168,6 +176,9 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       alert_slack_on_failure: true
       notify_slack_on_deployment: false
+      run_e2e_tests_assessment: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_assessment }}
+      run_e2e_tests_application: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_application }}
+      run_e2e_tests_python: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_python }}
 
   uat_deploy:
     needs: [ setup, unit_tests, type_checking, paketo_build, test_deploy ]
@@ -190,6 +201,9 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       alert_slack_on_failure: true
       notify_slack_on_deployment: false
+      run_e2e_tests_assessment: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_assessment }}
+      run_e2e_tests_application: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_application }}
+      run_e2e_tests_python: false  # Never been turned on for UAT yet
 
   prod_deploy:
     needs: [ setup, unit_tests, type_checking, paketo_build, test_deploy, uat_deploy ]
@@ -212,3 +226,6 @@ jobs:
       image_location: ${{ needs.paketo_build.outputs.image_location }}
       alert_slack_on_failure: true
       notify_slack_on_deployment: true
+      run_e2e_tests_assessment: false
+      run_e2e_tests_application: false
+      run_e2e_tests_python: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,11 @@ on:
         default: true
         type: boolean
         description: Run apply (node) e2e tests
+      run_e2e_tests_python:
+        required: false
+        default: true
+        type: boolean
+        description: Run python e2e tests
     secrets:
       AWS_ACCOUNT:
         required: true
@@ -133,7 +138,7 @@ jobs:
     with:
       run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment }}
       run_e2e_tests_application: ${{ inputs.run_e2e_tests_application }}
-      run_e2e_tests_python: ${{ inputs.environment == 'dev' || inputs.environment == 'test' }}
+      run_e2e_tests_python: ${{ inputs.run_e2e_tests_python }}
       env_name: ${{ inputs.environment }}
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,25 +53,6 @@ on:
         required: false
 
 jobs:
-  notify_slack_start:
-    name: Notify Slack of deployment starting
-    if: ${{ inputs.notify_slack_on_deployment }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Slack message for start of deployment
-      id: slack_start_deployment_message
-      uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
-      with:
-        stage: 'start'
-        app_name: pre-award
-        environment: ${{ inputs.environment }}
-        workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-        slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
-    outputs:
-      slack_start_message_ts: ${{ steps.slack_start_deployment_message.slack_start_message_ts }}
-      deployment_start_ts: ${{ steps.slack_start_deployment_message.timestamp }}
-
   deploy:
     name: ${{ matrix.deployment }}
     strategy:
@@ -85,7 +66,22 @@ jobs:
       contents: read  # This is required for actions/checkout
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    outputs:
+      slack_start_message_ts: ${{ steps.slack_start_deployment_message.outputs.slack_start_message_ts }}
+      deployment_start_ts: ${{ steps.slack_start_deployment_message.outputs.timestamp }}
     steps:
+    - name: Slack message for start of deployment
+      id: slack_start_deployment_message
+      if: ${{ matrix.deployment == 'pre-award' && inputs.notify_slack_on_deployment }}
+      uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
+      with:
+        stage: 'start'
+        app_name: pre-award
+        environment: ${{ inputs.environment }}
+        workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
+
     - name: Git clone the repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -164,12 +160,12 @@ jobs:
 
   notify_slack_end:
     name: Notify Slack of deployment ending
-    needs: [ notify_slack_start, e2e_test ]
+    needs: [ deploy, e2e_test ]
     runs-on: ubuntu-latest
-    if: ${{ always() && inputs.notify_slack_on_deployment && needs.notify_slack_start.outcome == 'success' }}
+    if: ${{ always() && inputs.notify_slack_on_deployment && needs.deploy.result == 'success' }}
     steps:
-    - name: Slack message for start of deployment
-      id: slack_start_deployment_message
+    - name: Slack message for end of deployment
+      id: slack_end_deployment_message
       uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
       with:
         stage: 'end'
@@ -179,6 +175,6 @@ jobs:
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
 
-        status: "${{ ( needs.deploy.outcome == 'success' && needs.e2e_test.outcome == 'success') && 'success' || 'failed' }}"
-        slack_message_ts: ${{ needs.notify_slack_start.outputs.slack_start_message_ts }}
-        deployment_start_ts: ${{ needs.notify_slack_start.outputs.deployment_start_ts }}
+        status: "${{ ( needs.deploy.result == 'success' && needs.e2e_test.result == 'success') && 'success' || 'failed' }}"
+        slack_message_ts: ${{ needs.deploy.outputs.slack_start_message_ts }}
+        deployment_start_ts: ${{ needs.deploy.outputs.deployment_start_ts }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,56 +67,8 @@ jobs:
       slack_start_message_ts: ${{ steps.slack_start_deployment_message.slack_start_message_ts }}
       deployment_start_ts: ${{ steps.slack_start_deployment_message.timestamp }}
 
-
-  db_migrations:
-    name: Run DB migrations
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read  # This is required for actions/checkout
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    steps:
-    - name: Git clone the repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-    - name: Get current date
-      shell: bash
-      id: currentdatetime
-      run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-
-    - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
-      with:
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-        role-session-name: "pre-award_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
-        aws-region: eu-west-2
-
-    - name: Install AWS Copilot CLI
-      shell: bash
-      run: |
-        curl -Lo aws-copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x aws-copilot && sudo mv aws-copilot /usr/local/bin/copilot
-
-    - name: confirm copilot env
-      shell: bash
-      run: |
-        if [ $(copilot env ls) != "${{ inputs.environment }}" ]; then
-          echo $(copilot env ls)
-          exit 1
-        fi
-
-    - name: Update manifest
-      run: |
-        yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/fsd-pre-award/manifest.yml
-        yq -i ".image.location = \"${{ inputs.image_location }}\""  copilot/fsd-pre-award/manifest.yml
-        yq -i "del(.image.build)"  copilot/fsd-pre-award/manifest.yml
-
-    - name: Run database migrations
-      id: db_migrations
-      run: scripts/migration-task-script.py ${{ inputs.environment }} ${{ inputs.image_location }}
-
   deploy:
     name: ${{ matrix.deployment }}
-    needs: [ db_migrations ]
     strategy:
       fail-fast: false
       matrix:
@@ -163,6 +115,10 @@ jobs:
         yq -i ".image.location = \"${{ inputs.image_location }}\""  copilot/fsd-${{ matrix.deployment }}/manifest.yml
         yq -i "del(.image.build)"  copilot/fsd-${{ matrix.deployment }}/manifest.yml
 
+    - name: Run database migrations
+      if: ${{ matrix.deployment == 'pre-award' }}
+      run: scripts/migration-task-script.py ${{ inputs.environment }} ${{ inputs.image_location }}
+
     - name: Copilot ${{ inputs.environment }} deploy
       id: deploy_build
       run: |
@@ -188,8 +144,8 @@ jobs:
 
   alert_slack_on_failure:
     name: Alert Slack if deployment fails
-    needs: [ db_migrations, deploy, e2e_test ]
-    if: ${{ inputs.alert_slack_on_failure && always() && (needs.db_migrations.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
+    needs: [ deploy, e2e_test ]
+    if: ${{ inputs.alert_slack_on_failure && always() && (needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
     with:
       app_name: pre-award
@@ -203,7 +159,7 @@ jobs:
 
   notify_slack_end:
     name: Notify Slack of deployment ending
-    needs: [ notify_slack_start, db_migrations, e2e_test ]
+    needs: [ notify_slack_start, e2e_test ]
     runs-on: ubuntu-latest
     if: ${{ always() && inputs.notify_slack_on_deployment && needs.notify_slack_start.outcome == 'success' }}
     steps:
@@ -218,6 +174,6 @@ jobs:
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
 
-        status: "${{ ( (needs.db_migrations.outcome == 'skipped' || needs.db_migrations.outcome == 'success') && needs.deploy.outcome == 'success' && needs.e2e_test.outcome == 'success') && 'success' || 'failed' }}"
+        status: "${{ ( needs.deploy.outcome == 'success' && needs.e2e_test.outcome == 'success') && 'success' || 'failed' }}"
         slack_message_ts: ${{ needs.notify_slack_start.outputs.slack_start_message_ts }}
         deployment_start_ts: ${{ needs.notify_slack_start.outputs.deployment_start_ts }}


### PR DESCRIPTION
### Change description
Three changes:

1. Run DB migrations as part of the deployment job. This is so that, for envs that require manual approval, developers don't need to approve the db migration, wait, and approve the copilot deploy.
2. Make the e2e test runs respect flags set when manually dispatching a workflow.
3. Move slack deployment-started notification inside the pre-award deploy job, so that it doesn't happen before waiting for a manual env deployment approval.