### PR TITLE
Update CHAM assessment deadline

### DIFF
--- a/pre_award/fund_store/config/fund_loader_config/FAB/cham_apply.py
+++ b/pre_award/fund_store/config/fund_loader_config/FAB/cham_apply.py
@@ -92,7 +92,7 @@ LOADER_CONFIG = {
         "deadline": "2025-05-18T22:59:00",
         "application_reminder_sent": False,
         "reminder_date": "2025-05-13T08:00:00",
-        "assessment_deadline": "2025-06-01T22:59:00",
+        "assessment_deadline": "2025-06-01T23:59:00",
         "prospectus": "https://www.gov.uk/government/publications/combatting-hate-against-muslims-fund-prospectus",
         "privacy_notice": "https://www.gov.uk/government/publications/combatting-hate-against-muslims-fund-prospectus/combatting-hate-against-muslims-privacy-notice",
         "contact_email": "chambid@communities.gov.uk",


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1299

Description:
Update CHAM assessment deadline to 23:59 on 1 June 2025.
