### PR TITLE
Send incomplete applications emails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,8 @@ jobs:
             command: job
           - deployment: pre-award-send-application-assessment-report
             command: job
+          - deployment: pre-award-send-incomplete-applications-emails
+            command: job
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout

--- a/apply/tasks.py
+++ b/apply/tasks.py
@@ -7,8 +7,15 @@ from invoke import Context, task  # type: ignore[attr-defined]
 from app import create_app
 from data.crud.accounts import get_account
 from data.crud.applications import get_applications_for_round_by_status
-from data.crud.fund_round_queries import get_rounds_for_application_deadline_reminders, set_application_reminder_sent
+from data.crud.fund_round_queries import (
+    create_event,
+    get_rounds_for_application_deadline_reminders,
+    get_rounds_with_passed_deadline,
+    set_application_reminder_sent,
+)
 from pre_award.application_store.db.models.application.enums import Status
+from pre_award.application_store.db.queries.application.queries import create_qa_base64file, get_application
+from pre_award.fund_store.db.models.event import EventType
 from services.notify import NotificationError, get_notification_service
 
 
@@ -70,3 +77,51 @@ def send_application_deadline_reminders(c: Context) -> None:
     app = create_app()
     with app.app_context():
         send_application_deadline_reminders_impl()
+
+
+def send_incomplete_application_emails_impl() -> None:
+    rounds_with_passed_deadline = get_rounds_with_passed_deadline()
+    incomplete_statuses = [Status.NOT_STARTED, Status.IN_PROGRESS, Status.COMPLETED]
+
+    for round in rounds_with_passed_deadline:
+        applications = get_applications_for_round_by_status(round.id, incomplete_statuses)
+
+        for application in applications:
+            application_with_form_json = get_application(application.id, as_json=True, include_forms=True)
+
+            try:
+                account_id = str(application.account_id)
+                account = get_account(account_id)
+                if not account:
+                    continue
+
+                application_data = create_qa_base64file(application_with_form_json, True)
+
+                notification = get_notification_service().send_unsubmitted_application_email(
+                    email_address=account.email,
+                    application_reference=str(application.reference),
+                    fund_name=round.fund.name_json["en"],
+                    round_name=round.title_json["en"],
+                    application_data=application_data,
+                    contact_help_email=round.contact_email,
+                )
+                current_app.logger.info(
+                    "Sent incomplete application notification %(notification_id)s to %(account_id)s",
+                    dict(notification_id=notification.id, account_id=account_id),
+                )
+            except NotificationError:
+                current_app.logger.exception(
+                    (
+                        "Error sending incomplete application notification to %(account_id)s "
+                        "for fund_id=%(fund_id)s round=%(round_id)s]"
+                    ),
+                    dict(account_id=account_id, fund_id=round.fund_id, round_id=round.id),
+                )
+        create_event(round.id, EventType.SEND_INCOMPLETE_APPLICATIONS, datetime.now(), True)
+
+
+@task
+def send_incomplete_application_emails(c: Context) -> None:
+    app = create_app()
+    with app.app_context():
+        send_incomplete_application_emails_impl()

--- a/copilot/fsd-pre-award-send-incomplete-applications-emails/manifest.yml
+++ b/copilot/fsd-pre-award-send-incomplete-applications-emails/manifest.yml
@@ -1,0 +1,81 @@
+name: fsd-pre-award-send-incomplete-applications-emails
+type: Scheduled Job
+
+on:
+  schedule: "cron(30 9 * * ? *)"
+retries: 0
+timeout: 10m
+
+# We inject `image.location` in our deployment pipeline
+image: {}
+entrypoint: launcher
+command: invoke apply.send-incomplete-application-emails
+
+cpu: 256
+memory: 512
+platform: linux/x86_64
+
+network:
+  vpc:
+    security_groups:
+      - from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-fsdpreawardstoresclusterSecurityGroup
+
+variables:
+  FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
+  SENTRY_DSN: "https://80c7f65b54f0eff535777a66b375adf0@o1432034.ingest.us.sentry.io/4508324370317312"
+  AWS_BUCKET_NAME:
+    from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
+  ASSESSMENT_FRONTEND_HOST: "https://assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  SENTRY_TRACES_SAMPLE_RATE: 0.02
+  API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"
+
+  ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
+  APPLICANT_FRONTEND_HOST: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk" # TODO: remove me when all frontends combined
+  APPLY_HOST: "apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  ASSESS_HOST: "assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  AUTH_HOST: "account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  COOKIE_DOMAIN: ".access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  FORM_DESIGNER_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+  COPILOT_AWS_BUCKET_NAME:
+    from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
+  REDIS_INSTANCE_URI:
+    from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-MagicLinksRedisInstanceURI
+
+secrets:
+  FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FSD_PRE_AWARD_FUND_STORE_API_HOST
+  ACCOUNT_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FSD_PRE_AWARD_ACCOUNT_STORE_API_HOST
+  APPLICATION_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FSD_PRE_AWARD_APPLICATION_STORE_API_HOST
+  ASSESSMENT_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FSD_PRE_AWARD_ASSESSMENT_STORE_API_HOST
+  SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
+  PREAWARD_DB_SECRET:
+    from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-fsdpreawardstoresclusterAuroraSecret
+  AUTHENTICATOR_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AUTHENTICATOR_HOST
+  AZURE_AD_CLIENT_ID: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AZURE_AD_CLIENT_ID
+  AZURE_AD_CLIENT_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AZURE_AD_CLIENT_SECRET
+  AZURE_AD_TENANT_ID: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AZURE_AD_TENANT_ID
+  MAINTENANCE_MODE: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FSD_FRONTEND_MAINTENANCE_MODE
+  MAINTENANCE_END_TIME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FSD_FRONTEND_MAINTENANCE_END_TIME
+  RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PUBLIC_KEY_BASE64
+  RSA256_PRIVATE_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PRIVATE_KEY_BASE64
+  GOV_NOTIFY_API_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/GOV_NOTIFY_API_KEY
+
+environments:
+  prod:
+    variables:
+      FLASK_ENV: production
+      ASSESSMENT_FRONTEND_HOST: "https://assess.access-funding.communities.gov.uk"
+      ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
+      COOKIE_DOMAIN: ".access-funding.communities.gov.uk"
+      APPLY_HOST: "apply.access-funding.communities.gov.uk"
+      ASSESS_HOST: "assess.access-funding.communities.gov.uk"
+      AUTH_HOST: "account.access-funding.communities.gov.uk"
+      API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local:8080"
+      APPLICANT_FRONTEND_HOST: "https://apply.access-funding.communities.gov.uk" # TODO: remove me when all frontends combined
+      FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.communities.gov.uk"
+      POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.communities.gov.uk"
+      POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.communities.gov.uk"
+      SENTRY_TRACES_SAMPLE_RATE: 1

--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -486,6 +486,37 @@ class NotificationService:
             },
         )
 
+    def send_unsubmitted_application_email(
+        self,
+        email_address: str,
+        application_reference: str,
+        fund_name: str,
+        round_name: str,
+        contact_help_email: str | None,
+        application_data: dict[str, Any],
+        govuk_notify_reference: str | None = None,
+    ) -> Notification:
+        questions = application_data.get("questions_file")
+
+        return self._send_email(
+            email_address,
+            self.APPLICATION_INCOMPLETE_TEMPLATE_ID,
+            personalisation={
+                "name of fund": fund_name,
+                "round name": round_name,
+                "application reference": application_reference,
+                "question": {
+                    "file": questions,
+                    "filename": None,
+                    "confirm_email_before_download": None,
+                    "retention_period": None,
+                },
+                "contact email": contact_help_email,
+            },
+            govuk_notify_reference=govuk_notify_reference,
+            email_reply_to_id=self.REPLY_TO_EMAILS_WITH_NOTIFY_ID.get(contact_help_email),  # type: ignore[arg-type]
+        )
+
 
 def get_notification_service() -> NotificationService:
     return cast(NotificationService, current_app.extensions["notification_service"])


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net/browse/FLS-1045

Description:
Once a fund round closes, we want to send an email to applicants with unsubmitted applications the questions and their answers.

How to test locally:
1. Create an application (possibly not a CTDF one, because it has only two criteria, but some other which has more)
2. Fill in a few subcriteria, but don't submit it.
3. Change the deadline of the round to a past date (but not more than a month).
4. Open a terminal inside the docker container:   `docker exec -it $(docker ps -qf name="funding-service-pre-award") bash`
5. Run the function:  `invoke apply.send-incomplete-application-emails`
6. You'll probably want to run it more than once, in this case you'll have to delete the event instance from the database, which has been created for the round, when running the function (otherwise it won't send the email the next time you run the function, because there is already an event created for the round, which means that the emails have already been sent.
7. Depending on your local Notify key, the email is either actually sent to the email address, or can be seen on Notify.


Screenshot of the email sent:
<img width="681" alt="Screenshot 2025-04-16 at 10 31 16" src="https://github.com/user-attachments/assets/24fd82c9-9447-47d9-97bd-efa7f0eb3ade" />

Next page:
<img width="525" alt="Screenshot 2025-04-16 at 10 31 30" src="https://github.com/user-attachments/assets/1bc61ebf-c954-44a0-a807-19baf984b897" />

Confirming the email address:
<img width="709" alt="Screenshot 2025-04-16 at 10 31 41" src="https://github.com/user-attachments/assets/6f295a59-b279-44e6-a9fe-0eaffd8daf50" />

Next page (lets the user know that the file will be available for 6 months):
<img width="705" alt="Screenshot 2025-04-16 at 10 31 53" src="https://github.com/user-attachments/assets/0c0614cc-1cb4-42bb-a635-24d93598705e" />

Screenshot of the downloaded file:
![Screenshot 2025-04-16 at 10 32 44](https://github.com/user-attachments/assets/eed531b4-8904-476c-9314-8de2a59bb14c)


