### PR TITLE
FLS-1075 Label applicant changes in sub-criteria

### DIFF
--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -276,8 +276,10 @@ def update_application_fields(existing_json_blob, new_json_blob, change_request_
             changed_fields.add(key)
             # Update history_log using the helper function.
             field["history_log"] = update_field_history(existing_fields.get(key, {}))
-            if field["key"] not in change_request_fields:
-                field["flag_for_assessor"] = True
+            if field["key"] in change_request_fields:
+                field["requested_change"] = True
+            else:
+                field["unrequested_change"] = True
 
     return changed_fields
 

--- a/pre_award/assess/assessments/models/applicants_response.py
+++ b/pre_award/assess/assessments/models/applicants_response.py
@@ -60,7 +60,7 @@ class QuestionAnswerPair(ApplicantResponseComponent, ABC):
         return cls(
             question=data["question"],
             answer=answer if answer else ANSWER_NOT_PROVIDED_DEFAULT,
-            field_id=data.get("field_id"),
+            field_id=_flatten_field_ids(data.get("field_id")),
             label=_get_response_label(data),
         )
 
@@ -88,7 +88,7 @@ class QuestionAnswerPairHref(QuestionAnswerPair, ABC):
             question=data["question"],
             answer=answer if answer else ANSWER_NOT_PROVIDED_DEFAULT,
             answer_href=href if answer else None,
-            field_id=data.get("field_id"),
+            field_id=_flatten_field_ids(data.get("field_id")),
             label=_get_response_label(data),
         )
 
@@ -113,7 +113,7 @@ class FormattedBesideQuestionAnswerPair(QuestionAnswerPair):
             question=data["question"],
             answer=(data.get("answer") if data.get("answer") else ANSWER_NOT_PROVIDED_DEFAULT),
             formatter=formatter if data.get("answer") else lambda x: x,
-            field_id=data.get("field_id"),
+            field_id=_flatten_field_ids(data.get("field_id")),
             label=_get_response_label(data),
         )
 
@@ -137,7 +137,7 @@ class MonetaryKeyValues(ApplicantResponseComponent):
             return AboveQuestionAnswerPair(
                 question=question,
                 answer=ANSWER_NOT_PROVIDED_DEFAULT,
-                field_id=data.get("field_id"),
+                field_id=_flatten_field_ids(data.get("field_id")),
                 label=_get_response_label(data),
             )
 
@@ -146,7 +146,7 @@ class MonetaryKeyValues(ApplicantResponseComponent):
             column_description=question,
             question_answer_pairs=[(desc, float(amt)) for desc, amt in data["answer"]],
             total=sum([float(amt) for _, amt in data["answer"]]),
-            field_id=data.get("field_id"),
+            field_id=_flatten_field_ids(data.get("field_id")),
             label=_get_response_label(data),
         )
 
@@ -165,7 +165,7 @@ class QuestionAboveHrefAnswerList(ApplicantResponseComponent):
         return cls(
             question=data["question"],
             key_to_url_dict=key_to_url_dict,
-            field_id=data.get("field_id"),
+            field_id=_flatten_field_ids(data.get("field_id")),
             label=_get_response_label(data),
         )
 
@@ -226,7 +226,7 @@ class NewAddAnotherTable(ApplicantResponseComponent):
             caption=data["question"],
             head=headings,
             rows=rows,
-            field_id=data.get("field_id"),
+            field_id=_flatten_field_ids(data.get("field_id")),
             label=_get_response_label(data),
         )
 

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1264,6 +1264,13 @@ def display_sub_criteria(
         )
 
     theme_answers_response = get_sub_criteria_theme_answers_all(application_id, theme_id)
+
+    # If the sub-criteria has been accepted, no need to label changed answers
+    if score:
+        for theme_answer in theme_answers_response:
+            theme_answer.pop("unrequested_change", None)
+            theme_answer.pop("requested_change", None)
+
     answers_meta = applicants_response.create_ui_components(theme_answers_response, application_id)
 
     common_template_config = {

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1273,9 +1273,7 @@ def display_sub_criteria(
         "application_id": application_id,
         "comments": theme_matched_comments,
         "change_requests": sub_criteria_change_requests,
-        "unrequested_changes": [
-            theme["question"] for theme in theme_answers_response if theme.get("flag_for_assessor")
-        ],
+        "unrequested_changes": any(theme.get("unrequested_change") for theme in theme_answers_response),
         "accounts_list": approval_change_request_users,
         "is_flaggable": False,  # Flag button is disabled in sub-criteria page,
         "display_comment_box": add_comment_argument,

--- a/pre_award/assess/assessments/templates/assessments/sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/sub_criteria.html
@@ -12,7 +12,6 @@
 {% from "assess/macros/assessment_change_request.html" import assessment_change_request %}
 {% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
 {%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
-{% from "govuk_frontend_jinja/components/warning-text/macro.html" import govukWarningText %}
 
 {% set pageHeading -%}
 {% if comment_form.comment.errors %}
@@ -64,10 +63,13 @@ Error:
     </div>
     <div class="theme govuk-grid-column-two-thirds">
         {% if unrequested_changes %}
-            {{ govukWarningText({
-                text: "The applicant has made unrequested changes",
-                iconFallbackText: "Warning"
-            }) }}
+            <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                <span class="govuk-visually-hidden">Warning</span>
+                The applicant has made unrequested changes.
+                </strong>
+            </div>
         {% endif %}
         <h3 class="govuk-heading-m response-title">Applicant's response</h3>
         {{ theme(answers_meta)}}

--- a/pre_award/assess/assessments/templates/assessments/sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/sub_criteria.html
@@ -12,6 +12,7 @@
 {% from "assess/macros/assessment_change_request.html" import assessment_change_request %}
 {% from "assess/macros/assessment_subcriteria_accepted.html" import assessment_subcriteria_accepted %}
 {%- from "govuk_frontend_jinja/components/pagination/macro.html" import govukPagination -%}
+{% from "govuk_frontend_jinja/components/warning-text/macro.html" import govukWarningText %}
 
 {% set pageHeading -%}
 {% if comment_form.comment.errors %}
@@ -63,18 +64,10 @@ Error:
     </div>
     <div class="theme govuk-grid-column-two-thirds">
         {% if unrequested_changes %}
-            <div class="assessment-alert assessment-alert--flagged" role="alert">
-                <h1 class="assessment-alert__heading govuk-heading-l">
-                    Unrequested Change Detected
-                </h1>
-                The applicant has modified one or more answers that were not requested for change. Please review the updated answers against the assessment criteria.
-                <h3>Questions modified</h3>
-                <ul>
-                    {% for question in unrequested_changes %}
-                        <li>{{ question }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
+            {{ govukWarningText({
+                text: "The applicant has made unrequested changes",
+                iconFallbackText: "Warning"
+            }) }}
         {% endif %}
         <h3 class="govuk-heading-m response-title">Applicant's response</h3>
         {{ theme(answers_meta)}}

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -659,7 +659,7 @@ def get_sub_criteria_theme_answers_all(
         theme_mapping_data["sub_criterias"],
         theme_id,
     )
-    mark_themes_needing_assessor_review(theme_mapping_data["application_json"], theme_question_answers)
+    mark_themes_with_changes(theme_mapping_data["application_json"], theme_question_answers)
     return theme_question_answers
 
 
@@ -672,7 +672,7 @@ def get_all_sub_criterias_with_application_json(application_id: str):
     return theme_mapping_data
 
 
-def mark_themes_needing_assessor_review(application_json, theme_fields):
+def mark_themes_with_changes(application_json, theme_fields):
     unrequested_changes = set()
     requested_changes = set()
     for form in application_json["jsonb_blob"]["forms"]:

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -673,16 +673,21 @@ def get_all_sub_criterias_with_application_json(application_id: str):
 
 
 def mark_themes_needing_assessor_review(application_json, theme_fields):
-    flag_for_assessor = set()
+    unrequested_changes = set()
+    requested_changes = set()
     for form in application_json["jsonb_blob"]["forms"]:
         for section in form["questions"]:
             for field in section["fields"]:
-                if field.get("flag_for_assessor"):
-                    flag_for_assessor.add(field["key"])
+                if field.get("unrequested_change"):
+                    unrequested_changes.add(field["key"])
+                elif field.get("requested_change"):
+                    requested_changes.add(field["key"])
 
     for theme in theme_fields:
-        if theme["field_id"] in flag_for_assessor:
-            theme["flag_for_assessor"] = True
+        if theme["field_id"] in unrequested_changes:
+            theme["unrequested_change"] = True
+        elif theme["field_id"] in requested_changes:
+            theme["requested_change"] = True
 
 
 def get_comments(

--- a/pre_award/assess/static/src/styles/govuk-overrides.css
+++ b/pre_award/assess/static/src/styles/govuk-overrides.css
@@ -15,6 +15,7 @@
     text-transform: none;
 }
 
+
 .gov-uk-table__cell--align-right {
     text-align: right;
 }
@@ -121,6 +122,10 @@
     padding: 2px 4px;
     letter-spacing: normal;
     text-transform: capitalize;
+}
+
+.govuk-tag.requested-change-tag, .govuk-tag.unrequested-change-tag {
+    text-transform: None;
 }
 
 .assigned-to {

--- a/pre_award/assess/templates/assess/macros/theme.html
+++ b/pre_award/assess/templates/assess/macros/theme.html
@@ -28,6 +28,15 @@
 <div class="template-answer bg-white">
     {% for meta in answers_meta %}
         {% if meta.should_render %}
+            {% if meta.label and meta.label.name == "REQUESTED_CHANGE" %}
+                <div class="govuk-tag requested-change-tag">
+                    Updated response
+                </div>
+            {% elif meta.label and meta.label.name == "UNREQUESTED_CHANGE"%}
+                <div class="govuk-tag govuk-tag--red unrequested-change-tag">
+                    Unrequested change
+                </div>
+            {% endif %}
           {{ ui_component_mapping[meta.key](meta) }}
         {% endif %}
     {% endfor %}

--- a/pre_award/assessment_store/db/queries/scores/queries.py
+++ b/pre_award/assessment_store/db/queries/scores/queries.py
@@ -122,7 +122,6 @@ def get_sub_criteria_to_latest_score_map(application_id: str) -> dict:
     for sid, score in result:
         if sid not in sub_criteria_to_latest_score:
             sub_criteria_to_latest_score[sid] = score
-
     return sub_criteria_to_latest_score
 
 


### PR DESCRIPTION
This PR marks fields that have been modified by the applicant with either "requested_changes" or "unrequested_changes" depending on if there is an associated change request. This is then used to label the fields in the sub-criteria page so that it is clear to the Assessor which answers have changed. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![Screenshot 2025-03-21 at 11 27 02](https://github.com/user-attachments/assets/ac0c3fc2-ee9e-462f-8ed9-2612043bac5a)

