### PR TITLE
Rename levellingup emails to communities

### DIFF
--- a/pre_award/fund_store/config/fund_loader_config/FAB/hsra_rp.py
+++ b/pre_award/fund_store/config/fund_loader_config/FAB/hsra_rp.py
@@ -81,7 +81,7 @@ LOADER_CONFIG = {
         "assessment_deadline": "2026-02-28T09:00:00",
         "prospectus": "https://www.gov.uk/government/publications/high-street-rental-auctions-grants-for-local-authorities/high-street-rental-auctions-fund-prospectus",
         "privacy_notice": "https://www.gov.uk/government/publications/high-street-rental-auctions-grants-for-local-authorities/high-street-rental-auctions-privacy-notice",
-        "contact_email": "HighStreetRentalAuctions@levellingup.gov.uk",
+        "contact_email": "HighStreetRentalAuctions@communities.gov.uk",
         "instructions_json": {"en": None, "cy": None},
         "feedback_link": "",
         "project_name_field_id": "qbBtUh",

--- a/pre_award/fund_store/config/fund_loader_config/FAB/hsra_vr.py
+++ b/pre_award/fund_store/config/fund_loader_config/FAB/hsra_vr.py
@@ -87,7 +87,7 @@ LOADER_CONFIG = {
         "assessment_deadline": "2026-02-28T09:00:00",
         "prospectus": "https://www.gov.uk/government/publications/high-street-rental-auctions-grants-for-local-authorities/high-street-rental-auctions-fund-prospectus",
         "privacy_notice": "https://www.gov.uk/government/publications/high-street-rental-auctions-grants-for-local-authorities/high-street-rental-auctions-privacy-notice",
-        "contact_email": "HighStreetRentalAuctions@levellingup.gov.uk",
+        "contact_email": "HighStreetRentalAuctions@communities.gov.uk",
         "instructions_json": {
             "en": None,
             "cy": None,

--- a/pre_award/fund_store/config/fund_loader_config/cyp/cyp_r1.py
+++ b/pre_award/fund_store/config/fund_loader_config/cyp/cyp_r1.py
@@ -161,7 +161,7 @@ round_config = [
         "assessment_deadline": CYP_R1_ASSESSMENT_DEADLINE_DATE,
         "prospectus": CYP_PROSPECTS_LINK,
         "privacy_notice": "https://www.gov.uk/guidance/the-children-and-young-peoples-resettlement-fund-privacy-notice",
-        "contact_email": "cyprfund@levellingup.gov.uk",
+        "contact_email": "cyprfund@communities.gov.uk",
         "instructions_json": None,
         "feedback_link": "",
         "project_name_field_id": "bsUoNG",

--- a/pre_award/fund_store/config/fund_loader_config/digital_planning/dpi_r2.py
+++ b/pre_award/fund_store/config/fund_loader_config/digital_planning/dpi_r2.py
@@ -137,7 +137,7 @@ round_config = [
         "assessment_deadline": DPI_R2_ASSESSMENT_DEADLINE_DATE,
         "prospectus": DPI_PROSPECTS_LINK,
         "privacy_notice": DPI_PRIVACY_NOTICE,
-        "contact_email": "digitalplanningteam@levellingup.gov.uk",
+        "contact_email": "digitalplanningteam@communities.gov.uk",
         "instructions_json": None,
         "feedback_link": "",
         "project_name_field_id": "JAAhRP",

--- a/pre_award/fund_store/config/fund_loader_config/night_shelter/ns_r2.py
+++ b/pre_award/fund_store/config/fund_loader_config/night_shelter/ns_r2.py
@@ -193,7 +193,7 @@ round_config = [
         "assessment_deadline": NS_R2_ASSESSMENT_DEADLINE_DATE,
         "prospectus": NIGHT_SHELTER_PROSPECTS_LINK,
         "privacy_notice": "https://www.gov.uk/guidance/night-shelter-transformation-fund-2022-2025-privacy-notice",
-        "contact_email": "transformationfund@levellingup.gov.uk",
+        "contact_email": "transformationfund@communities.gov.uk",
         "instructions_json": None,
         "feedback_link": "https://forms.office.com/e/n6J9KPebUy",
         "project_name_field_id": "YVsPtE",

--- a/scripts/migrate_levellingup_emails.sql
+++ b/scripts/migrate_levellingup_emails.sql
@@ -1,0 +1,7 @@
+-- Update any rows in the `round` table that have a contact email address on the levellingup domain to point at the communities domain instead.
+
+SELECT * FROM round WHERE contact_email LIKE '%@levellingup.gov.uk';
+
+UPDATE round SET contact_email = REPLACE(contact_email, '@levellingup.gov.uk', '@communities.gov.uk') WHERE contact_email LIKE '%@levellingup.gov.uk';
+
+SELECT * FROM round WHERE contact_email LIKE '%@levellingup.gov.uk';

--- a/services/notify/__init__.py
+++ b/services/notify/__init__.py
@@ -132,13 +132,11 @@ class NotificationService:
     REPLY_TO_EMAILS_WITH_NOTIFY_ID = {
         "LocalPlansandGreenBeltFunding@communities.gov.uk": "7bc1b42f-512d-4e43-a70a-3c06a3197f38",
         FUNDING_SERVICE_SUPPORT_EMAIL_ADDRESS: "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
-        "COF@levellingup.gov.uk": "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
         "COF@communities.gov.uk": "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
-        "transformationfund@levellingup.gov.uk": "25286d9a-8543-41b5-a00f-331b999e51f0",
-        "cyprfund@levellingup.gov.uk": "72bb79a8-2748-4404-9f01-14690bee3843",
+        "transformationfund@communities.gov.uk": "25286d9a-8543-41b5-a00f-331b999e51f0",
+        "cyprfund@communities.gov.uk": "72bb79a8-2748-4404-9f01-14690bee3843",
         "digitalplanningteam@communities.gov.uk": "73eecbb1-5dbc-4653-8c58-46aa79151210",
-        "digitalplanningteam@levellingup.gov.uk": "73eecbb1-5dbc-4653-8c58-46aa79151210",
-        "HighStreetRentalAuctions@levellingup.gov.uk": "0874cafb-a297-4f3c-bb3f-99bc578cce4a",
+        "HighStreetRentalAuctions@communities.gov.uk": "0874cafb-a297-4f3c-bb3f-99bc578cce4a",
         "sponsorship@communities.gov.uk": "cc80c848-a9e6-432a-bd3a-cf6fe6b77b3d",
         "chambid@communities.gov.uk": "51b1b1bb-5c4e-4faa-bca2-3e17c118c446",
     }


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-350

All emails sent to @levellingup are delivered to @communities (behind the scenes this was always done as a mail alias). We are no longer DLUHC, so let's scrub these remaining levellingup references.

We've updated the email reply-to addresses in Notify already. The reply-to IDs have not changed.