### PR TITLE
Add content to inform assessor to check uploaded file after any chang…

### DIFF
--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1264,6 +1264,9 @@ def display_sub_criteria(  # noqa: C901
         )
 
     theme_answers_response = get_sub_criteria_theme_answers_all(application_id, theme_id)
+    has_document_upload = any(
+        theme_answer["field_type"] == "clientSideFileUploadField" for theme_answer in theme_answers_response
+    )
 
     # If the sub-criteria has been accepted, no need to label changed answers
     if score:
@@ -1297,6 +1300,7 @@ def display_sub_criteria(  # noqa: C901
             "assessments/uncompeted_sub_criteria.html",
             unrequested_changes=any(theme.get("unrequested_change") for theme in theme_answers_response),
             change_requests=sub_criteria_change_requests,
+            has_document_upload=has_document_upload,
             answers_meta=answers_meta,
             questions={question["field_id"]: question["question"] for question in theme_answers_response},
             state=state,

--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -43,6 +43,11 @@
                 If you need more information from the applicant about one of these responses or want to ask them to clarify something, you can 'Request a change'.
             </p>
         {% endif %}
+        {% if has_document_upload %}
+            <p class="govuk-body">
+                Check any uploaded documents again before approving changes.
+            </p>
+        {% endif %}
     </div>
 {% endif %}
 


### PR DESCRIPTION
### Change description
We need to inform Assessors to double check uploaded files following a change request. This PR adds some content in the template. 
- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![Screenshot 2025-04-02 at 15 50 45](https://github.com/user-attachments/assets/d5c10ffb-b3ff-4d97-998e-ff4d5da0b974)
