### PR TITLE
Update acceptance flow to latest designs.

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accept_comment.html
@@ -18,7 +18,10 @@
     {% include "assess/components/header.html" %}
 {% endblock header %}
 {% block content %}
-    <h1 class="govuk-heading-l">{{ sub_criteria.name }}: Accepted</h1>
+    <h1 class="govuk-heading-l">Tell us why you've approved the responses</h1>
+    <p class="govuk-body">Your response will be used for an audit trail and visible to other assessors.</p>
+    <p class="govuk-body">Applicants will not see your response.</p>
+    <p class="govuk-body govuk-!-margin-bottom-8">You can still request changes to the application before the quality assessment (QA).</p>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
             <form method="post">
@@ -30,11 +33,11 @@
                             "id": change_request_form.comment.id,
                             "rows": 8,
                             "label": {
-                                "text": "Why has the change been accepted?",
+                                "text": "",
                                 "classes": "govuk-label--m",
                                 isPageHeading: true
                             },
-                            "value": "This submission meets the required criteria",
+                            "value": "",
                             "errorMessage": {
                                 "text": change_request_form.comment.errors.0
                             } if change_request_form.comment.errors

--- a/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
@@ -7,18 +7,35 @@
 {% endblock header %}
 
 {% block content %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half-from-desktop">
-            {{ govukPanel({
-              "titleText": "Your change has been accepted"
-            }) }}
-            <h2 class="govuk-heading-l">What happens next</h2>
-            <p class="govuk-body">Your acceptance has been sent to the applicant by email.</p>
-            <p class="govuk-body">The applicant will no longer be able to make changes to this section.</p>
-            <p class="govuk-body">
-                The status for this criteria will now be marked as <strong>Reviewed</strong>.
-            </p>
-            <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">Back to application</a>
+    {% if state.workflow_status=='CHANGE_RECEIVED' %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half-from-desktop">
+                {{ govukPanel({
+                "titleText": "You have approved the applicant's changes"
+                }) }}
+                <h2 class="govuk-heading-l govuk-!-margin-top-8">What happens next</h2>
+                <p class="govuk-body">We&#39;ve emailed the applicant to let them know that you&#39;ve accepted their changes.</p>
+                <p class="govuk-body">The applicant will not be able to make any more changes to this section.</p>
+                <p class="govuk-body">
+                    The status for this criteria will now be marked as <strong>&#39;Complete&#39;</strong>.
+                </p>
+                <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">Back to application</a>
+            </div>
         </div>
-    </div>
+    {% else %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half-from-desktop">
+                {{ govukPanel({
+                "titleText": "Responses approved"
+                }) }}
+                <h2 class="govuk-heading-l govuk-!-margin-top-8">What happens next</h2>
+                <p class="govuk-body">We&#39;ve emailed the applicant to let them know that you&#39;ve approved their responses.</p>
+                <p class="govuk-body">If you need the applicant to make more changes, you can request another change.</p>
+                <p class="govuk-body">
+                    The status will now be marked as <strong>&#39;Complete&#39;</strong>.
+                </p>
+                <a href="{{ url_for('assessment_bp.application', application_id=application_id) }}" class="govuk-link">Back to application</a>
+            </div>
+        </div>
+    {% endif %}
 {% endblock content %}

--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -5,56 +5,69 @@
 
 {% block sub_criteria_content %}
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    {{ navbar(application_id, sub_criteria, current_theme.id, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
-  </div>
-  <div class="theme govuk-grid-column-two-thirds">
-    {% if not score %}
-      <h1 class="govuk-heading-m">Review Responses</h1>
-      {% if state.workflow_status=='CHANGE_REQUESTED' %}
-        <p class="govuk-body">Awaiting applicant’s update</p>
-      {% elif unrequested_changes %}
-        {{ govukWarningText({
-            "text": "The applicant has made unrequested changes",
-            "iconFallbackText": "Warning"
-        }) }}
-      <p class="govuk-body">The applicant has made their responses based on your change requests. They also made
-        unrequested changes.</p>
-      <p class="govuk-body">Approve and save all responses or request another change.</p>
-      {% elif change_requests and not score %}
-        <p class="govuk-body">The applicant updated their response following your change request.</p>
-        <p class="govuk-body">You can approve the updates or request another change.</p>
-      {% else %}
-        <p class="govuk-body">Review the applicant's responses and 'Accept all responses' when you're ready.</p>
-        <p class="govuk-body">If you need more information from the applicant about one of these responses or want to ask them to clarify something, you can 'Request a change'.</p>
-      {% endif %}
-    {% endif %}
+    <div class="govuk-grid-column-one-third">
+        {{ navbar(application_id, sub_criteria, current_theme.id, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
+    </div>
+    <div class="theme govuk-grid-column-two-thirds">
+        {% if not score %}
+            {% if change_requests %}
+                <h1 class="govuk-heading-l">Review changes</h1>
+            {% else %}
+                <h1 class="govuk-heading-l">Review responses</h1>
+            {% endif %}
 
-    {% if change_requests and not score %}
-      {% for change_request in change_requests %}
-        <h2 class="govuk-heading-s change-title">Change requested</h2>
-        {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], score) }}
-      {% endfor %}
-    {% endif %}
-    <h3 class="govuk-heading-m response-title">Applicant's response</h3>
-    {{ theme(answers_meta)}}
-    {% if not score %}
-      {{ application_feedback(application_id, sub_criteria, current_theme.id,
-      approval_form,change_requests,unrequested_changes) }}
-    {% endif %}
-    {% if score %}
-      <h2 class="govuk-heading-m govuk-!-margin-top-9 govuk-!-margin-bottom-3">Submission acceptance</h2>
-      {{ assessment_subcriteria_accepted(score, accounts_list[score.user_id]) }}
-      {% if change_requests %}
-      {% for change_request in change_requests %}
-        <h2 class="govuk-heading-s">Change requests</h2>
-        {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], score) }}
-      {% endfor %}
-      {% endif %}
-    {% endif %}
-    {% if score or not change_requests %}
-      {% include "assess/components/sub_section_pagination.html" %}
-    {% endif %}
-  </div>
+            {% if state.workflow_status=='CHANGE_REQUESTED' %}
+                <p class="govuk-body">Awaiting applicant’s update</p>
+            {% elif unrequested_changes %}
+                {{ govukWarningText({
+                    "text": "The applicant has made unrequested changes",
+                    "iconFallbackText": "Warning"
+                }) }}
+                <p class="govuk-body">The applicant has updated their responses based on your change requests. They have also made
+                  unrequested changes.</p>
+                <p class="govuk-body">Approve and save all responses or request another change.</p>
+
+            {% elif change_requests and not score %}
+                <p class="govuk-body">The applicant updated their response following your change request.</p>
+                <p class="govuk-body">You can approve the updates or request another change.</p>
+            {% else %}
+                <p class="govuk-body">Review the applicant's responses and 'Accept all responses' when you're ready.</p>
+                <p class="govuk-body">If you need more information from the applicant about one of these responses or want to ask them to clarify something, you can 'Request a change'.</p>
+            {% endif %}
+        {% endif %}
+
+        {% if change_requests and not score %}
+            {% for change_request in change_requests %}
+                <h2 class="govuk-heading-s change-title">Change requested</h2>
+                {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], score) }}
+            {% endfor %}
+        {% endif %}
+
+        {% if state.workflow_status=='CHANGE_RECEIVED' %}
+            <h3 class="govuk-heading-m response-title">Applicant's updated response</h3>
+        {% else %}
+            <h3 class="govuk-heading-m response-title">Applicant's responses</h3>
+        {% endif %}
+
+        {{ theme(answers_meta)}}
+        {% if not score %}
+            {{ application_feedback(application_id, sub_criteria, current_theme.id,
+            approval_form,change_requests,unrequested_changes) }}
+        {% endif %}
+        {% if score %}
+            <h2 class="govuk-heading-m govuk-!-margin-top-9 govuk-!-margin-bottom-3">Submission acceptance</h2>
+            {{ assessment_subcriteria_accepted(score, accounts_list[score.user_id]) }}
+            {% if change_requests %}
+                {% for change_request in change_requests %}
+                    <h2 class="govuk-heading-s">Change requests</h2>
+                    {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], score) }}
+                {% endfor %}
+            {% endif %}
+          {% endif %}
+
+          {% if score or not change_requests %}
+            {% include "assess/components/sub_section_pagination.html" %}
+          {% endif %}
+    </div>
 </div>
 {% endblock sub_criteria_content %}

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -944,7 +944,7 @@ class TestRoutes:
                 follow_redirects=True,
             )
         assert 200 == response.status_code
-        assert "Your change has been accepted" in str(response.data)
+        assert "Your have approved the applicant's changes" or "Responses approved" in str(response.data)
         mock_approve_sub_criteria.assert_called_once_with(
             application_id="resolved_app",
             sub_criteria_id="test_sub_criteria_id",

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -944,7 +944,9 @@ class TestRoutes:
                 follow_redirects=True,
             )
         assert 200 == response.status_code
-        assert "Your have approved the applicant's changes" or "Responses approved" in str(response.data)
+        assert "You have approved the applicant's changes" in str(response.data) or "Responses approved" in str(
+            response.data
+        )
         mock_approve_sub_criteria.assert_called_once_with(
             application_id="resolved_app",
             sub_criteria_id="test_sub_criteria_id",


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net/browse/FLS-1083

### Description:
UI updates to match the latest design. 
Depending on whether the applicant's responses are accepted without requesting any changes, or accepted after requesting some changes, we now have different button texts and confirmation page. 

### Screenshots of UI changes:

### Accepting all responses (no change request):
![Screenshot 2025-03-27 at 14 28 45](https://github.com/user-attachments/assets/f415c212-a78e-4c64-9355-17033d65518f)

![Screenshot 2025-03-27 at 14 29 11](https://github.com/user-attachments/assets/14c32fb9-6491-4783-b6a6-01b7f9175411)

![Screenshot 2025-03-27 at 14 29 45](https://github.com/user-attachments/assets/3b963345-d293-43fc-b2c4-00baabeb1329)


### Accepting responses (after change request):
![Screenshot 2025-03-27 at 14 33 58](https://github.com/user-attachments/assets/a4cb3b69-aeef-4a71-9d23-2d1855cd1cf4)

![Screenshot 2025-03-27 at 14 36 20](https://github.com/user-attachments/assets/042eed98-7d82-44eb-8ea9-10c4660c21ee)

![Screenshot 2025-03-27 at 14 36 51](https://github.com/user-attachments/assets/839acfb4-4d07-4a84-a82b-2cd177f93c37)
