### PR TITLE
BAU: Enabling UNCOMPETED_WORKFLOW for all envs

### DIFF
--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -325,7 +325,7 @@ class DefaultConfig(object):
     FEATURE_CONFIG = {
         "TAGGING": True,
         "ASSESSMENT_ASSIGNMENT": False,
-        "UNCOMPETED_WORKFLOW": False,
+        "UNCOMPETED_WORKFLOW": True,
         **CommonConfig.dev_feature_configuration,
     }
 


### PR DESCRIPTION
PFN needs to use the Uncompeted journey in UAT hence enabling it for all envs


### Change description
- Enable UNCOMPETED_WORKFLOW flag in DefaultConfig env

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Check that uncompeted features are working in UAT env
