### PR TITLE
Restrict commenter actions

### DIFF
--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1331,7 +1331,7 @@ def display_sub_criteria(  # noqa: C901
     "/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/accept_changes",
     methods=["GET", "POST"],
 )
-@check_access_application_id
+@check_access_application_id(roles_required=[Config.LEAD_ASSESSOR, Config.ASSESSOR])
 def accept_changes(application_id, sub_criteria_id):
     form = ChangeRequestForm()
     state = get_state_for_tasklist_banner(application_id)
@@ -1378,7 +1378,7 @@ def accept_changes(application_id, sub_criteria_id):
     "/application_id/<application_id>/sub_criteria_id/<sub_criteria_id>/theme_id/<theme_id>/request_change",
     methods=["GET", "POST"],
 )
-@check_access_application_id
+@check_access_application_id(roles_required=[Config.LEAD_ASSESSOR, Config.ASSESSOR])
 def request_changes(application_id, sub_criteria_id, theme_id):
     sub_criteria = get_sub_criteria(application_id, sub_criteria_id)
     current_theme = next(iter(t for t in sub_criteria.themes if t.id == theme_id))

--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -69,8 +69,10 @@
 
 {{ theme(answers_meta)}}
 {% if not score and not has_active_change_request %}
-    {{ application_feedback(application_id, sub_criteria, current_theme.id,
-    approval_form,change_requests,unrequested_changes) }}
+    {% if g.access_controller.is_assessor or g.access_controller.is_lead_assessor %}
+        {{ application_feedback(application_id, sub_criteria, current_theme.id,
+        approval_form,change_requests,unrequested_changes) }}
+    {% endif %}
 {% endif %}
 {% if score %}
     <h2 class="govuk-heading-s govuk-!-margin-top-8 accepted-change-title">Responses accepted</h2>


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1303

Description:
Restrict commenter actions for uncompeted workflow: 
 - not allow them to approve a sub-criteria
 - or not allow them requesting a change.
