### PR TITLE
Add is_resubmission to metadata

### DIFF
--- a/pre_award/apply/default/application_routes.py
+++ b/pre_award/apply/default/application_routes.py
@@ -413,6 +413,7 @@ def continue_application(application_id):
 
     form_data = application.get_form_data(application, form_name)
     change_requests = prepare_change_requests_metadata(application_id)
+    is_resubmission = application.date_submitted != "null"
 
     rehydrate_payload = format_rehydrate_payload(
         form_data=form_data,
@@ -424,6 +425,7 @@ def continue_application(application_id):
         fund_name=fund.short_name,
         round_name=round.short_name,
         change_requests=change_requests,
+        is_resubmission=is_resubmission,
     )
 
     rehydration_token = get_token_to_return_to_application(form_name, rehydrate_payload)

--- a/pre_award/apply/helpers.py
+++ b/pre_award/apply/helpers.py
@@ -80,6 +80,7 @@ def format_rehydrate_payload(
     has_eligibility=False,
     round_close_notification_url=None,
     change_requests=None,
+    is_resubmission=False,
 ):
     """
     Returns information in a JSON format that provides the
@@ -153,6 +154,7 @@ def format_rehydrate_payload(
     formatted_data["metadata"]["round_name"] = round_name
     formatted_data["metadata"]["has_eligibility"] = has_eligibility
     formatted_data["metadata"]["change_requests"] = form_change_requests
+    formatted_data["metadata"]["is_resubmission"] = is_resubmission
 
     if round_close_notification_url is not None:
         formatted_data["metadata"]["round_close_notification_url"] = round_close_notification_url

--- a/tests/pre_award/apply_tests/test_helpers.py
+++ b/tests/pre_award/apply_tests/test_helpers.py
@@ -134,3 +134,17 @@ def test_format_rehydrate_payload_test_all_change_requests_filtered_out(app: Fla
     )
 
     assert formatted_data["metadata"]["change_requests"] is None
+
+
+def test_format_rehydrate_payload_test_adds_is_resubmission(app: Flask) -> None:
+    formatted_data = format_rehydrate_payload(
+        form_data={},
+        application_id="abc",
+        returnUrl="https://test.test",
+        form_name="test_form",
+        markAsCompleteEnabled=True,
+        change_requests=None,
+        is_resubmission=True,
+    )
+
+    assert formatted_data["metadata"]["is_resubmission"] is True


### PR DESCRIPTION
Add is_resubmission to metadata.

We need to display a tag on form pages that don't have change requests. 
The absence of change requests is not enough to determine if the form filled in is being submitted for the 1st time ever or not.

So adding this boolean to help with it.