### PR TITLE
Revert "Allow manual deploy via GitHub workflow dispatch only to Dev env"

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -10,6 +10,9 @@ on:
         required: true
         options:
         - dev
+        - test
+        - uat
+        - prod
       run_e2e_tests_assessment:
         required: false
         default: true


### PR DESCRIPTION
Reverts communitiesuk/funding-service-pre-award#360

We created that PR because we believed it was no longer possible to manually deploy to Test, UAT or Prod environments. In fact it is possible to manually deploy, it's just that only main branch can be deployed. There could be legitimate use cases for manually deploying main branch. Our PR should therefore be reverted so that the available options mirror the reality of what's possible.