### PR TITLE
FLS-1138: Fix for accessibility bug in apply tasklist

### DIFF
--- a/pre_award/apply/templates/apply/tasklist.html
+++ b/pre_award/apply/templates/apply/tasklist.html
@@ -141,7 +141,7 @@
                         {{ application_status("COMPLETED") }}
                     </dd>
                 {% endif %}
-                <p class="govuk-body govuk-!-margin-bottom-7">
+                <dt class="govuk-body govuk-!-margin-bottom-7">
                     {% if application_meta_data["number_of_completed_forms"] == 0 %}
                         {% trans %}None of the sections have been completed.{% endtrans %}
                     {% else %}
@@ -149,7 +149,7 @@
                         {{ application_meta_data["number_of_completed_forms"] }} {% trans %}of{% endtrans %}
                         {{ application_meta_data["number_of_forms"] }} {% trans %}sections.{% endtrans %}
                     {% endif %}
-                </p>
+                </dt>
             {% endif %}
             </dl>
 


### PR DESCRIPTION
Ticket: 

https://mhclgdigital.atlassian.net/browse/FLS-1138

### Change description

Running a scan using the Axe extension on Chrome revealed an accessibility issue in the apply tasklist. Specifically, a &lt;p&gt; tag was found as a child of a &lt;dl&gt; (description list) tag, which is not considered accessible. To resolve this issue, we have replaced the &lt;p&gt; tag with a &lt;dt&gt; tag.

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Run scan of axe extension on chrome while on apply tasklist page to make sure there are no issues
