### PR TITLE
Bugfix - Fix failing Apply E2E tests

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -57,7 +57,6 @@ variables:
   AUTH_HOST: "account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   AUTHENTICATOR_HOST: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   FORM_DESIGNER_HOST: "https://form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-  FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
@@ -90,6 +89,7 @@ secrets:
   RSA256_PRIVATE_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PRIVATE_KEY_BASE64
   GOV_NOTIFY_API_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/GOV_NOTIFY_API_KEY
   FORMS_SERVICE_PRIVATE_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FORM_RUNNER_INTERNAL_HOST
+  FORMS_SERVICE_PUBLIC_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FORM_RUNNER_EXTERNAL_HOST
 
 
 # You can override any of the values defined above by environment.


### PR DESCRIPTION
### Description

These tests have been failing since [basic auth was added to Form Runner](https://github.com/communitiesuk/digital-form-builder-adapter/pull/178). This is because the `continue_application` function, which redirects users to the Form Runner, is core to Apply.

By switching `FORMS_SERVICE_PUBLIC_HOST` from a Copilot variable to a secret, we can store a basic auth-embedded version of the Form Runner URL in the AWS Parameter Store, meaning we can automate our way through the authentication barrier. As a byproduct, Apply users in pre-prod environments will also be spared the pain of basic auth. As the main point of basic auth is to block web crawlers, this seems okay.

### Linked TODOs

We will need to add a secret `FORM_RUNNER_EXTERNAL_HOST` to all pre-prod environments - Dev, Test and UAT. This URL will be `https://${BASIC_AUTH_USERNAME}:${BASIC_AUTH_PASSWORD}@application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk`.