### PR TITLE
Only display uploaded file that matches answer in Assess

### DIFF
--- a/pre_award/assess/assessments/models/applicants_response.py
+++ b/pre_award/assess/assessments/models/applicants_response.py
@@ -342,6 +342,7 @@ def _ui_component_from_factory(item: dict, application_id: str):  # noqa: C901
                 quoted=True,
             )
             for key in file_keys
+            if answer == key.split("/")[-1]
         }
         return QuestionAboveHrefAnswerList.from_dict(item, key_to_url_dict)
 


### PR DESCRIPTION
### Change description
This partially closes off a bug that only appears in the uncompeted journey.
Previous behaviour: display all files in the s3 bucket for that field
New behaviour: Only display the file that matches the filename present in the answer of the field. (In the uncompeted journey, there is a "staging" period whereby an applicant may have uploaded a new file but has not re-submitted. In this case the assessor will see 'Not provided' for a period, until resubmission occurs). 

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
