### PR TITLE
Flip sentry sampling rate

### DIFF
--- a/copilot/fsd-pre-award-application-deadline-reminders/manifest.yml
+++ b/copilot/fsd-pre-award-application-deadline-reminders/manifest.yml
@@ -26,7 +26,7 @@ variables:
   AWS_BUCKET_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  SENTRY_TRACES_SAMPLE_RATE: 1.0
+  SENTRY_TRACES_SAMPLE_RATE: 0.02
   API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"
 
   ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
@@ -78,4 +78,4 @@ environments:
       FORMS_SERVICE_PUBLIC_HOST: "https://forms.access-funding.levellingup.gov.uk"
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.levellingup.gov.uk"
       POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.levellingup.gov.uk"
-      SENTRY_TRACES_SAMPLE_RATE: 0.02
+      SENTRY_TRACES_SAMPLE_RATE: 1

--- a/copilot/fsd-pre-award-send-application-assessment-report/manifest.yml
+++ b/copilot/fsd-pre-award-send-application-assessment-report/manifest.yml
@@ -26,7 +26,7 @@ variables:
   AWS_BUCKET_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  SENTRY_TRACES_SAMPLE_RATE: 1.0
+  SENTRY_TRACES_SAMPLE_RATE: 0.02
   API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"
 
   ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
@@ -80,4 +80,4 @@ environments:
       FORMS_SERVICE_PUBLIC_HOST: "https://forms.access-funding.levellingup.gov.uk"
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.levellingup.gov.uk"
       POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.levellingup.gov.uk"
-      SENTRY_TRACES_SAMPLE_RATE: 0.02
+      SENTRY_TRACES_SAMPLE_RATE: 1

--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -53,7 +53,7 @@ variables:
   AWS_BUCKET_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  SENTRY_TRACES_SAMPLE_RATE: 0.5
+  SENTRY_TRACES_SAMPLE_RATE: 0.02
   API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"
 
   ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
@@ -270,4 +270,4 @@ environments:
       FORMS_SERVICE_PUBLIC_HOST: "https://forms.access-funding.levellingup.gov.uk"
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.levellingup.gov.uk"
       POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.levellingup.gov.uk"
-      SENTRY_TRACES_SAMPLE_RATE: 0.02
+      SENTRY_TRACES_SAMPLE_RATE: 1


### PR DESCRIPTION
I originally set sentry to sample traces at high volume in dev/test/uat, but because of our regular e2e tests (and because we have a low allowance for spans) we're using up our allowance regularly, leading to gaps in our monitoring+observability.

I also don't think many of our team currently use sentry span insights in dev/test/uat in the way I'd intended, so spending our allowance here feels less useful.

Let's monitor prod at 100%, because those are likely to provide more realistic insights (and if there are errors, more information to help debug). The volume there is also significantly lower, so we should not have to worry about hitting our allowances.