### PR TITLE
FS-5043 - Adding FAB-specific error content in Authenticator when user is missing required role

### DIFF
--- a/pre_award/authenticator/frontend/templates/authenticator/user/user.html
+++ b/pre_award/authenticator/frontend/templates/authenticator/user/user.html
@@ -3,43 +3,42 @@
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 {% block content %}
-<div>
-    <h1 class="govuk-heading-xl">Apply for Funding</h1>
-</div>
-<div>
+   {% if source_app == "fund-application-builder" %}
+       <h1 class="govuk-heading-xl">You do not have access to this service</h1>
+       <p class="govuk-body">Your account does not have the right permission to access this service.</p>
+       <p class="govuk-body">Contact us through the <a href="{{ support_desk_assess }}" target="_blank">service desk</a> to request access.</p>
+   {% else %}
+       <h1 class="govuk-heading-xl">Apply for Funding</h1>
+       <div>
+           {% if roles_required %}
+               <p class="govuk-body">You do not have access as your account does not have the right permissions set up.</p>
+               <p class="govuk-body">Please contact us through our support desk portal <a href="{{ support_desk_assess }}" target="_blank">here</a> to request access or get help if you think this is a mistake.</p>
+           {% else %}
+               {% if logged_in_user %}
+                   <p class="govuk-body">
+                       You are currently logged in as:
+                       {% if logged_in_user.full_name %}
+                           <br /><strong>{{ logged_in_user.full_name }}</strong>
+                           <br /><i>({{ logged_in_user.email }})</i>
+                       {% else %}
+                           <br /><strong>{{ logged_in_user.email }}</strong>
+                       {% endif %}
+                   </p>
+                   {{ govukButton({
+                       "isStartButton": false,
+                       "href" : logout_url,
+                       "text": "Sign out"
+                   }) }}
+               {% else %}
+                   <p class="govuk-body">You are not logged in.</p>
 
-    {% if roles_required %}
-    <p class="govuk-body">You do not have access as your account does not have the right permissions set up.
-    <p class="govuk-body">Please contact us through our support desk portal <a href="{{ support_desk_assess }}"
-            target="_blank">here</a> to request access or get help if you think this is a mistake.</p>
-    </p>
-    {% else %}
-
-    {% if logged_in_user %}
-    <p class="govuk-body">
-        You are currently logged in as:
-        {% if logged_in_user.full_name %}
-        <br /><strong>{{ logged_in_user.full_name }}</strong>
-        <br /><i>({{ logged_in_user.email }})</i>
-        {% else %}
-        <br /><strong>{{ logged_in_user.email }}</strong>
-        {% endif %}
-    </p>
-    {{ govukButton({
-    "isStartButton": false,
-    "href" : logout_url,
-    "text": "Sign out"
-    }) }}
-    {% else %}
-    <p class="govuk-body">You are not logged in.</p>
-
-    {{ govukButton({
-    "isStartButton": false,
-    "href" : login_url,
-    "text": "Sign in"
-    }) }}
-    {% endif %}
-
-    {% endif %}
-</div>
+                   {{ govukButton({
+                       "isStartButton": false,
+                       "href" : login_url,
+                       "text": "Sign in"
+                   }) }}
+               {% endif %}
+           {% endif %}
+       </div>
+   {% endif %}
 {% endblock content %}

--- a/pre_award/authenticator/frontend/user/routes.py
+++ b/pre_award/authenticator/frontend/user/routes.py
@@ -20,11 +20,12 @@ def user():
     with roles_required, logged_in_user and login/
     logout urls.
     Query Args:
-       - roles_required: List[str] is set by checking if
-         logged_in_user
+       - roles_required: List[str] is set by checking if logged_in_user has all roles required
+       - source_app: SupportedApp is set by the app that is requesting the user page
     """
     status_code = 200
     roles_required = request.args.get("roles_required")
+    source_app = request.args.get("source_app")
     logged_in_user = g.user if g.is_authenticated else None
     if logged_in_user:
         if roles_required:
@@ -42,6 +43,7 @@ def user():
             login_url=url_for("api_sso.login"),
             logout_url=url_for("api_sso.logout"),
             support_desk_assess=Config.SUPPORT_DESK_ASSESS,
+            source_app=source_app,
         ),
         status_code,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "sqlalchemy[mypy]==2.0.38",
     "xhtml2pdf==0.2.17",
     "notifications-python-client==10.0.1",
-    "funding-service-design-utils[toggles]==6.0.2",
+    "funding-service-design-utils[toggles]==6.1.0",
 ]
 
 [tool.djlint]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = "==3.10.*"
 resolution-markers = [
     "platform_python_implementation != 'PyPy'",
@@ -151,7 +150,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "urllib3", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/4b/096b2fac3ba92ace94f69f238eea9948af568b487c3898e9a8881bfe506b/botocore-1.37.7.tar.gz", hash = "sha256:2faeac11766db912bc444669b04359080b7b83b2f57a3906c77c8105b70ce1e8", size = 13627744 }
 wheels = [
@@ -215,11 +214,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.0"
+version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524 },
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080 },
 ]
 
 [[package]]
@@ -301,7 +300,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -469,7 +468,7 @@ version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/ee/96c65e17222b973f0d3d0aa9bad6a59104ca1b0eb5b659c25c2900fccd85/dparse-0.6.4.tar.gz", hash = "sha256:90b29c39e3edc36c6284c82c4132648eaf28a01863eb3c231c2512196132201a", size = 27912 }
 wheels = [
@@ -756,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "6.0.2"
+version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -777,9 +776,9 @@ dependencies = [
     { name = "sentry-sdk", extra = ["flask"] },
     { name = "sqlalchemy-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/d7/44f9256ec686bbcd24cb92e7f1d9b5c512a7cda669d6a30e09ef7d203dd9/funding_service_design_utils-6.0.2.tar.gz", hash = "sha256:23c94a220a21582745baa8c0ae124d423f7774ddb6382d1024cebaee13af2872", size = 67669 }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/a4/85d0fa3a958027d1b61131f3a9c34913c6159814c55a8f8001b5abf3f5ba/funding_service_design_utils-6.1.0.tar.gz", hash = "sha256:bef1f66e0d3a4e6a6aa383668ac01c7dfa7d9a4ad42a7d1954b0c227794cd632", size = 67990 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/d5/2b5ed168f1aac1ce578ab7f50561fabe73716ab021a252eaa957232cd0fa/funding_service_design_utils-6.0.2-py3-none-any.whl", hash = "sha256:bdf607b209f16a0db6efc72107e11d604a589bff031e5530c52084a71511b2e1", size = 81399 },
+    { url = "https://files.pythonhosted.org/packages/ef/b0/35b714680499a62498a7b3a11ed2fcfb6a95fd029402ccd18953855e3e1d/funding_service_design_utils-6.1.0-py3-none-any.whl", hash = "sha256:223fd5b700e9459946e414084677812a66d806b9f8a52500f0523b9a3c3a324b", size = 81655 },
 ]
 
 [package.optional-dependencies]
@@ -900,7 +899,7 @@ requires-dist = [
     { name = "flask-sqlalchemy", specifier = "==3.1.1" },
     { name = "flask-talisman", specifier = "==1.1.0" },
     { name = "flask-wtf", specifier = "==1.2.2" },
-    { name = "funding-service-design-utils", extras = ["toggles"], specifier = "==6.0.2" },
+    { name = "funding-service-design-utils", extras = ["toggles"], specifier = "==6.1.0" },
     { name = "govuk-frontend-jinja", specifier = "==2.8.0" },
     { name = "greenlet", specifier = "==3.1.1" },
     { name = "gunicorn", extras = ["gevent"], specifier = "==23.0.0" },
@@ -1393,7 +1392,7 @@ version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
@@ -1548,7 +1547,7 @@ name = "pandas"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version == '3.10.*'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -1786,7 +1785,7 @@ name = "pypdf"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/9a/72d74f05f64895ebf1c7f6646cf7fe6dd124398c5c49240093f92d6f0fdd/pypdf-5.1.0.tar.gz", hash = "sha256:425a129abb1614183fd1aca6982f650b47f8026867c0ce7c4b9f281c443d2740", size = 5011381 }
 wheels = [
@@ -1799,11 +1798,11 @@ version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
@@ -1816,7 +1815,7 @@ version = "1.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911 }
 wheels = [
@@ -2030,7 +2029,7 @@ name = "redis"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout" },
+    { name = "async-timeout", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/88/63d802c2b18dd9eaa5b846cbf18917c6b2882f20efda398cc16a7500b02c/redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d", size = 4561721 }
 wheels = [
@@ -2123,7 +2122,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
@@ -2168,7 +2167,7 @@ name = "ruamel-yaml"
 version = "0.18.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython' and python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/81/4dfc17eb6ebb1aac314a3eb863c1325b907863a1b8b1382cdffcb6ac0ed9/ruamel.yaml-0.18.6.tar.gz", hash = "sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b", size = 143362 }
 wheels = [
@@ -2296,7 +2295,7 @@ name = "sqlalchemy"
 version = "2.0.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "(platform_machine == 'AMD64' and python_full_version == '3.10.*') or (platform_machine == 'WIN32' and python_full_version == '3.10.*') or (platform_machine == 'aarch64' and python_full_version == '3.10.*') or (platform_machine == 'amd64' and python_full_version == '3.10.*') or (platform_machine == 'ppc64le' and python_full_version == '3.10.*') or (platform_machine == 'win32' and python_full_version == '3.10.*') or (platform_machine == 'x86_64' and python_full_version == '3.10.*')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/08/9a90962ea72acd532bda71249a626344d855c4032603924b1b547694b837/sqlalchemy-2.0.38.tar.gz", hash = "sha256:e5a4d82bdb4bf1ac1285a68eab02d253ab73355d9f0fe725a97e1e0fa689decb", size = 9634782 }
@@ -2508,7 +2507,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [


### PR DESCRIPTION
### Ticket

[Appropriate Authenticator content for FAB users when missing role](https://mhclgdigital.atlassian.net/browse/FS-5043)

### Description

We need to add role-based authentication to FAB, as per TDA requirements for FAB moving into production. With the current implementation of the `login_required` decorator from this funding-service-design-utils library, if the user is missing the required role, they get sent to a page that looks like this:

![image](https://github.com/user-attachments/assets/f39404b1-dd9a-49ce-bf5c-afb598a44e7d)

As you can see, the content doesn't make sense from the perspective of a FAB user.

To fix, we are going to begin passing a new `source_app` query parameter via the `_failed_role_redirect` function in fsd-utils - see [PR here](https://github.com/communitiesuk/funding-service-design-utils/pull/222). Then, in the Authenticator, we need to respond to this query parameter, conditionally rendering FAB-appropriate content. This PR handles that.

### How to test

Spin up the apps locally (see [Docker Runner](https://github.com/communitiesuk/funding-service-design-docker-runner)) and hit the endpoint `https://authenticator.levellingup.gov.localhost:4004/service/user?roles_required=FSD_ADMIN&source_app=fund-application-builder` - you should see the following content:

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/4722a776-e58f-4e50-9f39-f27dd3a249ed" />

Meanwhile if you hit the same endpoint but without the `source_app` parameter, or with `source_app` set to something different to `fund-application-builder`, you'll see the original content:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/b4653072-903b-42e0-98cd-e3c2269ed7b8" />