### PR TITLE
Fls 1203 incorrect subcriteria status

### DIFF
--- a/pre_award/assessment_store/api/routes/_helpers.py
+++ b/pre_award/assessment_store/api/routes/_helpers.py
@@ -48,7 +48,7 @@ def _derive_status(
     if has_flag_with_raised_status:
         return Status.CHANGE_REQUESTED.name
 
-    if has_flag_with_received_status and workflow_status == Status.CHANGE_RECEIVED.name:
+    if has_flag_with_received_status:
         return Status.CHANGE_RECEIVED.name
 
     if sub_criteria_id in comment_map:

--- a/pre_award/assessment_store/api/routes/_helpers.py
+++ b/pre_award/assessment_store/api/routes/_helpers.py
@@ -28,7 +28,6 @@ def _derive_status(
     score_map: dict,
     comment_map: dict,
     change_requests: list[AssessmentFlag],
-    workflow_status: str,
     sub_criteria_id: str,
 ) -> str:
     if sub_criteria_id in score_map:
@@ -64,7 +63,6 @@ def transform_to_assessor_task_list_metadata(
     score_map: dict,
     comment_map: dict,
     change_requests: list[AssessmentFlag],
-    workflow_status: str,
 ) -> tuple[list[dict], list[dict]]:
     current_app.logger.info("Configured fund-rounds:")
     current_app.logger.info(Config.ASSESSMENT_MAPPING_CONFIG.keys())
@@ -96,7 +94,7 @@ def transform_to_assessor_task_list_metadata(
                     "id": sc["id"],
                     "score": score_map.get(sc["id"]),
                     "theme_count": len(sc["themes"]),
-                    "status": _derive_status(score_map, comment_map, change_requests, workflow_status, sc["id"]),
+                    "status": _derive_status(score_map, comment_map, change_requests, sc["id"]),
                 }
                 for sc in c["sub_criteria"]
             ],

--- a/pre_award/assessment_store/api/routes/assessment_routes.py
+++ b/pre_award/assessment_store/api/routes/assessment_routes.py
@@ -202,7 +202,7 @@ def get_assessor_task_list_state(application_id: str) -> dict:
     comment_map = get_sub_criteria_to_has_comment_map(application_id)
     change_requests = [flag for flag in get_flags_for_application(application_id) if flag.is_change_request]
     sections, criterias = transform_to_assessor_task_list_metadata(
-        metadata["fund_id"], metadata["round_id"], score_map, comment_map, change_requests, metadata["workflow_status"]
+        metadata["fund_id"], metadata["round_id"], score_map, comment_map, change_requests
     )
     qa_complete = get_qa_complete_record_for_application(application_id)
 

--- a/tests/pre_award/assessment_store_tests/test_routes_helper.py
+++ b/tests/pre_award/assessment_store_tests/test_routes_helper.py
@@ -39,10 +39,10 @@ def test_derive_status():
             "sub_criteria_id": "criteria1",
             "expected": Status.CHANGE_REQUESTED.name,
         },
-        # Flag resolved, workflow status matches
+        # Flag resolved, any workflow status
         {
             "change_requests": [flag_resolved],
-            "workflow_status": Status.CHANGE_RECEIVED.name,
+            "workflow_status": Status.CHANGE_REQUESTED.name,
             "sub_criteria_id": "criteria1",
             "expected": Status.CHANGE_RECEIVED.name,
         },

--- a/tests/pre_award/assessment_store_tests/test_routes_helper.py
+++ b/tests/pre_award/assessment_store_tests/test_routes_helper.py
@@ -62,7 +62,6 @@ def test_derive_status():
             score_map=score_map,
             comment_map=comment_map,
             change_requests=case["change_requests"],
-            workflow_status=case["workflow_status"],
             sub_criteria_id=case["sub_criteria_id"],
         )
 


### PR DESCRIPTION
### Change description
Fix for issue spotted in E2E testing: if a change has been requested, workflow status is updated to change requested, and this disrupts any previous change received sub-criteria statuses. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
See steps in ticket

### Screenshots of UI changes (if applicable)
![Screenshot 2025-04-08 at 15 20 23](https://github.com/user-attachments/assets/6aef8c18-3db9-4ce0-889e-064c0b84f114)
