### PR TITLE
FS-4810 - We need to remove 'prod' from FAB host URL in env vars for Authenticator

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -247,3 +247,4 @@ environments:
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.communities.gov.uk"
       POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.communities.gov.uk"
       SENTRY_TRACES_SAMPLE_RATE: 1
+      FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.communities.gov.uk"


### PR DESCRIPTION
### Ticket

[Putting FAB in production environment](https://mhclgdigital.atlassian.net/browse/FS-4810)

### Description

As with other host URLs passed into Authenticator via env vars, we need to override the FAB host URL to remove the `prod` from the URL, because the prod URL for FAB is not `https://fund-application-builder.access-funding.prod.communities.gov.uk/`, it is `https://fund-application-builder.access-funding.communities.gov.uk/`. This is needed for authentication to work in FAB in production.