### PR TITLE
Hide buttons to change request or approve when change request is active

### DIFF
--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1334,7 +1334,6 @@ def accept_changes(application_id, sub_criteria_id):
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
     assessment_status = determine_assessment_status(sub_criteria.workflow_status, state.is_qa_complete)
 
-    is_approval_or_change_request_allowed(state, sub_criteria_id)
     if not is_approval_or_change_request_allowed(state, sub_criteria_id):
         return abort(403)
 
@@ -1386,7 +1385,6 @@ def request_changes(application_id, sub_criteria_id, theme_id):
     field_ids = [question["field_id"] for question in filtered_questions]
     form = build_request_changes_form(field_ids)
 
-    is_approval_or_change_request_allowed(state, sub_criteria_id)
     if not is_approval_or_change_request_allowed(state, sub_criteria_id):
         return abort(403)
 

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1303,7 +1303,9 @@ def display_sub_criteria(  # noqa: C901
             unrequested_changes=any(theme.get("unrequested_change") for theme in theme_answers_response),
             change_requests=sub_criteria_change_requests,
             has_document_upload=has_document_upload,
-            has_flag_raised=any(flag.latest_status == FlagType.RAISED for flag in sub_criteria_change_requests),
+            has_active_change_request=any(
+                flag.latest_status == FlagType.RAISED for flag in sub_criteria_change_requests
+            ),
             answers_meta=answers_meta,
             questions={question["field_id"]: question["question"] for question in theme_answers_response},
             state=state,

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1302,6 +1302,7 @@ def display_sub_criteria(  # noqa: C901
             unrequested_changes=any(theme.get("unrequested_change") for theme in theme_answers_response),
             change_requests=sub_criteria_change_requests,
             has_document_upload=has_document_upload,
+            has_flag_raised=any(flag.latest_status == FlagType.RAISED for flag in sub_criteria_change_requests),
             answers_meta=answers_meta,
             questions={question["field_id"]: question["question"] for question in theme_answers_response},
             state=state,

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -64,6 +64,7 @@ from pre_award.assess.assessments.models.location_data import LocationData
 from pre_award.assess.assessments.models.round_summary import create_round_summaries, is_after_today
 from pre_award.assess.assessments.status import (
     all_status_completed,
+    is_approval_or_change_request_allowed,
     update_ar_status_to_completed,
     update_ar_status_to_qa_completed,
 )
@@ -1333,6 +1334,10 @@ def accept_changes(application_id, sub_criteria_id):
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
     assessment_status = determine_assessment_status(sub_criteria.workflow_status, state.is_qa_complete)
 
+    is_approval_or_change_request_allowed(state, sub_criteria_id)
+    if not is_approval_or_change_request_allowed(state, sub_criteria_id):
+        return abort(403)
+
     if request.method == "POST" and form.validate_on_submit():
         approve_sub_criteria(
             application_id=application_id,
@@ -1380,6 +1385,11 @@ def request_changes(application_id, sub_criteria_id, theme_id):
 
     field_ids = [question["field_id"] for question in filtered_questions]
     form = build_request_changes_form(field_ids)
+
+    is_approval_or_change_request_allowed(state, sub_criteria_id)
+    if not is_approval_or_change_request_allowed(state, sub_criteria_id):
+        return abort(403)
+
     if request.method == "POST" and form.validate_on_submit():
         selected_field = form.field_ids.data
         today_date = datetime.now(tz=timezone.utc).date()

--- a/pre_award/assess/assessments/status.py
+++ b/pre_award/assess/assessments/status.py
@@ -1,6 +1,7 @@
 import requests
 from flask import current_app
 
+from pre_award.assessment_store.db.models.assessment_record.enums import Status
 from pre_award.config import Config
 
 
@@ -65,6 +66,6 @@ def is_approval_or_change_request_allowed(state, sub_criteria_id):
     """Return True only if sub_criteria's status is in  'COMPLETED' or 'CHANGE_REQUESTED'."""
     for criteria in state.criterias:
         for sub in criteria.sub_criterias:
-            if sub.id == sub_criteria_id and sub.status in ["COMPLETED", "CHANGE_REQUESTED"]:
+            if sub.id == sub_criteria_id and sub.status in [Status.COMPLETED.name, Status.CHANGE_REQUESTED.name]:
                 return False
     return True

--- a/pre_award/assess/assessments/status.py
+++ b/pre_award/assess/assessments/status.py
@@ -59,3 +59,12 @@ def update_ar_status_to_qa_completed(application_id, user_id):
             "Could not create qa_complete record for application %(application_id)s",
             dict(application_id=application_id),
         )
+
+
+def is_approval_or_change_request_allowed(state, sub_criteria_id):
+    """Return True only if sub_criteria's status is in  'COMPLETED' or 'CHANGE_REQUESTED'."""
+    for criteria in state.criterias:
+        for sub in criteria.sub_criterias:
+            if sub.id == sub_criteria_id and sub.status in ["COMPLETED", "CHANGE_REQUESTED"]:
+                return False
+    return True

--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -15,7 +15,7 @@
     </h1>
 
     <div class="govuk-!-margin-bottom-8">
-        {% if has_flag_raised %}
+        {% if has_active_change_request %}
             <p class="govuk-body">You requested changes to this section and the applicant has not responded yet.</p>
             <p class="govuk-body">Once the applicant has sent their response, you can approve the changes or request another change.</p>
         {% elif unrequested_changes %}
@@ -68,7 +68,7 @@
 </h3>
 
 {{ theme(answers_meta)}}
-{% if not score and not has_flag_raised %}
+{% if not score and not has_active_change_request %}
     {{ application_feedback(application_id, sub_criteria, current_theme.id,
     approval_form,change_requests,unrequested_changes) }}
 {% endif %}

--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -15,8 +15,9 @@
     </h1>
 
     <div class="govuk-!-margin-bottom-8">
-        {% if state.workflow_status=='CHANGE_REQUESTED' %}
-            <p class="govuk-body">Awaiting applicant’s update</p>
+        {% if has_flag_raised %}
+            <p class="govuk-body">You requested changes to this section and the applicant has not responded yet.</p>
+            <p class="govuk-body">Once the applicant has sent their response, you can approve the changes or request another change.</p>
         {% elif unrequested_changes %}
             {{ govukWarningText({
                 "text": "The applicant has made unrequested changes",
@@ -67,7 +68,7 @@
 </h3>
 
 {{ theme(answers_meta)}}
-{% if not score %}
+{% if not score and not has_flag_raised %}
     {{ application_feedback(application_id, sub_criteria, current_theme.id,
     approval_form,change_requests,unrequested_changes) }}
 {% endif %}

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -893,7 +893,6 @@ class TestRoutes:
 
         token = create_valid_token(test_lead_assessor_claims)
         assess_test_client.set_cookie("fsd_user_token", token)
-        is_approval_or_change_request_allowed(mock_get_assessor_tasklist_state, sub_criteria_id)
         response = assess_test_client.get(
             f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}/accept_changes"  # noqa
         )
@@ -930,7 +929,6 @@ class TestRoutes:
 
         token = create_valid_token(test_lead_assessor_claims)
         assess_test_client.set_cookie("fsd_user_token", token)
-        is_approval_or_change_request_allowed(mock_get_assessor_tasklist_state, sub_criteria_id)
 
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -7,6 +7,7 @@ from flask import session
 
 from pre_award.assess.assessments.models.round_status import RoundStatus
 from pre_award.assess.assessments.models.round_summary import RoundSummary, Stats
+from pre_award.assess.assessments.status import is_approval_or_change_request_allowed
 from pre_award.assess.services.models.flag import Flag
 from tests.pre_award.assess_tests.api_data.test_data import fund_specific_claim_map
 from tests.pre_award.assess_tests.conftest import create_valid_token, test_commenter_claims, test_lead_assessor_claims
@@ -892,7 +893,7 @@ class TestRoutes:
 
         token = create_valid_token(test_lead_assessor_claims)
         assess_test_client.set_cookie("fsd_user_token", token)
-
+        is_approval_or_change_request_allowed(mock_get_assessor_tasklist_state, sub_criteria_id)
         response = assess_test_client.get(
             f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}/accept_changes"  # noqa
         )
@@ -929,6 +930,7 @@ class TestRoutes:
 
         token = create_valid_token(test_lead_assessor_claims)
         assess_test_client.set_cookie("fsd_user_token", token)
+        is_approval_or_change_request_allowed(mock_get_assessor_tasklist_state, sub_criteria_id)
 
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
@@ -1611,7 +1613,7 @@ class TestRoutes:
 
         token = create_valid_token(test_lead_assessor_claims)
         assess_test_client.set_cookie("fsd_user_token", token)
-
+        is_approval_or_change_request_allowed(mock_get_assessor_tasklist_state, sub_criteria_id)
         response = assess_test_client.get(
             f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}/theme_id/test_theme_id/request_change"
         )
@@ -1651,6 +1653,35 @@ class TestRoutes:
         )
         assert 200 == response.status_code
         assert b"Your request for changes has been sent" in response.data
+
+    @pytest.mark.application_id("resolved_app")
+    @pytest.mark.sub_criteria_id("test_sub_criteria_id")
+    def test_prevent_change_request(
+        self,
+        assess_test_client,
+        request,
+        mock_get_sub_criteria,
+        mock_get_sub_criteria_theme,
+        mock_get_fund,
+        mock_get_funds,
+        mock_get_round,
+        mock_get_application_metadata,
+        mock_get_assessor_tasklist_state,
+    ):
+        application_id = request.node.get_closest_marker("application_id").args[0]
+        sub_criteria_id = request.node.get_closest_marker("sub_criteria_id").args[0]
+
+        token = create_valid_token(test_lead_assessor_claims)
+        assess_test_client.set_cookie("fsd_user_token", token)
+        mock_get_assessor_tasklist_state.return_value["criterias"][0]["sub_criterias"][0]["status"] = "CHANGE_REQUESTED"
+        post_data = {"field_ids": ["JCACTy"], "reason_JCACTy": "testing"}
+
+        response = assess_test_client.post(
+            f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}/theme_id/test_theme_id/request_change",
+            data=post_data,
+            follow_redirects=True,
+        )
+        assert b"Access Denied" in response.data
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Dev Ticket : https://mhclgdigital.atlassian.net/browse/FLS-1115
Design Reference : https://mhclgdigital.atlassian.net/browse/FLS-1133

Hide both the "Approve" and "Raise another change request" buttons when there is an active change request from the assessor.

Previously, the plan was to disable the "Approve" button on the sub_criteria page when an active change request existed.

<img width="988" alt="Screenshot 2025-04-07 at 11 24 02" src="https://github.com/user-attachments/assets/d060b766-f8bf-4475-a964-056a7feae669" />



