### PR TITLE
Remove outdated sentence from template

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/change_request_success_page.html
+++ b/pre_award/assess/assessments/templates/assessments/change_request_success_page.html
@@ -26,7 +26,6 @@ Request changes –
       <p class="govuk-body">We've emailed the applicant to let them know you've requested changes.</p>
       <p class="govuk-body">They'll need to sign in to their application form to see your change requests.</p>
       <p class="govuk-body">We'll email you when the applicant makes changes.</p>
-      <p class="govuk-body">If you need the applicant to make more changes, you can request another change.</p>
       <p class="govuk-body">The status will now be marked as <b>'Change requested'</b>.</p>
 
       <a


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1256

Description:
This PR removes the “If you need the applicant to make more changes, you can request another change.” text from the success page after making a change-request.

The original screenshots (containing the sentence above) can be found in the ticket.


Screenshot (before):
<img width="820" height="916" alt="Screenshot 2025-07-10 at 12 51 03" src="https://github.com/user-attachments/assets/a9365a72-41b7-4f5a-918f-85dc595b6257" />

Screenshots of the updated page:
<img width="781" height="887" alt="Screenshot 2025-07-10 at 12 49 31" src="https://github.com/user-attachments/assets/a86cfa78-734f-4c62-b2d3-d5ea745a13a4" />

