### PR TITLE
Remove outdated text from success banners

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_accepted.html
@@ -30,7 +30,6 @@
                 }) }}
                 <h2 class="govuk-heading-l govuk-!-margin-top-8">What happens next</h2>
                 <p class="govuk-body">We&#39;ve emailed the applicant to let them know that you&#39;ve approved their responses.</p>
-                <p class="govuk-body">If you need the applicant to make more changes, you can request another change.</p>
                 <p class="govuk-body">
                     The status will now be marked as <strong>&#39;Complete&#39;</strong>.
                 </p>

--- a/pre_award/assess/assessments/templates/assessments/change_request_success_page.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_success_page.html
@@ -26,7 +26,6 @@ Request changes –
       <p class="govuk-body">We've emailed the applicant to let them know you've requested changes.</p>
       <p class="govuk-body">They'll need to sign in to their application form to see your change requests.</p>
       <p class="govuk-body">We'll email you when the applicant makes changes.</p>
-      <p class="govuk-body">If you need the applicant to make more changes, you can request another change.</p>
       <p class="govuk-body">The status will now be marked as <b>'Change requested'</b>.</p>
 
       <a


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1256

Description:
This PR removes the “If you need the applicant to make more changes, you can request another change.” text from two banners. 

The original screenshots (containing the sentence above) can be found in the ticket. 

Screenshots of the updated banners:
![Screenshot 2025-07-07 at 09 27 40](https://github.com/user-attachments/assets/8f75be79-b49c-4530-ba26-07836f2e56e2)

![Screenshot 2025-07-07 at 09 21 17](https://github.com/user-attachments/assets/fff499c1-51c1-433a-9c6c-6e805fc92dd1)
