### PR TITLE
Start to retire the UAT environment

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy to AWS
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-UAT-Prod' || 'Build & Unit Test') }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-Prod' || 'Build & Unit Test') }}
 
 on:
   workflow_dispatch:
@@ -11,7 +11,6 @@ on:
         options:
         - dev
         - test
-        - uat
         - prod
       run_e2e_tests_assessment:
         required: false
@@ -157,7 +156,7 @@ jobs:
 
   test_deploy:
     needs: [ setup, unit_tests, type_checking, paketo_build ]
-    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') || contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') || contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') }}
+    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') || contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') }}
     uses: ./.github/workflows/deploy.yml
     concurrency:
       group: 'fsd-preaward-test'
@@ -180,33 +179,8 @@ jobs:
       run_e2e_tests_application: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_application }}
       run_e2e_tests_python: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_python }}
 
-  uat_deploy:
-    needs: [ setup, unit_tests, type_checking, paketo_build, test_deploy ]
-    if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') || contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') }}
-    uses: ./.github/workflows/deploy.yml
-    concurrency:
-      group: 'fsd-preaward-uat'
-      cancel-in-progress: false
-    secrets:
-      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-      FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-      FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-      FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
-      FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
-      SLACK_DEPLOYMENTS_CHANNEL_ID: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
-    with:
-      environment: uat
-      image_location: ${{ needs.paketo_build.outputs.image_location }}
-      alert_slack_on_failure: true
-      notify_slack_on_deployment: false
-      run_e2e_tests_assessment: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_assessment }}
-      run_e2e_tests_application: ${{ (github.event_name == 'push' && true) || inputs.run_e2e_tests_application }}
-      run_e2e_tests_python: false  # Never been turned on for UAT yet
-
   prod_deploy:
-    needs: [ setup, unit_tests, type_checking, paketo_build, test_deploy, uat_deploy ]
+    needs: [ setup, unit_tests, type_checking, paketo_build, test_deploy ]
     if: ${{ contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') }}
     uses: ./.github/workflows/deploy.yml
     concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,7 @@ jobs:
 
   e2e_test:
     name: Run end-to-end (browser) tests
-    if: ${{ inputs.environment == 'dev' || inputs.environment == 'test' || inputs.environment == 'uat' }}  # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
+    if: ${{ inputs.environment == 'dev' || inputs.environment == 'test' }}  # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
     needs: [ deploy ]
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/run-shared-tests.yml@main
     with:

--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -164,51 +164,6 @@ environments:
       healthcheck:
         path: /healthcheck
         port: 8080
-
-  uat:
-    variables:
-      ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
-    count:
-      range: 2-4
-      cooldown:
-        in: 60s
-        out: 30s
-      cpu_percentage:
-        value: 70
-      memory_percentage:
-        value: 80
-      requests: 30
-      response_time: 2s
-    sidecars:
-      nginx:
-        port: 8087
-        image:
-          location: xscys/nginx-sidecar-basic-auth
-        variables:
-          FORWARD_PORT: 8080
-          CLIENT_MAX_BODY_SIZE: 10m
-        secrets:
-          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
-          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-    http:
-      alias:
-        - account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
-        - assess.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
-        - apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
-      additional_rules:
-        - path: /
-          target_container: nginx
-          alias:
-            - assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
-            - frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
-            - authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
-          healthcheck:
-            path: /healthcheck
-            port: 8080
-      target_container: nginx
-      healthcheck:
-        path: /healthcheck
-        port: 8080
   prod:
     http:
       alias:

--- a/pre_award/assess/config/__init__.py
+++ b/pre_award/assess/config/__init__.py
@@ -14,7 +14,7 @@ match FLASK_ENV:
         from pre_award.config.envs.dev import DevConfig as Config
     case "test":
         from pre_award.config.envs.test import TestConfig as Config
-    case "uat" | "production":
+    case "production":
         from pre_award.config.envs.production import ProductionConfig as Config
     case _:
         from pre_award.config.envs.default import DefaultConfig as Config

--- a/pre_award/config/__init__.py
+++ b/pre_award/config/__init__.py
@@ -12,7 +12,7 @@ match FLASK_ENV:
         from pre_award.config.envs.test import TestConfig as Config
     case "unit_test":
         from pre_award.config.envs.unit_test import UnitTestConfig as Config
-    case "uat" | "production":
+    case "production":
         from pre_award.config.envs.production import ProductionConfig as Config
     case _:
         from pre_award.config.envs.default import DefaultConfig as Config

--- a/pre_award/fund_store/scripts/data_updates/README.md
+++ b/pre_award/fund_store/scripts/data_updates/README.md
@@ -8,7 +8,7 @@ Once this data has been loaded, if it needs to change, there are 2 options:
 This folder is intended to serve option 2.
 
 ## Script format
-When data needs to be updated (after it has already been inserted in UAT/production - for changes during development use option 1 and truncate the data then reinsert).
+When data needs to be updated (after it has already been inserted in production - for changes during development use option 1 and truncate the data then reinsert).
 
 For each change,
 1. Update the main [fund loader config](/config/fund_loader_config/) with any new values.

--- a/tests/pre_award/test_debugtoolbar.py
+++ b/tests/pre_award/test_debugtoolbar.py
@@ -9,7 +9,6 @@ from pre_award.config.envs.default import DefaultConfig
         ("development", True),
         ("dev", False),
         ("test", False),
-        ("uat", False),
         ("prod", False),
         ("production", False),
     ),


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-342

https://github.com/communitiesuk/funding-service-requests-for-comments/discussions/17

As per the conclusion of the above RFC, we're moving away from having three pipelined environments to two (test/prod) and a free-for-all pre-merge env (dev).

This patch removes all concepts of the UAT env from the app, but won't tear down the app instances themselves yet. We'll do this manually later when all of our services have been updated and the UAT env is disconnected from all pipelines/etc.