### PR TITLE
Update applicant export feature

### DIFF
--- a/pre_award/assessment_store/api/routes/assessment_routes.py
+++ b/pre_award/assessment_store/api/routes/assessment_routes.py
@@ -325,17 +325,15 @@ def get_application_json(application_id):
 
 @assessment_assessment_bp.get("/application_fields_export/<fund_id>/<round_id>/<report_type>")
 def get_application_data_for_export(fund_id: str, round_id: str, report_type: str) -> List[Dict]:
-    """Fetch application data for applicant export, prioritizing round-specific data if available."""
+    """Fetch application data for export, prioritizing round-specific data if available."""
 
-    get_round = f"{fund_id}:{round_id}"
-
-    applicant_info = applicant_info_mapping.get(get_round, applicant_info_mapping.get(fund_id, {}))
+    round_data = applicant_info_mapping.get(f"{fund_id}:{round_id}") or applicant_info_mapping.get(fund_id, {})
 
     app_list = get_assessment_export_data(
         fund_id=fund_id,
         round_id=round_id,
         report_type=report_type,
-        list_of_fields=applicant_info,
+        list_of_fields=round_data,
     )
 
     return app_list

--- a/pre_award/assessment_store/api/routes/assessment_routes.py
+++ b/pre_award/assessment_store/api/routes/assessment_routes.py
@@ -325,11 +325,17 @@ def get_application_json(application_id):
 
 @assessment_assessment_bp.get("/application_fields_export/<fund_id>/<round_id>/<report_type>")
 def get_application_data_for_export(fund_id: str, round_id: str, report_type: str) -> List[Dict]:
+    """Fetch application data for applicant export, prioritizing round-specific data if available."""
+
+    get_round = f"{fund_id}:{round_id}"
+
+    applicant_info = applicant_info_mapping.get(get_round, applicant_info_mapping.get(fund_id, {}))
+
     app_list = get_assessment_export_data(
         fund_id=fund_id,
         round_id=round_id,
         report_type=report_type,
-        list_of_fields=applicant_info_mapping[fund_id],
+        list_of_fields=applicant_info,
     )
 
     return app_list

--- a/pre_award/assessment_store/config/mappings/assessment_mapping_fund_round.py
+++ b/pre_award/assessment_store/config/mappings/assessment_mapping_fund_round.py
@@ -1634,6 +1634,187 @@ applicant_info_mapping = {
         },
         "OUTPUT_TRACKER": {},
     },
+    f"{LPDF_FUND_ID}:{LPDF_ROUND_1_ID}": {
+        "ASSESSOR_EXPORT": {
+            "form_fields": {
+                "RoLhhf": {"en": {"title": "Local authority name", "field_type": "textField"}},
+                "sdrrOT": {"en": {"title": "Lead contact first name", "field_type": "textField"}},
+                "itKcJz": {"en": {"title": "Lead contact last name", "field_type": "textField"}},
+                "gswBOa": {"en": {"title": "Lead contact job title", "field_type": "textField"}},
+                "BkuACU": {"en": {"title": "Lead contact email address", "field_type": "textField"}},
+                "hRxtWX": {
+                    "en": {
+                        "title": "Is this expression of interest being submitted jointly with another local authority?",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "MhgGgD": {
+                    "en": {
+                        "title": "Tell us which local authorities you are submitting this joint expression of interest with",
+                        "field_type": "freeTextField",
+                    }
+                },
+                "csFGxz": {
+                    "en": {
+                        "title": "Do you have agreement from all of the local authorities involved in this joint expression of interest",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "OlCBjB": {
+                    "en": {
+                        "title": "Which local authority will act as the accountable body for the funding and monitoring?",
+                        "field_type": "textField",
+                    }
+                },
+                "WIOGzl": {"en": {"title": "Spending proposals", "field_type": "checkboxesField"}},
+                "cePdOW": {
+                    "en": {
+                        "title": "Tell us what other types of activities this funding will be used to support",
+                        "field_type": "textField",
+                    }
+                },
+                "ncrZUY": {"en": {"title": "Open Digital Planning", "field_type": "yesNoField"}},
+                "PdObhd": {
+                    "en": {
+                        "title": "I confirm our plan’s draft housing requirement meets less than 80% of our revised local housing need (as published on GOV.UK)",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "hsWqpW": {
+                    "en": {
+                        "title": "I confirm that we will need to revise our draft plan to reflect the revised NPPF and local housing need prior to submitting the document for examination",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "PnGUpK": {
+                    "en": {
+                        "title": "I confirm I anticipate submitting our plan by the deadline set out in the National Planning Policy Framework (by June or December 2026 as appropriate)",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "oYfyOJ": {
+                    "en": {
+                        "title": "I agree to respond to MHCLG’s requests to submit an updated local plan timetable (Local Development Scheme or LDS) to MHCLG within 12 weeks of the publication of the revised National Planning Policy Framework, and to provide regular updates on our progress against milestones",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "CTerDe": {
+                    "en": {
+                        "title": "I agree to collaborate with MHCLG over monitoring and evaluation requirements",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "uIGuiD": {
+                    "en": {
+                        "title": "I confirm our section 151 officer, or deputy section 151 officer, supports this submission",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "VtcHob": {
+                    "en": {
+                        "title": "I commit to have proposals in place by March 2025 on how we will spend the funding",
+                        "field_type": "yesNoField",
+                    }
+                },
+            },
+        },
+        "OUTPUT_TRACKER": {},
+    },
+    f"{LPDF_FUND_ID}:{LPDF_ROUND_2_ID}": {
+        "ASSESSOR_EXPORT": {
+            "form_fields": {
+                "RoLhhf": {"en": {"title": "Local authority name", "field_type": "textField"}},
+                "sdrrOT": {"en": {"title": "Lead contact name", "field_type": "textField"}},
+                "gswBOa": {"en": {"title": "Lead contact job title", "field_type": "textField"}},
+                "BkuACU": {"en": {"title": "Lead contact email address", "field_type": "textField"}},
+                "hRxtWX": {
+                    "en": {
+                        "title": "Is this expression of interest being submitted jointly with another local authority?",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "MhgGgD": {
+                    "en": {
+                        "title": "Tell us which local authorities you are submitting this joint expression of interest with",
+                        "field_type": "freeTextField",
+                    }
+                },
+                "csFGxz": {
+                    "en": {
+                        "title": "Do you have agreement from all of the local authorities involved in this joint expression of interest",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "OlCBjB": {
+                    "en": {
+                        "title": "Accountable local authority",
+                        "field_type": "textField",
+                    }
+                },
+                "WIOGzl": {
+                    "en": {
+                        "title": "Which types of activities will this funding be used to support?",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "cePdOW": {
+                    "en": {
+                        "title": "Tell us what other types of activities this funding will be used to support",
+                        "field_type": "textField",
+                    }
+                },
+                "ncrZUY": {
+                    "en": {
+                        "title": "Would you like to receive more information about the Open Digital Planning community and support to develop digital and data skills in your planning service?",
+                        "field_type": "yesNoField",
+                    }
+                },
+                "FLpMfV": {
+                    "en": {
+                        "title": "I confirm our emerging local plan is currently at Regulation 18 stage (as of 14 February 2025)",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "PnGUpK": {
+                    "en": {
+                        "title": "I confirm I will submit our plan by the deadline set out in the National Planning Policy Framework (by December 2026)",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "oYfyOJ": {
+                    "en": {
+                        "title": "I agree to respond to MHCLG\u2019s requests to submit an updated local plan timetable (Local Development Scheme or LDS) to MHCLG by 6 March 2025",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "KMcHcx": {
+                    "en": {
+                        "title": "I agree to provide regular updates on our progress against milestones",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "VtcHob": {
+                    "en": {
+                        "title": "I commit to have proposals in place by March 2025 on how we will spend the funding",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "CTerDe": {
+                    "en": {
+                        "title": "I agree to collaborate with MHCLG over monitoring and evaluation requirements",
+                        "field_type": "checkboxesField",
+                    }
+                },
+                "uIGuiD": {
+                    "en": {
+                        "title": "I confirm our section 151 officer, or deputy section 151 officer, supports this submission",
+                        "field_type": "checkboxesField",
+                    }
+                },
+            },
+        },
+        "OUTPUT_TRACKER": {},
+    },
 }
 
 # APPLICATION SEEDING CONFIGURATION

--- a/pre_award/assessment_store/db/queries/assessment_records/queries.py
+++ b/pre_award/assessment_store/db/queries/assessment_records/queries.py
@@ -736,7 +736,7 @@ def get_export_data(  # noqa: C901 - historical sadness
     assessment_metadatas: list,
     language: str,  # noqa
 ) -> List[Dict]:  # noqa
-    form_fields = list_of_fields[report_type].get("form_fields", {})
+    form_fields = list_of_fields.get(report_type, {}).get("form_fields", {})
     field_ids = form_fields.keys()
     final_list = []
 


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-983

This update allows to export applicant data based on both funds and rounds. If a round exists for a fund, it grabs the data for that round; if not, it falls back to the main fund data. This way, adding new rounds won’t impact the existing setup. We’ve also added a config for LPDF Round 2.
