### PR TITLE
BAU: Update PFN RP subcriterias' titles

### DIFF
--- a/pre_award/assessment_store/config/mappings/pfn_mapping_parts/rp_scored_sections.py
+++ b/pre_award/assessment_store/config/mappings/pfn_mapping_parts/rp_scored_sections.py
@@ -8,11 +8,11 @@ scored_sections = [
         "sub_criteria": [
             {
                 "id": "do-the-activities-being-pursued-by-a-place-fit-with-the-plan-for-neighbourhoods-programme-objectives",
-                "name": "Do the activities being pursued by a place fit with the Plan for Neighbourhoods programme objectives?",
+                "name": "Activities. Do the activities being pursued by a place fit with the Plan for Neighbourhoods programme objectives?",
                 "themes": [
                     {
                         "id": "do-the-activities-being-pursued-by-a-place-fit-with-the-plan-for-neighbourhoods-programme-objectives",
-                        "name": "Do the activities being pursued by a place fit with the Plan for Neighbourhoods programme objectives?",
+                        "name": "Activities. Do the activities being pursued by a place fit with the Plan for Neighbourhoods programme objectives?",
                         "answers": [
                             {
                                 "field_id": "yMWAhw",
@@ -232,11 +232,11 @@ scored_sections = [
             },
             {
                 "id": "does-the-place-have-a-credible-and-realistic-expenditure-forecast-fitting-with-the-funding-flexibility-rules",
-                "name": "Does the place have a credible and realistic expenditure forecast, fitting with the funding flexibility rules?",
+                "name": "Expenditure. Does the place have a credible and realistic expenditure forecast, fitting with the funding flexibility rules?",
                 "themes": [
                     {
                         "id": "does-the-place-have-a-credible-and-realistic-expenditure-forecast-fitting-with-the-funding-flexibility-rules",
-                        "name": "Does the place have a credible and realistic expenditure forecast, fitting with the funding flexibility rules?",
+                        "name": "Expenditure. Does the place have a credible and realistic expenditure forecast, fitting with the funding flexibility rules?",
                         "answers": [
                             {
                                 "field_id": "lREPmq",
@@ -877,11 +877,11 @@ scored_sections = [
             },
             {
                 "id": "have-the-local-community-and-key-stakeholders-been-key-in-informing-and-shaping-the-plan-and-will-they-be-actively-involved-in-evolution-and-delivery-of-the-plan-throughout-the-next-decade",
-                "name": "Have the local community and key stakeholders been key in informing and shaping the plan and will they be actively involved in evolution and delivery of the plan throughout the next decade?",
+                "name": "Community. Have the local community and key stakeholders been key in informing and shaping the plan and will they be actively involved in evolution and delivery of the plan throughout the next decade?",
                 "themes": [
                     {
                         "id": "have-the-local-community-and-key-stakeholders-been-key-in-informing-and-shaping-the-plan-and-will-they-be-actively-involved-in-evolution-and-delivery-of-the-plan-throughout-the-next-decade",
-                        "name": "Have the local community and key stakeholders been key in informing and shaping the plan and will they be actively involved in evolution and delivery of the plan throughout the next decade?",
+                        "name": "Community. Have the local community and key stakeholders been key in informing and shaping the plan and will they be actively involved in evolution and delivery of the plan throughout the next decade?",
                         "answers": [
                             {
                                 "field_id": "gAJCVy",
@@ -1101,11 +1101,11 @@ scored_sections = [
             },
             {
                 "id": "will-appropriate-governance-arrangements-be-in-place-to-fully-realise-the-intended-role-of-the-neighbourhood-board-and-to-allow-the-board-to-work-in-partnership-with-the-accountable-body-to-deliver-the-programme-successfully",
-                "name": "Will appropriate governance arrangements be in place to fully realise the intended role of the Neighbourhood Board and to allow the board to work in partnership with the accountable body to deliver the programme successfully?",
+                "name": "Governance. Will appropriate governance arrangements be in place to fully realise the intended role of the Neighbourhood Board and to allow the board to work in partnership with the accountable body to deliver the programme successfully?",
                 "themes": [
                     {
                         "id": "will-appropriate-governance-arrangements-be-in-place-to-fully-realise-the-intended-role-of-the-neighbourhood-board-and-to-allow-the-board-to-work-in-partnership-with-the-accountable-body-to-deliver-the-programme-successfully",
-                        "name": "Will appropriate governance arrangements be in place to fully realise the intended role of the Neighbourhood Board and to allow the board to work in partnership with the accountable body to deliver the programme successfully?",
+                        "name": "Governance. Will appropriate governance arrangements be in place to fully realise the intended role of the Neighbourhood Board and to allow the board to work in partnership with the accountable body to deliver the programme successfully?",
                         "answers": [
                             {
                                 "field_id": "qjonxe",
@@ -1267,11 +1267,11 @@ scored_sections = [
             },
             {
                 "id": "will-appropriate-control-processes-will-be-in-place-for-management-of-public-funds",
-                "name": "Will appropriate control processes will be in place for management of public funds?",
+                "name": "Management. Will appropriate control processes will be in place for management of public funds?",
                 "themes": [
                     {
                         "id": "will-appropriate-control-processes-will-be-in-place-for-management-of-public-funds",
-                        "name": "Will appropriate control processes will be in place for management of public funds?",
+                        "name": "Management. Will appropriate control processes will be in place for management of public funds?",
                         "answers": [
                             {
                                 "field_id": "lsLcXO",


### PR DESCRIPTION
Requirement from the fund team to update the titles :

> Activities. Do the activities being pursued by a place fit with the Plan for Neighbourhoods programme objectives?
Expenditure. Does the place have a credible and realistic expenditure forecast, fitting with the funding flexibility rules?
Community. Have the local community and key stakeholders been key in informing and shaping the plan and will they be actively involved in evolution and delivery of the plan throughout the next decade?
Governance. Will appropriate governance arrangements be in place to fully realise the intended role of the Neighbourhood Board and to allow the board to work in partnership with the accountable body to deliver the programme successfully?
Management. Will appropriate control processes will be in place for management of public funds? 


### Change description
- Updated the PFN RP subcriteria titles as requested by the PFN team

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test:
- Go to PFN RP in assess, and verify the updated subriteria titles are being shown


### Screenshots of UI changes (if applicable)
Before:

<img width="378" alt="Screenshot 2025-07-09 at 13 16 05" src="https://github.com/user-attachments/assets/f97d14f9-4e8b-40ce-a084-2511f8a09c31" />

After:

<img width="382" alt="Screenshot 2025-07-09 at 13 16 37" src="https://github.com/user-attachments/assets/126be288-df02-4bb5-8c5b-530b9bccb187" />

