### PR TITLE
FLS-1378 - Fix fund type filter on assessor dashboard

### DIFF
--- a/pre_award/assess/services/models/fund.py
+++ b/pre_award/assess/services/models/fund.py
@@ -33,7 +33,7 @@ class Fund:
     # TODO: Move fund_type to a property on fund_store
     @property
     def fund_types(self) -> set[str]:
-        return {ALL_VALUE, "competitive"}
+        return {ALL_VALUE, self.funding_type}
 
     def add_round(self, fund_round: Round):
         if not self.rounds:

--- a/pre_award/assess/templates/assess/macros/assessor_tool_dashboard_filters.html
+++ b/pre_award/assess/templates/assess/macros/assessor_tool_dashboard_filters.html
@@ -21,8 +21,9 @@
             </label>
             <select id="filter_fund_type" name="filter_fund_type" class="govuk-select">
                 {{ generate_option(filters.filter_fund_type, 'ALL', 'All') }}
-                {{ generate_option(filters.filter_fund_type, 'competitive', 'Competitive fund') }}
-                {{ generate_option(filters.filter_fund_type, 'allocative', 'Allocative fund') }}
+                {{ generate_option(filters.filter_fund_type, 'COMPETITIVE', 'Competitive fund') }}
+                {{ generate_option(filters.filter_fund_type, 'UNCOMPETED', 'Uncompeted fund') }}
+                {{ generate_option(filters.filter_fund_type, 'EOI', 'Expression of Interest') }}
             </select>
         </div>
         <div class="govuk-form-group govuk-!-display-inline-block">


### PR DESCRIPTION
### Ticket

[Investigate - The Filter by fund type on the funding service dashboard is not filtering correctly](https://mhclgdigital.atlassian.net/browse/FLS-1378)

### Description

The fund type filtering on the assessor tool dashboard was not working correctly due to a mismatch between frontend filter values and database enum values. The Fund model's fund_types property was hardcoded to return {"ALL", "competitive"} regardless of the fund's actual funding type, causing filters like "Allocative fund" (which should match UNCOMPETED funds) to return no results. This has been fixed by updating the fund_types property to dynamically return the correct funding type based on the fund's actual funding_type field, and updating the frontend filter dropdown to use the database enum values (COMPETITIVE, UNCOMPETED, EOI) directly while maintaining user-friendly display text.

### How to test

- Spin up Assess locally
- Go to the assessor dashboard (@ https://assessment.communities.gov.localhost:3010/assess/assessor_tool_dashboard)
- Ensure that you have competitive and uncompeted funds in your database - you can run the SQL query `SELECT short_name, funding_type FROM public.fund`
- Filter to "Competitive fund" and observe that only competitive funds are returned; likewise for "Allocative fund"

### Screenshots

<img width="1751" height="965" alt="image" src="https://github.com/user-attachments/assets/3254768a-c2f9-41c1-946d-6e7dc1144796" />

<img width="1751" height="966" alt="image" src="https://github.com/user-attachments/assets/bb77b106-a212-4ac6-8ca1-5f64e77bf1ab" />
