### PR TITLE
BAU: restore authenticator host override on production

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -216,6 +216,7 @@ environments:
       COOKIE_DOMAIN: ".access-funding.levellingup.gov.uk"
       APPLY_HOST: "frontend.access-funding.levellingup.gov.uk"
       ASSESS_HOST: "assessment.access-funding.levellingup.gov.uk"
+      AUTHENTICATOR_HOST: "https://authenticator.access-funding.levellingup.gov.uk"
       AUTH_HOST: "authenticator.access-funding.levellingup.gov.uk"
       API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local:8080"
       APPLICANT_FRONTEND_HOST: "https://frontend.access-funding.levellingup.gov.uk" # TODO: remove me when all frontends combined


### PR DESCRIPTION
### Change description
Fixes regression after #229 previously this was set by a secret, but needs to be overridden in prod.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Sign in link should work on production


### Screenshots of UI changes (if applicable)
