### PR TITLE
BAU PFN Update Application Submitted template

### DIFF
--- a/pre_award/apply/default/application_routes.py
+++ b/pre_award/apply/default/application_routes.py
@@ -497,6 +497,7 @@ def submit_application():
                 application_email=application_email,
                 fund_name=fund_data.name,
                 fund_short_name=fund_data.short_name,
+                round_id=round_data.id,
                 fund_type=fund_data.funding_type,
                 round_short_name=round_data.short_name,
                 assessment_start_date=assessment_start_date,

--- a/pre_award/apply/templates/apply/application_submitted.html
+++ b/pre_award/apply/templates/apply/application_submitted.html
@@ -26,10 +26,13 @@ import govukButton -%}
           <p class="govuk-body">
             {% trans %}You do not need to do anything else at this time.{% endtrans %}
           </p>
-
+          <!-- TODO Assuming that this is the only round (PFN-RP) that is not going to need the hardcoded text
+            "The assessors will start ...". otherwise we need to find a better way to handle this -->
+          {% if round_id|string != '9217792e-d8c2-45c8-8170-eed4a8946184' %}
           <p class="govuk-body">
             {% trans %}The assessors will start reviewing applications from {% endtrans %}{{ assessment_start_date }}.
           </p>
+          {% endif %}
           {% if fund_type == "UNCOMPETED" %}
             <p class="govuk-body">{% trans %}We’ll email you if the assessor needs additional information or has any questions about your application for{% endtrans %} {{fund_name}}.</p>
           {% endif %}


### PR DESCRIPTION
### Change description
- PFN RP does not want to see the text on application submitted page "The assessors will start reviewing applications from"
- Skipping that text for this round, will need to find a better solution if it is a requirement anticipated from other funds as well

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")