### PR TITLE
Fix DPIF errors

### DIFF
--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -320,7 +320,7 @@ def submit_application(application_id) -> Applications:  # noqa: C901
             .options(load_only(AssessmentRecord.jsonb_blob))
         )
 
-        if existing_application and fund.funding_type == "UNCOMPETED":
+        if existing_application and fund.funding_type == "UNCOMPETED" and fund.short_name != "DPIF":
             # For uncompeted funds, the application may already exist and this may be a resubmission.
 
             # updating row json blob

--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -320,6 +320,7 @@ def submit_application(application_id) -> Applications:  # noqa: C901
             .options(load_only(AssessmentRecord.jsonb_blob))
         )
 
+        # TODO find a better way to do this without hardcoding fund name
         if existing_application and fund.funding_type == "UNCOMPETED" and fund.short_name != "DPIF":
             # For uncompeted funds, the application may already exist and this may be a resubmission.
 

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1297,6 +1297,7 @@ def display_sub_criteria(  # noqa: C901
         "pagination": state.get_pagination_from_sub_criteria_id(sub_criteria_id),
     }
 
+    # TODO find a better way to do this without hardcoding fund name
     if (
         common_template_config["fund"].funding_type == "UNCOMPETED"
         and common_template_config["fund"].short_name != "DPIF"

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1297,7 +1297,10 @@ def display_sub_criteria(  # noqa: C901
         "pagination": state.get_pagination_from_sub_criteria_id(sub_criteria_id),
     }
 
-    if common_template_config["fund"].funding_type == "UNCOMPETED":
+    if (
+        common_template_config["fund"].funding_type == "UNCOMPETED"
+        and common_template_config["fund"].short_name != "DPIF"
+    ):
         return render_template(
             "assessments/uncompeted_sub_criteria.html",
             unrequested_changes=any(theme.get("unrequested_change") for theme in theme_answers_response),


### PR DESCRIPTION

Problem:
DPIF should follow competed fund flow but was defined as an uncompeted fund, which is creating some unexpected behaviour of our applications, so we need to make sure that the uncompeted journey only works for uncompeted funds or non DPIF funds.

- Fixed checks to ensure that only non-DPIF funds trigger the Uncompeted workflow, thereby preventing DPIF funds from inadvertently following it.

_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
