### PR TITLE
FSPT-228: switch over UAT to communities hostname

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -48,6 +48,19 @@ network:
 # Optional fields for more advanced use-cases.
 # Pass environment variables as key value pairs.
 variables:
+  ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
+  COOKIE_DOMAIN: ".access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  ASSESS_HOST: "assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  ASSESSMENT_FRONTEND_HOST: "https://assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  APPLICANT_FRONTEND_HOST: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  APPLY_HOST: "apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  AUTH_HOST: "account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  AUTHENTICATOR_HOST: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  FORM_DESIGNER_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
   SENTRY_DSN: "https://80c7f65b54f0eff535777a66b375adf0@o1432034.ingest.us.sentry.io/4508324370317312"
   AWS_BUCKET_NAME:
@@ -56,17 +69,6 @@ variables:
   SENTRY_TRACES_SAMPLE_RATE: 0.02
   API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"
 
-  ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
-  APPLICANT_FRONTEND_HOST: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk" # TODO: remove me when all frontends combined
-  APPLY_HOST: "frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  ASSESS_HOST: "assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  AUTH_HOST: "authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  AUTHENTICATOR_HOST: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  FORM_DESIGNER_HOST: "https://form-designer.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  FORMS_SERVICE_PUBLIC_HOST: "https://forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   COPILOT_AWS_BUCKET_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
   REDIS_INSTANCE_URI:
@@ -95,18 +97,6 @@ environments:
   dev:
     variables:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
-      COOKIE_DOMAIN: ".access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      ASSESS_HOST: "assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      ASSESSMENT_FRONTEND_HOST: "https://assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      APPLICANT_FRONTEND_HOST: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      APPLY_HOST: "apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      AUTH_HOST: "account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      AUTHENTICATOR_HOST: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      FORM_DESIGNER_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
     count:
       spot: 2
     sidecars:
@@ -142,18 +132,6 @@ environments:
   test:
     variables:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
-      COOKIE_DOMAIN: ".access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      ASSESS_HOST: "assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      ASSESSMENT_FRONTEND_HOST: "https://assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      APPLICANT_FRONTEND_HOST: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      APPLY_HOST: "apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      AUTH_HOST: "account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      AUTHENTICATOR_HOST: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      FORM_DESIGNER_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-      POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
     count:
       spot: 2
     sidecars:
@@ -190,7 +168,6 @@ environments:
   uat:
     variables:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
-      COOKIE_DOMAIN: ".uat.access-funding.test.levellingup.gov.uk"
     count:
       range: 2-4
       cooldown:


### PR DESCRIPTION
### Change description
switches over UAT to communities hostname through environment variable changes.

We can consolidate environment variables as part of this as dev, test and UAT should share config now

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Post deployment services should resolve at `uat.communities.gov.uk` URLs


### Screenshots of UI changes (if applicable)
