### PR TITLE
This environment variable should https:// prefix

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -61,7 +61,7 @@ variables:
   APPLY_HOST: "frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   ASSESS_HOST: "assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   AUTH_HOST: "authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  AUTHENTICATOR_HOST: "authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
+  AUTHENTICATOR_HOST: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   FORM_DESIGNER_HOST: "https://form-designer.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   FORMS_SERVICE_PUBLIC_HOST: "https://forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"


### PR DESCRIPTION
It's confusing because we don't have good separation between variables that do/don't expect this prefix.

It did used to have this before, and this variable is used to inject the magic link into emails. Those are now missing https://.

This may be why the e2e tests are failing in that env now. But even if not - we should still fix this.

You can see further down the file that this env var does have the prefix.