### PR TITLE
Removing UI components for uncompeted flow

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -3,7 +3,7 @@
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 {% from "assess/macros/flag_history.html" import flag_tabs %}
 {% from "assess/macros/section_element.html" import section_element -%}
-{% from "assess/macros/criteria_element.html" import criteria_element -%}
+{% from "assess/macros/criteria_element.html" import criteria_element with context -%}
 {% from "assess/macros/banner_summary.html" import banner_summary %}
 {% from "assess/macros/flag_application_button.html" import flag_application_button %}
 {% from "assess/macros/mark_qa_complete_button.html" import mark_qa_complete_button %}

--- a/pre_award/assess/templates/assess/macros/criteria_element.html
+++ b/pre_award/assess/templates/assess/macros/criteria_element.html
@@ -29,7 +29,7 @@
                     sub_criteria.name
                 )
             },
-            { "text": sub_criteria.score if sub_criteria.score is not none or "", "format": "numeric" } if g.access_controller.has_any_assessor_role else None,
+            { "text": sub_criteria.score if sub_criteria.score is not none or "", "format": "numeric" } if not is_uncompeted_flow(fund) and g.access_controller.has_any_assessor_role else None,
             {
                 "html": status,
                 "format": "numeric"
@@ -37,23 +37,28 @@
         ]) %}
     {% endfor %}
 
-    {% set _ = rows.append([
-        { "html": "<strong>Total criteria score</strong>" },
-        { "text": "" },
-        { "text": "{} of {}".format(criteria.total_criteria_score, criteria.number_of_scored_sub_criteria * max_possible_sub_criteria_score), "format": "numeric" },
-    ]) if g.access_controller.has_any_assessor_role %}
+    {% if not is_uncompeted_flow(fund) and g.access_controller.has_any_assessor_role %}
+        {% set _ = rows.append([
+            { "html": "<strong>Total criteria score</strong>" },
+            { "text": "" },
+            { "text": "{} of {}".format(criteria.total_criteria_score, criteria.number_of_scored_sub_criteria * max_possible_sub_criteria_score), "format": "numeric" },
+        ]) %}
+    {% endif %}
 
     <h3 class="{{ name_classes or '' }}">{{ criteria.name }}</h3>
-    <p class="govuk-body govuk-!-margin-bottom-2">
-        <strong>{{ (criteria.weighting * 100)|int }}%</strong> of overall score.
-    </p>
+
+    {% if not is_uncompeted_flow(fund) %}
+        <p class="govuk-body govuk-!-margin-bottom-2">
+            <strong>{{ (criteria.weighting * 100)|int }}%</strong> of overall score.
+        </p>
+    {% endif %}
 
     {{
         govukTable({
         "firstCellIsHeader":false,
         "head": [
             { "text": "Assessment sub criteria", "classes": "govuk-!-width-one-half"  },
-            { "text": "Score out of {}".format(max_possible_sub_criteria_score), "format": "numeric" } if g.access_controller.has_any_assessor_role else None,
+            { "text": "Score out of {}".format(max_possible_sub_criteria_score), "format": "numeric" } if not is_uncompeted_flow(fund) and g.access_controller.has_any_assessor_role else None,
             { "text": "Status", "format": "numeric" }
         ],
         "rows": rows,


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1098

Description:
These changes remove the scoring- and weight UI components on ASSESSMENT's application view for uncompeted flow.
Unit tests are updated to reflect the changes. 

SCREENSHOTS:
Competitive flow:
![Screenshot 2025-05-08 at 17 43 39](https://github.com/user-attachments/assets/be93c705-f2bf-4bad-bef3-a86f0756837b)

Uncompeted flow:
![Screenshot 2025-05-08 at 17 45 08](https://github.com/user-attachments/assets/80b2cb81-04d4-47ad-878f-3b5446ea26ca)
