### PR TITLE
Increase 'Add a comment' link font size

### DIFF
--- a/pre_award/assess/templates/assess/macros/comments.html
+++ b/pre_award/assess/templates/assess/macros/comments.html
@@ -7,7 +7,7 @@
             {% if sub_criteria and current_theme and display_comment_box != True and not display_comment_edit_box %}
                 <a
                     id="comment"
-                    class="govuk-link govuk-link--no-visited-state"
+                    class="govuk-body govuk-link govuk-link--no-visited-state"
                     type="submit"
                     data-module="govuk-button"
                     href="{{ url_for(


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1262

Description:
This PR matches the 'Add a comment' link's font size to other texts on page.


Before:
<img width="1014" alt="Screenshot 2025-07-07 at 11 37 38" src="https://github.com/user-attachments/assets/0e0b47f8-4881-42cb-8fab-aca65ac3be08" />

After:
![Screenshot 2025-07-07 at 11 39 10](https://github.com/user-attachments/assets/7f043770-0ec4-4436-be55-8584d6eb07a0)

