### PR TITLE
Add tests for DPIF fix and use test config for UAT env

### DIFF
--- a/pre_award/assess/config/__init__.py
+++ b/pre_award/assess/config/__init__.py
@@ -12,9 +12,9 @@ match FLASK_ENV:
         from pre_award.config.envs.development import DevelopmentConfig as Config
     case "dev":
         from pre_award.config.envs.dev import DevConfig as Config
-    case "test":
+    case "test" | "uat":
         from pre_award.config.envs.test import TestConfig as Config
-    case "uat" | "production":
+    case "production":
         from pre_award.config.envs.production import ProductionConfig as Config
     case _:
         from pre_award.config.envs.default import DefaultConfig as Config

--- a/tests/pre_award/application_store_tests/test_submit.py
+++ b/tests/pre_award/application_store_tests/test_submit.py
@@ -664,19 +664,37 @@ def test_flags_resubmitted_uncompeted_application(setup_submitted_application, d
     assert updated_flag_updates[0].assessment_flag_id == updated_assessment_flags[0].id
 
 
-@pytest.mark.fund_config(
-    {
-        "name": "Generated test fund",
-        "identifier": "1",
-        "short_name": "TEST",
-        "description": "Testing fund",
-        "welsh_available": False,
-        "name_json": {"en": "English title", "cy": "Welsh title"},
-        "funding_type": "COMPETED",
-        "rounds": [],
-    }
+COMPETED_CONFIG = {
+    "name": "Generated test fund",
+    "identifier": "1",
+    "short_name": "TEST",
+    "description": "Testing fund",
+    "welsh_available": False,
+    "name_json": {"en": "English title", "cy": "Welsh title"},
+    "funding_type": "COMPETED",
+    "rounds": [],
+}
+
+DPIF_CONFIG = {
+    "name": "Generated test fund",
+    "identifier": "1",
+    "short_name": "DPIF",
+    "description": "Testing fund",
+    "welsh_available": False,
+    "name_json": {"en": "English title", "cy": "Welsh title"},
+    "funding_type": "UNCOMPETED",
+    "rounds": [],
+}
+
+
+@pytest.mark.parametrize(
+    "fund_configs",
+    [
+        pytest.param(None, marks=pytest.mark.fund_config(COMPETED_CONFIG), id="COMPETED"),
+        pytest.param(None, marks=pytest.mark.fund_config(DPIF_CONFIG), id="DPIF"),
+    ],
 )
-def test_resubmitted_application_from_competed_fund(setup_submitted_application, db):
+def test_resubmitted_application_from_competed_fund(fund_configs, setup_submitted_application, db):
     application_id = str(setup_submitted_application)
     application = get_application(application_id, include_forms=True)
 

--- a/tests/pre_award/assess_tests/api_data/test_data.py
+++ b/tests/pre_award/assess_tests/api_data/test_data.py
@@ -534,6 +534,7 @@ mock_api_results = {
         "name": "Digital Planning Innovation Fund",
         "short_name": "DPIF",
         "description": "unit testing fund",
+        "funding_type": "UNCOMPETED",
     },
     "fund_store/funds/{fund_id}/rounds/{round_id}": {
         "id": test_round_id,

--- a/tests/pre_award/assess_tests/conftest.py
+++ b/tests/pre_award/assess_tests/conftest.py
@@ -998,3 +998,19 @@ def assert_fund_dashboard(
     all_text = " ".join(tr.text for tr in tbody.find_all("tr"))
     for v in expected_assigned_values:
         assert v in all_text
+
+
+def get_subcriteria_soup(request, assess_test_client):
+    # Mocking fsd-user-token cookie
+    token = create_valid_token(test_commenter_claims)
+    assess_test_client.set_cookie("fsd_user_token", token)
+
+    # Retrieve markers
+    application_id = request.node.get_closest_marker("application_id").args[0]
+    sub_criteria_id = request.node.get_closest_marker("sub_criteria_id").args[0]
+
+    # Send the GET request and parse the response
+    response = assess_test_client.get(
+        f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}"  # noqa
+    )
+    return BeautifulSoup(response.data, "html.parser")

--- a/tests/pre_award/assess_tests/conftest.py
+++ b/tests/pre_award/assess_tests/conftest.py
@@ -46,6 +46,13 @@ test_commenter_claims = {
     "roles": ["TF_COMMENTER", "UF_COMMENTER"],
 }
 
+test_dpif_commenter_claims = {
+    "accountId": "dpif_commenter",
+    "email": "commenter@test.com",
+    "fullName": "DPIF commenter User",
+    "roles": ["DPIF_COMMENTER"],
+}
+
 test_roleless_user_claims = {
     "accountId": "test-user",
     "email": "test@example.com",

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -14,6 +14,7 @@ from tests.pre_award.assess_tests.api_data.test_data import fund_specific_claim_
 from tests.pre_award.assess_tests.conftest import (
     assert_fund_dashboard,
     create_valid_token,
+    get_subcriteria_soup,
     test_commenter_claims,
     test_dpif_commenter_claims,
     test_lead_assessor_claims,
@@ -1298,20 +1299,9 @@ class TestRoutes:
         mock_get_bulk_accounts,
         mock_get_assessment_flags,
     ):
-        # Mocking fsd-user-token cookie
-        token = create_valid_token(test_commenter_claims)
-        assess_test_client.set_cookie("fsd_user_token", token)
-
-        application_id = request.node.get_closest_marker("application_id").args[0]
-        sub_criteria_id = request.node.get_closest_marker("sub_criteria_id").args[0]
-
-        response = assess_test_client.get(
-            f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}"  # noqa
-        )
-        soup = BeautifulSoup(response.data, "html.parser")
-        assert (
-            soup.title.string
-            == "test_theme_name – test_sub_criteria – Project In prog and Res – Assessment Hub – GOV.UK"
+        soup = get_subcriteria_soup(request, assess_test_client)
+        assert soup.title.string == (
+            "test_theme_name – test_sub_criteria – Project In prog and Res – Assessment Hub – GOV.UK"
         )
 
     @pytest.mark.application_id("uncompeted_app")
@@ -1333,17 +1323,8 @@ class TestRoutes:
         mock_get_bulk_accounts,
         mock_get_assessment_flags,
     ):
-        # Mocking fsd-user-token cookie
-        token = create_valid_token(test_commenter_claims)
-        assess_test_client.set_cookie("fsd_user_token", token)
-
-        application_id = request.node.get_closest_marker("application_id").args[0]
-        sub_criteria_id = request.node.get_closest_marker("sub_criteria_id").args[0]
-
-        response = assess_test_client.get(
-            f"/assess/application_id/{application_id}/sub_criteria_id/{sub_criteria_id}"  # noqa
-        )
-        soup = BeautifulSoup(response.data, "html.parser")
+        soup = get_subcriteria_soup(request, assess_test_client)
+        # Check that the expected text exists in a specified paragraph element.
         assert (
             "Review the applicant's responses and 'Accept all responses' when you're ready."
             in soup.findAll("p", class_="govuk-body")[4].text


### PR DESCRIPTION
### Change description

- Tests have been added for the changes in this [PR](https://github.com/communitiesuk/funding-service-pre-award/pull/423).
- We want to enable the uncompeted journey on the UAT environment by setting `"UNCOMPETED_WORKFLOW": True`. This needs to be done so that we can perform user testing of the uncompeted journey in UAT.

- [X] Unit tests and other appropriate tests added or updated
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Make sure uncompeted journey works as expected in UAT
