### PR TITLE
FLS-1401 - Adding descriptive labels to links across Apply and Assess

### DIFF
--- a/pre_award/apply/templates/apply/partials/applications_table.html
+++ b/pre_award/apply/templates/apply/partials/applications_table.html
@@ -29,7 +29,15 @@
         {% endset %}
 
         {% if not application.status == 'SUBMITTED' and not is_past_submission_deadline %}
-            {% set application_link = '<a class="govuk-link" href="{}">{}</a>'.format(url_for('application_routes.tasklist', application_id=application.id, redirect_to_fund=True), gettext('Continue application')) %}
+            {% set application_link = '<a class="govuk-link" href="{}">{}<span class="govuk-visually-hidden"> for {}</span></a>'.format(
+                url_for(
+                    'application_routes.tasklist',
+                    application_id=application.id,
+                    redirect_to_fund=True,
+                ),
+                gettext('Continue application'),
+                application.project_name if application.project_name else gettext('Untitled project')
+            ) %}
         {% endif %}
 
         {% set row = [

--- a/pre_award/assess/tagging/templates/tagging/manage_tags.html
+++ b/pre_award/assess/tagging/templates/tagging/manage_tags.html
@@ -131,7 +131,7 @@
                                             fund_id = fund_round['fund_id'],
                                             round_id = fund_round['round_id'],
                                             tag_id=tag.id) }}">
-                                                Edit
+                                                Edit<span class="govuk-visually-hidden"> {{ tag.value }} tag</span>
                                             </a>
                                         </td>
                                     {% else %}
@@ -140,7 +140,7 @@
                                             fund_id=fund_round['fund_id'],
                                             round_id=fund_round['round_id'],
                                             tag_id=tag.id) }}">
-                                                Reactivate
+                                                Reactivate<span class="govuk-visually-hidden"> {{ tag.value }} tag</span>
                                             </a>
                                         </td>
                                     {% endif %}

--- a/pre_award/assess/templates/assess/macros/comments.html
+++ b/pre_award/assess/templates/assess/macros/comments.html
@@ -54,14 +54,14 @@
                                             theme_id=comment.theme_id,
                                             edit_comment="1",
                                             comment_id=comment.id
-                                        ) }}" >Edit comment</a>
+                                        ) }}" >Edit comment<span class="govuk-visually-hidden"> left by {{ comment.full_name }} on {{ comment.updates[-1].date_created|utc_to_bst }}</span></a>
                                     {% elif comment.comment_type == "WHOLE_APPLICATION" %}
                                         <a class="govuk-link" href="{{ url_for(
                                             "assessment_bp.application",
                                             application_id=comment.application_id,
                                             edit_comment="1",
                                             comment_id=comment.id
-                                        ) }}" >Edit comment</a>
+                                        ) }}" >Edit comment<span class="govuk-visually-hidden"> left by {{ comment.full_name }} on {{ comment.updates[-1].date_created|utc_to_bst }}</span></a>
                                     {% endif %}
                                 {% endif %}
                                 {% if comment.updates|length > 1 %}
@@ -72,13 +72,13 @@
                                         sub_criteria_id=comment.sub_criteria_id,
                                         theme_id=comment.theme_id,
                                         show_comment_history="1",
-                                        comment_id=comment.id) }}">See history</a>
+                                        comment_id=comment.id) }}">See history<span class="govuk-visually-hidden"> for comment left by {{ comment.full_name }} on {{ comment.updates[-1].date_created|utc_to_bst }}</span></a>
                                     {% elif comment.comment_type == "WHOLE_APPLICATION" %}
                                         <a class="govuk-link" href="{{ url_for(
                                         "assessment_bp.application",
                                         application_id=comment.application_id,
                                         show_comment_history="1",
-                                        comment_id=comment.id) }}">See history</a>
+                                        comment_id=comment.id) }}">See history<span class="govuk-visually-hidden"> for comments on whole application</span></a>
                                     {% endif %}
                                 {% endif %}
                             </div>

--- a/pre_award/assess/templates/assess/macros/fund_dashboard_summary.html
+++ b/pre_award/assess/templates/assess/macros/fund_dashboard_summary.html
@@ -23,10 +23,10 @@
 {% endmacro %}
 
 {% macro round_links(access_controller, assessments_href, download_available, export_href, feedback_export_href,
-assessment_tracker_href, comments_export_href, round_status) %}
+assessment_tracker_href, comments_export_href, round_status, round_name, fund_name) %}
     {% if round_status.has_assessment_opened %}
         <a class="govuk-link" data-qa="dashboard_summary" href="{{ assessments_href }}">
-            View all {% if round_status.is_assessment_active %}active{% else %}closed{% endif %} assessments
+            View all {% if round_status.is_assessment_active %}active{% else %}closed{% endif %} assessments<span class="govuk-visually-hidden"> for {{ fund_name }} {{ round_name }}</span>
         </a>
         </br>
         </br>
@@ -35,14 +35,14 @@ assessment_tracker_href, comments_export_href, round_status) %}
         {% if download_available %}
             {% if export_href and round_status.has_assessment_opened %}
                 <a class="govuk-link" href="{{ export_href }}">
-                    Export applicant information
+                    Export applicant information<span class="govuk-visually-hidden"> for {{ fund_name }} {{ round_name }}</span>
                 </a>
                 </br>
                 </br>
             {% endif %}
             {% if feedback_export_href %}
                 <a class="govuk-link" href="{{ feedback_export_href }}">
-                    Export feedback survey responses
+                    Export feedback survey responses<span class="govuk-visually-hidden"> for {{ fund_name }} {{ round_name }}</span>
                 </a>
                 </br>
                 </br>
@@ -50,13 +50,13 @@ assessment_tracker_href, comments_export_href, round_status) %}
         {% endif %}
         {% if assessment_tracker_href and round_status.has_assessment_opened %}
             <a class="govuk-link" href="{{ assessment_tracker_href }}">
-                Assessment Tracker Export
+                Assessment Tracker Export<span class="govuk-visually-hidden"> for {{ fund_name }} {{ round_name }}</span>
             </a>
             </br>
             </br>
         {% endif %}
         <a class="govuk-link" href="{{ comments_export_href }}">
-            Export comments
+            Export comments<span class="govuk-visually-hidden"> for {{ fund_name }} {{ round_name }}</span>
         </a>
     {% endif %}
 {% endmacro %}
@@ -72,7 +72,7 @@ assessment_tracker_href, comments_export_href, round_status) %}
             <li class="govuk-summary-card__action">
                 <a class="govuk-link govuk-link__white_font govuk-!-margin-right-4" data-qa="manage-tags"
                     href="{{ url_for('tagging_bp.load_fund_round_tags', fund_id=summary.fund_id, round_id=summary.round_id) }}">
-                    Manage tags
+                    Manage tags<span class="govuk-visually-hidden"> for {{ summary.fund_name }} {{ summary.round_name }}</span>
                 </a>
             </li>
         </ul>
@@ -145,7 +145,7 @@ assessment_tracker_href, comments_export_href, round_status) %}
             {{ round_links(summary.access_controller, summary.assessments_href,
                 summary.round_application_fields_download_available,
                 summary.export_href, summary.feedback_export_href, summary.assessment_tracker_href,
-                summary.comments_export_href, summary.status)
+                summary.comments_export_href, summary.status, summary.round_name, summary.fund_name)
             }}
         {% endif %}
 

--- a/tests/pre_award/apply_tests/test_dashboard.py
+++ b/tests/pre_award/apply_tests/test_dashboard.py
@@ -231,7 +231,10 @@ def test_dashboard_route(apply_test_client, mocker, mock_login):
     assert len(soup.find_all("strong", class_="in-progress-tag-new")) == 1
     assert len(soup.find_all("strong", class_="govuk-tag--yellow")) == 1
     assert len(soup.find_all("strong", class_="complete-tag")) == 2
-    assert len(soup.find_all("a", string="Continue application")) == 2
+
+    continue_application_links = [link for link in soup.find_all("a") if "Continue application" in link.get_text()]
+    assert len(continue_application_links) == 2
+
     assert (
         len(
             soup.find_all(

--- a/tests/pre_award/assess_tests/test_jinja_macros.py
+++ b/tests/pre_award/assess_tests/test_jinja_macros.py
@@ -1152,7 +1152,8 @@ class TestJinjaMacros(object):
             mock_access_controller.is_lead_assessor = is_lead_assessor
             rendered_html = render_template_string(
                 "{{round_links(access_controller, assessments_href, download_available, export_href,"
-                " feedback_export_href,assessment_tracker_href, comments_export_href, round_status)}}",
+                " feedback_export_href,assessment_tracker_href, comments_export_href, round_status, round_name,"
+                " fund_name)}}",
                 round_links=get_template_attribute("assess/macros/fund_dashboard_summary.html", "round_links"),
                 access_controller=mock_access_controller,
                 assessments_href="assessments_href",
@@ -1169,10 +1170,16 @@ class TestJinjaMacros(object):
                     has_assessment_opened,
                     False,
                 ),
+                round_name="Test Round",
+                fund_name="Test Fund",
             )
 
             soup = BeautifulSoup(rendered_html, "html.parser")
             found_links = soup.find_all("a", class_="govuk-link")
             assert len(found_links) == len(exp_links_text)
-            for text in exp_links_text:
-                assert soup.find("a", class_="govuk-link", string=lambda str: text in str)  # noqa: B023
+
+            link_texts = [link.get_text() for link in found_links]
+            for expected_text in exp_links_text:
+                assert any(expected_text in link_text for link_text in link_texts), (
+                    f"Expected text '{expected_text}' not found in any link"
+                )

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -135,15 +135,11 @@ class TestRoutes:
         response = assess_test_client.get("/assess/assessor_tool_dashboard/")
         assert 200 == response.status_code, "Wrong status code on response"
         soup = BeautifulSoup(response.data, "html.parser")
-
-        all_exports_links = soup.find_all(
-            "a",
-            class_="govuk-link",
-            string=lambda text: "Export" in text if text else False,
-        )
+        all_links = soup.find_all("a", class_="govuk-link")
+        all_exports_links = [link for link in all_links if "Export" in link.get_text()]
         assert len(all_exports_links) == exp_link_count
         if not download_available and mock_is_lead_assessor:
-            assert "Assessment Tracker Export" in all_exports_links[-2].text
+            assert "Assessment Tracker Export" in all_exports_links[-2].get_text()
 
     fund_case = namedtuple("FundCase", "fund_short round_short role_key assigned_div expected_extra_tabs")
 


### PR DESCRIPTION
### Ticket

[Add descriptive labels to links for screen reader users.](https://mhclgdigital.atlassian.net/browse/FLS-1401)

### Background

This ticket highlighted that the "Manage tags" link on the assessor dashboard was missing vital contextual information for a screen reader, specifically the fund and round name, which are required because it is possible to "Manage tags" for multiple funds and rounds via this page.

The ticket requested that the developer tackles this specific issue, and then goes through the whole of Apply and Assess looking for similar situations. I did this by searching `govuk-link` against the codebase and then combing for instances where you have a link for an action specific to an entity, on pages where it is possible to perform that action against different entities. I ended up finding a few other instances beyond "Manage tags", see "Description of changes" below...

### Description of changes

- Adding visually hidden text to "Continue application" links in applications table in Apply, so that they read "Continue application for $projectName"

- Adding visually hidden text to "Edit" and "Reactivate" links in manage tags table in Assess, to that they read "Edit $tagName tag" and "Reactivate $tagName tag" respectively

- Adding visually hidden text to "Edit comment" and "See history" links in comment panels in Assess, so that they read "Edit comment left by $user on $date" (e.g., "Edit comment left by Development User on 21 July 2025 at 15:44") and "See history for comment left by $user on $date" respectively. I used user and date to identify comment rather than comment text for brevity

- Adding visually hidden text to "View all active / closed assessments", "Export applicant information", "Export feedback survey responses", "Assessment Tracker Export", "Export comments" and "Manage tags" links for fund rounds on assessor dashboard in Assess

### Screenshots

**Continue application**

<img width="1587" height="593" alt="image" src="https://github.com/user-attachments/assets/9d46e384-7d75-4d7e-b9d1-b95cdbb4d5cd" />

---

**Edit tag**

<img width="1584" height="754" alt="image" src="https://github.com/user-attachments/assets/d08be3ef-15e7-4fd3-ae95-d247ab2c725f" />

---

**Edit comment**

<img width="1592" height="552" alt="image" src="https://github.com/user-attachments/assets/e26a1b89-a295-4eff-bf3a-5e1e8af44a0f" />

---

**View all active assessments** (visually hidden text for other links is also visible in HTML)

<img width="1591" height="734" alt="image" src="https://github.com/user-attachments/assets/0e348466-be4e-4a97-89c1-b5efc8c713e1" />

---

**Manage tags**

<img width="1593" height="480" alt="image" src="https://github.com/user-attachments/assets/9e451a59-b0d0-4365-86f4-068c95032292" />
