### PR TITLE
Change default LOG_LEVEL

### DIFF
--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -26,7 +26,7 @@ class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent.parent)
 
     # Logging
-    FSD_LOG_LEVEL = logging.WARNING
+    FSD_LOG_LEVEL = logging.INFO
 
     # Database
     SQLALCHEMY_DATABASE_URI = environ.get(


### PR DESCRIPTION
INFO Log Levels are currently not being picked up by Cloudwatch.

Would be helpful if they were, rather than making non-warning level logs to be warning level.