### PR TITLE
FLS-1424: Fix tabular data ordering

### DIFF
--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -90,7 +90,6 @@ from pre_award.assess.services.aws import get_file_for_download_from_aws
 from pre_award.assess.services.data_services import (
     assign_user_to_assessment,
     get_all_associated_tags_for_application,
-    get_all_sub_criterias_with_application_json,
     get_all_uploaded_documents_theme_answers,
     get_applicant_export,
     get_applicant_feedback_and_survey_report,
@@ -141,7 +140,10 @@ from pre_award.assess.themes.deprecated_theme_mapper import (
     map_application_with_sub_criterias_and_themes,
     order_entire_application_by_themes,
 )
-from pre_award.assessment_store.api.routes.assessment_routes import calculate_overall_score_percentage_for_application
+from pre_award.assessment_store.api.routes.assessment_routes import (
+    calculate_overall_score_percentage_for_application,
+    get_application_json_and_sub_criterias,
+)
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as WorkflowStatus
 from pre_award.assessment_store.db.queries.flags.queries import (
     get_change_requests_for_application,
@@ -1887,7 +1889,7 @@ def view_entire_application(application_id):
     state = get_state_for_tasklist_banner(application_id)
     fund_round_name = state.fund_short_name + state.round_short_name
 
-    _data = get_all_sub_criterias_with_application_json(application_id)
+    _data = get_application_json_and_sub_criterias(application_id)
     application_json = _data["application_json"]
     sub_criterias = _data["sub_criterias"]
 

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -22,6 +22,7 @@ from pre_award.assess.services.models.sub_criteria import SubCriteria
 from pre_award.assess.shared.helpers import get_ttl_hash
 from pre_award.assess.tagging.models.tag import AssociatedTag, Tag, TagType
 from pre_award.assess.themes.deprecated_theme_mapper import map_application_with_sub_criteria_themes_fields
+from pre_award.assessment_store.api.routes.assessment_routes import get_application_json_and_sub_criterias
 from pre_award.assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as WorkflowStatus
 from pre_award.common.locale_selector.get_lang import get_lang
@@ -656,11 +657,7 @@ def get_sub_criteria_theme_answers_all(
     application_id: str,
     theme_id: str,
 ) -> Union[list, None]:
-    theme_mapping_data_url = (
-        f"{Config.ASSESSMENT_STORE_API_HOST}"
-        f"{Config.SUB_CRITERIA_THEME_ANSWERS_ENDPOINT.format(application_id=application_id)}"
-    )
-    theme_mapping_data = get_data(theme_mapping_data_url)
+    theme_mapping_data = get_application_json_and_sub_criterias(application_id)
     theme_question_answers = map_application_with_sub_criteria_themes_fields(
         theme_mapping_data["application_json"],
         theme_mapping_data["sub_criterias"],
@@ -668,15 +665,6 @@ def get_sub_criteria_theme_answers_all(
     )
     mark_themes_with_changes(theme_mapping_data["application_json"], theme_question_answers)
     return theme_question_answers
-
-
-def get_all_sub_criterias_with_application_json(application_id: str):
-    theme_mapping_data_url = (
-        f"{Config.ASSESSMENT_STORE_API_HOST}"
-        f"{Config.SUB_CRITERIA_THEME_ANSWERS_ENDPOINT.format(application_id=application_id)}"
-    )
-    theme_mapping_data = get_data(theme_mapping_data_url)
-    return theme_mapping_data
 
 
 def mark_themes_with_changes(application_json, theme_fields):

--- a/pre_award/assessment_store/config/mappings/pfn_mapping_parts/rp_scored_sections.py
+++ b/pre_award/assessment_store/config/mappings/pfn_mapping_parts/rp_scored_sections.py
@@ -277,8 +277,12 @@ scored_sections = [
                                             "column_title": "Capacity funding (2027-28)",
                                             "type": "numberField",
                                         },
-                                        "mjXkxo": {
+                                        "OdZjMh": {
                                             "column_title": "Capacity funding (2028-29)",
+                                            "type": "numberField",
+                                        },
+                                        "DbQDzt": {
+                                            "column_title": "Capacity funding (2029-30)",
                                             "type": "numberField",
                                         },
                                     },
@@ -292,24 +296,28 @@ scored_sections = [
                                 "question": [
                                     "",
                                     {
-                                        "jhEJRB": {
-                                            "column_title": "Capacity funding (2029-30)",
-                                            "type": "numberField",
-                                        },
-                                        "IlUUxg": {
+                                        "mjXkxo": {
                                             "column_title": "Capacity funding (2030-31)",
                                             "type": "numberField",
                                         },
-                                        "nZFwqm": {
+                                        "jhEJRB": {
                                             "column_title": "Capacity funding (2031-32)",
                                             "type": "numberField",
                                         },
-                                        "rQUbSC": {
+                                        "nZFwqm": {
+                                            "column_title": "Capacity funding (2032-33)",
+                                            "type": "numberField",
+                                        },
+                                        "IlUUxg": {
                                             "column_title": "Capacity funding (2033-34)",
                                             "type": "numberField",
                                         },
                                         "GCnfMS": {
-                                            "column_title": "Capacity funding (2034-25)",
+                                            "column_title": "Capacity funding (2034-35)",
+                                            "type": "numberField",
+                                        },
+                                        "rQUbSC": {
+                                            "column_title": "Capacity funding (2035-36)",
                                             "type": "numberField",
                                         },
                                     },

--- a/pre_award/assessment_store/openapi/api.yml
+++ b/pre_award/assessment_store/openapi/api.yml
@@ -633,33 +633,6 @@ paths:
               schema:
                 type: object
                 $ref: 'assessor_task_list.yml#/components/schemas/AssessorTaskListState'
-  '/sub_criteria_themes/{application_id}':
-    parameters:
-    - name: application_id
-      in: path
-      required: true
-      schema:
-        type: string
-        format: path
-    get:
-      tags:
-        - assessments
-      summary: Retrieves application json and sub criterias
-      description: Retrieves application json and sub criterias
-      operationId: assessment_store.api.routes.get_application_json_and_sub_criterias
-      responses:
-        200:
-          description: SUCCESS
-          content:
-            application/json:
-              example:
-                {}
-        500:
-          description: "Bad request - Incorrect application_id or theme_id"
-          content:
-            application/json:
-              schema:
-                $ref: 'components.yml#/components/schemas/GeneralError'
   '/comment':
     get:
       tags:

--- a/pre_award/config/envs/default.py
+++ b/pre_award/config/envs/default.py
@@ -383,8 +383,6 @@ class DefaultConfig(object):
         ASSESSMENT_STORE_API_HOST + "/application/{application_id}/all_uploaded_documents"
     )
 
-    SUB_CRITERIA_THEME_ANSWERS_ENDPOINT = "/sub_criteria_themes/{application_id}"
-
     SUB_CRITERIA_OVERVIEW_ENDPOINT = "/sub_criteria_overview/{application_id}/{sub_criteria_id}"
 
     SUB_CRITERIA_BANNER_STATE_ENDPOINT = "/sub_criteria_overview/banner_state/{application_id}"


### PR DESCRIPTION
### Ticket
https://mhclgdigital.atlassian.net/browse/FLS-1424

### Problem/Bug

When multi-input fields were configured to display in a tabular format for the PFN RP Expenditure subcriteria, the columns appeared in an incorrect or seemingly random order. This PR addresses and resolves that issue by ensuring the fields are rendered in the correct sequence.

### Context

While investigating why the columns were not appearing in the Applicant Response section of Assess, I discovered that the issue stemmed from the get_data method. This method was used to call an endpoint '/sub_criteria_themes/{application_id}' that fetched the JSON subcriteria. Although it was only intended to retrieve the data, it implicitly ordered the fields based on the keys (e.g., "kzCRNQ"), which affected the column rendering.

Additionally, since we've transitioned to a monolith infrastructure, it's now best practice to avoid using endpoints to interact with other parts of Pre-Award (such as assessment-store and application-store). Instead, we should directly query the relevant services or use their existing methods. In line with this, I replaced the endpoint call with a direct invocation of the appropriate route method within the service get_application_json_and_sub_criterias.

### Change description
- Replaced call to endpoint '/sub_criteria_themes/{application_id}' with call to the method itself get_application_json_and_sub_criterias
- Removed get_all_sub_criterias_with_application_json from data_services since it's only calling the endpoint, instead replaced where the removed method (get_all_sub_criterias_with_application_json) was being called with call to the intended route's method get_application_json_and_sub_criterias
- Removed the endpoint /sub_criteria_themes/{application_id} from the api.yml and from default.py since it's not being used anywhere.

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Go to a fund that uses tabular representation of multiinput fields in Assess, e.g. PFN RP
- Go to the subcriteria where we show that tabular information, e.g. Expenditure subcriteria in PFN RP
- Make sure that the tabular information is being displayed in correct order e.g. in case of PFN RP the information is chronologinally in correct order, 2024 then 2025 then 2026 and so on
- Go to the Assessment tasklist page of the same application and click on the "View entire application" button make sure all tabular data is also being shown in correct order here.


### Screenshots of UI changes (if applicable)
### Before:
**Subcriteria page:**
<img width="958" height="375" alt="Screenshot 2025-07-17 at 11 53 39" src="https://github.com/user-attachments/assets/c701e880-abc9-4345-a7eb-d5b06308a5ca" />

**View entire application page:**
<img width="1479" height="340" alt="Screenshot 2025-07-17 at 11 54 04" src="https://github.com/user-attachments/assets/dd06610f-f16f-4e14-9329-a85dfd26966f" />

### After:
**Subcriteria page:**
<img width="980" height="426" alt="Screenshot 2025-07-17 at 11 55 24" src="https://github.com/user-attachments/assets/7446ed70-e04d-4a1c-88a9-c706f811e91a" />

**View entire application page:**
<img width="1470" height="410" alt="Screenshot 2025-07-17 at 11 55 39" src="https://github.com/user-attachments/assets/f211e260-44fd-440c-b530-9ccc4244e2be" />