### PR TITLE
implement comments-export for single application

### DIFF
--- a/pre_award/application_store/db/queries/comments/queries.py
+++ b/pre_award/application_store/db/queries/comments/queries.py
@@ -13,12 +13,14 @@ from pre_award.assessment_store.db.models.comment.comments_update import Comment
 from pre_award.db import db
 
 
-def retrieve_all_comments(fund_id, round_id):
+def retrieve_all_comments(fund_id, round_id, application_id=None):
     filters = []
     if fund_id:
         filters.append(Applications.fund_id == fund_id)
     if round_id:
         filters.append(Applications.round_id == round_id)
+    if application_id:
+        filters.append(Applications.id == application_id)
 
     results = (
         db.session.query(CommentsUpdate, Comment, Applications, Account)
@@ -26,7 +28,7 @@ def retrieve_all_comments(fund_id, round_id):
         .join(Applications, Comment.application_id == Applications.id)
         .join(Account, Comment.user_id == cast(Account.id, String))
         .filter(*filters)
-        .order_by(Comment.application_id, Comment.sub_criteria_id)
+        .order_by(Comment.application_id, Comment.sub_criteria_id, Comment.date_created)
         .all()
     )
 
@@ -45,6 +47,13 @@ def retrieve_all_comments(fund_id, round_id):
         sub_criteria = get_sub_criteria(first_application_id, sub_criteria_id)
         sub_criteria_name_map[sub_criteria_id] = sub_criteria.name if sub_criteria.name else None
 
+    comments_list = build_comments_list(results, sub_criteria_name_map)
+
+    return comments_list
+
+
+def build_comments_list(results, sub_criteria_name_map):
+    """Build a list of comment dictionaries from query results."""
     comments_list = []
     for cu, comment, application, commenter_account in results:
         comments_list.append(
@@ -63,7 +72,6 @@ def retrieve_all_comments(fund_id, round_id):
                 "Comment": cu.comment,
             }
         )
-
     return comments_list
 
 
@@ -71,6 +79,7 @@ def export_comments_to_excel(
     comments_list,
     fund_short_name,
     round_short_name,
+    application_id=None,
 ):
     output = io.BytesIO()
     df = pd.DataFrame(comments_list)
@@ -79,8 +88,13 @@ def export_comments_to_excel(
     output.seek(0)
 
     date_str = datetime.now().strftime("%d-%m-%Y")
-    filename = f"comments_export_{fund_short_name.upper()}_{round_short_name.upper()}_{date_str}.xlsx"
-
+    if application_id:
+        filename = (
+            f"comments_export_{fund_short_name.upper()}_{round_short_name.upper()}"
+            f"_Application_ID_{application_id}_{date_str}.xlsx"
+        )
+    else:
+        filename = f"comments_export_{fund_short_name.upper()}_{round_short_name.upper()}_{date_str}.xlsx"
     return send_file(
         output,
         mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -1709,6 +1709,7 @@ def application(application_id):
         comment_form=comment_form,
         comments=theme_matched_comments,
         fund=fund,
+        round=fund_round,
         percentage_score=percentage_score,
     )
 
@@ -1845,6 +1846,27 @@ def comments_export(fund_short_name, round_short_name):
 
     comments_list = retrieve_all_comments(round.fund_id, round.id)
     return export_comments_to_excel(comments_list, fund_short_name, round_short_name)
+
+
+@assessment_bp.route(
+    "/comments_export_for_application/<fund_short_name>/<round_short_name>/<application_id>",
+    methods=["GET"],
+)
+@check_access_fund_short_name_round_sn(roles_required=[Config.LEAD_ASSESSOR])
+def comments_export_for_application(fund_short_name, round_short_name, application_id):
+    rnd = get_round(
+        fund_short_name,
+        round_short_name,
+        use_short_name=True,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+
+    comments_list = retrieve_all_comments(
+        rnd.fund_id,
+        rnd.id,
+        application_id=application_id,
+    )
+    return export_comments_to_excel(comments_list, fund_short_name, round_short_name, application_id)
 
 
 @assessment_bp.route("/qa_complete/<application_id>", methods=["GET", "POST"])

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -54,7 +54,7 @@
 {# djlint:on #}
     <div class="govuk-grid-column-one-quarter">
         {% if g.access_controller.is_assessor %}
-            {{ assessment_actions(application_id) }}
+            {{ assessment_actions(application_id, fund.short_name, round.short_name) }}
         {% endif %}
 
         {{ comment(comments, application_id, True, display_comment_box, display_comment_edit_box) }}

--- a/pre_award/assess/templates/assess/macros/assessment_actions.html
+++ b/pre_award/assess/templates/assess/macros/assessment_actions.html
@@ -1,7 +1,16 @@
-{% macro assessment_actions(application_id) %}
+{% macro assessment_actions(application_id, fund_short_name, round_short_name) %}
 
     <h3 class="govuk-heading-m">Assessment actions</h3>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible section_break_blue">
     <p class="govuk-body">   <a href="{{ url_for('assessment_bp.view_entire_application', application_id=application_id) }}" target="_blank">View entire application (opens in new tab)</a></p>
 
+    {% if g.access_controller.is_lead_assessor %}
+        <p class="govuk-body">
+            <a href="{{ url_for('assessment_bp.comments_export_for_application',
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
+            application_id=application_id) }}">
+            Export assessment comments</a>
+        </p>
+    {% endif %}
 {% endmacro %}

--- a/pre_award/assessment_store/db/models/comment/enums.py
+++ b/pre_award/assessment_store/db/models/comment/enums.py
@@ -11,6 +11,6 @@ class CommentType(Enum):
     @property
     def label(self):
         if self == CommentType.WHOLE_APPLICATION:
-            return "Whole application comment"
+            return "Application-level comment"
         elif self == CommentType.COMMENT:
             return "Sub-criteria comment"

--- a/tests/pre_award/application_store_tests/test_submit.py
+++ b/tests/pre_award/application_store_tests/test_submit.py
@@ -1,9 +1,12 @@
+import io
 import json
-from datetime import datetime, timezone
+from collections import Counter
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pandas as pd
 import pytest
 from click.testing import CliRunner
 from flask_session import Session
@@ -21,6 +24,7 @@ from pre_award.application_store.db.queries.application.queries import (
     submit_application,
     update_application_fields,
 )
+from pre_award.application_store.db.queries.comments.queries import export_comments_to_excel, retrieve_all_comments
 from pre_award.application_store.db.queries.form.queries import add_new_forms
 from pre_award.application_store.db.queries.updating.queries import update_form
 from pre_award.application_store.external_services import get_fund
@@ -29,12 +33,14 @@ from pre_award.assessment_store.config.mappings.assessment_mapping_fund_round im
 from pre_award.assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
 from pre_award.assessment_store.db.models.assessment_record.enums import Status
 from pre_award.assessment_store.db.models.assessment_record.enums import Status as WorkflowStatus
+from pre_award.assessment_store.db.models.comment.enums import CommentType
 from pre_award.assessment_store.db.models.flags.assessment_flag import AssessmentFlag
 from pre_award.assessment_store.db.models.flags.flag_update import FlagStatus, FlagUpdate
 from pre_award.assessment_store.db.queries.assessment_records._helpers import derive_application_values
 from pre_award.assessment_store.scripts.derive_assessment_values import derive_assessment_values
 from pre_award.config import Config
 from services.notify import NotificationService
+from tests.pre_award.application_store_tests.conftest import create_comment_with_updates
 from tests.pre_award.assessment_store_tests.test_assessment_mapping_fund_round import COF_FUND_ID
 from tests.pre_award.utils import AnyStringMatching
 
@@ -904,3 +910,122 @@ def test_derive_application_values_pfn(pfn_application_json_extract, app):
     assert result["funding_amount_requested"] == 12000 + 18000
     assert result["language"] == "en"
     assert result["project_name"] == "Test Council"
+
+
+def test_export_comments_to_excel(
+    db,
+    setup_submitted_application,
+    app,
+    mock_comments_sub_criteria,
+    comments_test_account,
+    comments_base_time,
+    comments_data,
+):
+    application_id = setup_submitted_application
+    user_id = comments_test_account.id
+
+    # Create comments with updates for the test application
+    for idx, cdata in enumerate(comments_data):
+        create_comment_with_updates(
+            db=db,
+            application_id=application_id,
+            user_id=user_id,
+            sub_criteria_id=cdata["sub_criteria_id"],
+            comment_type=cdata["comment_type"],
+            update_texts=cdata["updates"],
+            comments_base_time=comments_base_time + timedelta(hours=idx),
+            account=comments_test_account,
+        )
+
+    # Create a different application to later check for filtering
+    other_app = Applications(
+        id="00000000-0000-0000-0000-000000000000",
+        account_id="other-user",
+        fund_id=str(uuid4()),
+        round_id=str(uuid4()),
+        key="other-key",
+        language="en",
+        reference="OTHER-REF",
+        project_name="Other Project",
+    )
+    db.session.add(other_app)
+    db.session.commit()
+
+    # Create an assessment record for the other application
+    assessment_record = AssessmentRecord(
+        application_id=other_app.id,
+        short_id="OTHER-SHORT-ID",
+        type_of_application="Test",
+        project_name="Other Project",
+        funding_amount_requested=0,
+        round_id=other_app.round_id,
+        fund_id=other_app.fund_id,
+        language="en",
+        workflow_status="NOT_STARTED",
+        asset_type="Test",
+        jsonb_blob={},
+    )
+    db.session.add(assessment_record)
+    db.session.commit()
+
+    # Create a comment for the other application
+    create_comment_with_updates(
+        db=db,
+        application_id=other_app.id,
+        user_id="other-user",
+        sub_criteria_id=None,
+        comment_type=CommentType.WHOLE_APPLICATION,
+        update_texts=["Other app comment"],
+        comments_base_time=comments_base_time,
+        account=comments_test_account,
+    )
+    # Retrieve the test application
+    application = db.session.get(Applications, application_id)
+
+    # Retrieve comments for the test application
+    comments_list = retrieve_all_comments(
+        fund_id=application.fund_id,
+        round_id=application.round_id,
+        application_id=application.id,
+    )
+
+    # Export to Excel (in-memory)
+    fund_short_name = "TEST"
+    round_short_name = "ROUND"
+    with app.test_request_context():
+        response = export_comments_to_excel(
+            comments_list, fund_short_name, round_short_name, application_id=application_id
+        )
+        response.direct_passthrough = False
+        output = response.get_data()
+
+    # Read the Excel file
+    output_io = io.BytesIO(output)
+    df = pd.read_excel(output_io)
+
+    # Check that all comments for the test application are present
+    expected_comments = []
+    for cdata in comments_data:
+        expected_comments.extend(cdata["updates"])
+    assert Counter(df["Comment"]) == Counter(expected_comments)
+
+    # Check that no comments from the other applications are present
+    assert "Other app comment" not in df["Comment"].values
+
+    # Check ordering: Application-level comments (sub_criteria_id=None) first,
+    # then by sub_criteria_id, then by date_created
+    sub_criteria_col = df["Sub-criteria name"].fillna("None").values
+    app_level_end = 0
+    for val in sub_criteria_col:
+        if val == "None":
+            app_level_end += 1
+        else:
+            break
+
+    # All application-level comments should be at the top
+    assert all(val == "None" for val in sub_criteria_col[:app_level_end])
+    # The rest should be grouped by sub_criteria_id (SC1, then SC2)
+    sc1_start = app_level_end
+    sc1_end = sc1_start + sum(1 for c in comments_data if c["sub_criteria_id"] == "SC1" for _ in c["updates"])
+    assert all(val == "Sub Criteria 1" for val in sub_criteria_col[sc1_start:sc1_end])
+    assert all(val == "Sub Criteria 2" for val in sub_criteria_col[sc1_end:])

--- a/tests/pre_award/assessment_store_tests/test_routes.py
+++ b/tests/pre_award/assessment_store_tests/test_routes.py
@@ -356,10 +356,11 @@ def test_get_team_flag_stats(flask_test_client, seed_application_records):
 
     assert response.status_code == 200
     assert len(response.json) == 2
-    assert response.json[0]["team_name"] == "ASSESSOR"
-    assert response.json[0]["raised"] == 2
-    assert response.json[1]["team_name"] == "LEAD_ASSESSOR"
-    assert response.json[1]["raised"] == 1
+    teams = {team["team_name"]: team for team in response.json}
+    assert "ASSESSOR" in teams
+    assert "LEAD_ASSESSOR" in teams
+    assert teams["ASSESSOR"]["raised"] == 2
+    assert teams["LEAD_ASSESSOR"]["raised"] == 1
 
 
 def test_create_flag(flask_test_client):


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1376

Description:
We have previously added the functionality to export all comments of all applications. 
This PR extends this functionality, to allow users to export all comments of a single application.
The link has been added to the application tasklist page on ASSESS:
<img width="1690" height="530" alt="Screenshot 2025-07-21" src="https://github.com/user-attachments/assets/66b35331-47d6-490f-94b8-a7ecaacf0032" />

Example export file:
[comments_export_CHAM_REG_Application_ID_423f60e9-e606-4edb-aa9f-e5a22a436257_21-07-2025.xlsx](https://github.com/user-attachments/files/21344952/comments_export_CHAM_REG_Application_ID_423f60e9-e606-4edb-aa9f-e5a22a436257_21-07-2025.xlsx)

How to test:
In ASSESS, go to any application and add a few comments. Both application-level comments and sub-criteria comments. 
Click the "Export assessment comments" link, and a file should be generated, including all comments of the given application.

