### PR TITLE
scrollable tabular data

### DIFF
--- a/pre_award/assess/static/src/styles/govuk-overrides.css
+++ b/pre_award/assess/static/src/styles/govuk-overrides.css
@@ -405,3 +405,8 @@ a.govuk-link.deactivate {
     font-size: medium;
     width: 54px;
 }
+.custom-scrollable-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+}

--- a/pre_award/assess/templates/assess/macros/theme/new_add_another_table.jinja2
+++ b/pre_award/assess/templates/assess/macros/theme/new_add_another_table.jinja2
@@ -1,13 +1,12 @@
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 
 {% macro new_add_another_table(meta) %}
-
     {{ govukTable({
-         'caption': meta.caption,
-         'captionClasses': 'govuk-heading-m',
-         'firstCellIsHeader': False,
-         'head': meta.head,
-         'rows': meta.rows
+        'classes': 'custom-scrollable-table',
+        'caption': meta.caption,
+        'captionClasses': 'govuk-heading-m',
+        'firstCellIsHeader': False,
+        'head': meta.head,
+        'rows': meta.rows
     }) }}
-
 {% endmacro %}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-1347

PFN has long tables they want to view in Assess. Large tables were previously overflowing and not responsive. This custom change makes the tables scrollable for now to fix the issue with PFN's finance tables. 

To test You'd need to add finance tables from PFN to the scored section.
Before

![Screenshot 2025-06-26 at 15 12 42](https://github.com/user-attachments/assets/d068674c-7d25-4572-b94f-505df9584c53)

After

https://github.com/user-attachments/assets/da9d82b0-df34-4bcf-92fb-633dcfedb816


