### PR TITLE
Prevent sending change received email to competitive funds

### DIFF
--- a/pre_award/application_store/_helpers/application.py
+++ b/pre_award/application_store/_helpers/application.py
@@ -135,7 +135,9 @@ def send_submit_notification(
 
 
 def send_change_received_notification(fund, round_data):
-    if fund.funding_type != "UNCOMPETED":
+    if (
+        fund.short_name == "DPIF" or fund.funding_type != "UNCOMPETED"
+    ):  # TODO remove DPIF conditon once we move it to COMPETITIVE funds`
         return
     get_notification_service().send_change_received_email(
         email_address=round_data.contact_email,

--- a/tests/pre_award/application_store_tests/test_submit.py
+++ b/tests/pre_award/application_store_tests/test_submit.py
@@ -904,6 +904,7 @@ def test_send_change_received_notification_skip_for_competitive_fund(
 
     fund_id = get_fund_id(setup_completed_application)
     fund_data = get_fund(fund_id)
+    fund_data.short_name = "DPIF"
     fund_data.funding_type = "COMPETITIVE"
     send_change_received_notification(
         fund=fund_data,


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-1336

This change makes sure that change received emails are only sent for UNCOMPETED funds.

Right now, during resubmission, emails were also being sent to COMPETED funds by mistake. Even though this will be fixed in a separate [PR](https://github.com/communitiesuk/funding-service-pre-award/pull/469) , it’s still good to add this check to prevent it from happening again.
