### PR TITLE
CHAM-REG: modify instructions_json

### DIFF
--- a/pre_award/fund_store/config/fund_loader_config/FAB/cham_reg.py
+++ b/pre_award/fund_store/config/fund_loader_config/FAB/cham_reg.py
@@ -74,7 +74,7 @@ LOADER_CONFIG = {
         "privacy_notice": "https://www.gov.uk/government/publications/confronting-hate-against-muslims-fund-prospectus/confronting-hate-against-muslims-privacy-notice",
         "contact_email": "chambid@communities.gov.uk",
         "instructions_json": {
-            "en": "You must complete this registration form to apply for the Confronting Hate Against Muslims Fund. Read the fund's <a href='https://www.gov.uk/government/publications/confronting-hate-against-muslims-fund-prospectus'>prospectus</a> before you start.",
+            "en": "You must complete this registration form to apply for the Confronting Hate Against Muslims Fund.",
             "cy": None,
         },
         "feedback_link": "",


### PR DESCRIPTION
Description:
Modify instructions_json for CHAM-REG fund, to avoid duplication of text.

The "Read the fund's prospectus before you start." was displayed twice before this change:
![image](https://github.com/user-attachments/assets/5aeb6475-5b44-402a-b88d-2b4a89e48e48)

Screenshot afterwards:
![Screenshot 2025-04-01 at 14 58 24](https://github.com/user-attachments/assets/24478e61-55ee-4900-a3f0-b5573dbcb892)
