### PR TITLE
Quoting CSV file values on Assessor Export

### DIFF
--- a/pre_award/assess/assessments/helpers.py
+++ b/pre_award/assess/assessments/helpers.py
@@ -190,7 +190,7 @@ _EXCLUDED_HEADERS = (
 def generate_assessment_info_csv(data: dict):
     output = StringIO()
     headers = list(OrderedDict.fromkeys(key for d in data for key in d.keys() if key not in _EXCLUDED_HEADERS))
-    csv_writer = csv.writer(output)
+    csv_writer = csv.writer(output, quoting=csv.QUOTE_ALL)
 
     if len(data) == 0:
         return output.getvalue()

--- a/tests/pre_award/assess_tests/test_helpers.py
+++ b/tests/pre_award/assess_tests/test_helpers.py
@@ -261,21 +261,29 @@ def test_generate_csv_for_fields():
             "AppId": "de36ae35-9ef6-4dc5-a2bf-de9ee481c8af",
             "Charity number ": "Test missing keys",
         },
+        {
+            "AppId": "de36ae35-9ef6-4dc5-a2bf-de9ee481c8af",
+            "Charity number ": "01234567",
+            "Company registration number": "01112222",
+        },
+        {
+            "AppId": "de36ae35-9ef6-4dc5-a2bf-de9ee481c8af",
+            "Charity number ": "00123456",
+            "Company registration number": "AK123456",
+        },
     ]
 
     expected_result = (
-        "AppId,Charity number ,Do you need to do any further feasibility"
-        " work?,Project name,Doc"
-        " Name\r\n9a8b6c00-e461-466c-acb3-2519621b3a38,Test,False,Save the"
-        " humble pub in"
-        " Bangor,sample1.doc\r\nde36ae35-9ef6-4dc5-a2bf-de9ee481c8af,Test,False,Save"
-        " the humble pub in"
-        " Bangor,sample1.doc\r\nde36ae35-9ef6-4dc5-a2bf-de9ee481c8af,Test"
-        " missing keys,,,\r\n"
+        '"AppId","Charity number ","Do you need to do any further feasibility work?",'
+        '"Project name","Doc Name","Company registration number"\r\n"9a8b6c00-e461-466c-acb3-2519621b3a38",'
+        '"Test","False","Save the humble pub in Bangor","sample1.doc",""\r\n'
+        '"de36ae35-9ef6-4dc5-a2bf-de9ee481c8af","Test","False","Save the humble pub in Bangor",'
+        '"sample1.doc",""\r\n"de36ae35-9ef6-4dc5-a2bf-de9ee481c8af","Test missing keys","","","",'
+        '""\r\n"de36ae35-9ef6-4dc5-a2bf-de9ee481c8af","01234567","","","","01112222"\r\n'
+        '"de36ae35-9ef6-4dc5-a2bf-de9ee481c8af","00123456","","","","AK123456"\r\n'
     )
 
     result = generate_assessment_info_csv(test_data)
-
     assert result == expected_result
 
 


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1241

Description:
Please see detailed description of the issue and the proposed solution in the JIRA ticket above. 
This change makes sure that all values are surrounded with quotes in the generated CSV file. There is only a slight advantage to doing it, specifically if opening the file with LibreOffice. 
With this change we don’t have to set every column one-by-one to text-type (e.g. the company registration number and the charity number columns), but we just need to tick the following option: _Format quoted field as text_. And then it will display the values correctly.
If opening the file with Excel, it asks for confirmation whether to remove leading zeros or not. 


### How to test
Open the attached CSV file and check that the values in the company registration number and the charity number columns have the leading zero displayed. 
![Screenshot 2025-04-29 at 13 07 49](https://github.com/user-attachments/assets/d3f3ae4b-a69c-4231-8396-faa6d86cb1cd)

Alternatively, check out this branch, create a CHAM application (2nd round, APPLY), and then on Assesment's assessor_tool_dashboard generate a CSV file by clicking "Export applicant information", and open that file.
[assessor_export_2025-04-29_11-47-45_en.csv](https://github.com/user-attachments/files/19958708/assessor_export_2025-04-29_11-47-45_en.csv)
