### PR TITLE
Retrieve FORMS_SERVICE_PUBLIC_HOST from AWS Parameter Store in prod

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -244,7 +244,6 @@ environments:
       AUTH_HOST: "account.access-funding.communities.gov.uk"
       API_HOST: "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local:8080"
       APPLICANT_FRONTEND_HOST: "https://apply.access-funding.communities.gov.uk" # TODO: remove me when all frontends combined
-      FORMS_SERVICE_PUBLIC_HOST: "https://application-questions.access-funding.communities.gov.uk"
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.communities.gov.uk"
       POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.communities.gov.uk"
       SENTRY_TRACES_SAMPLE_RATE: 0.1


### PR DESCRIPTION
We are currently getting this error 'An ECS task definition to group your containers and run them on ECS - Resource handler returned message: Invalid request provided: Create TaskDefinition: The secret name must be unique and not shared with new or existing environment variables set on the container, such as FORMS_SERVICE_PUBLIC_HOST.' when we try to deploy prod. This is because FORMS_SERVICE_PUBLIC_HOST is defined as a secret globally but as a variable for prod.

We can resolve this by removing the hard-coded variable override in the prod config, instead relying like all other envs on the FORM_RUNNER_EXTERNAL_HOST variable from the AWS Parameter Store. We just need to add that secret in prod AWS Parameter Store before deploy.