### PR TITLE
FLS-1403 - Fix unexpected collapse on click on Accordion components

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/assessor_tool_dashboard.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tool_dashboard.html
@@ -42,7 +42,7 @@
                 <div class="govuk-accordion__section-header">
                     <h2 class="govuk-accordion__section-heading">
                         <button type="button" aria-controls="accordion-default-content-{{ loop.index }}"
-                                class="govuk-accordion__section-button landing-accordion" data-qa="show"
+                                class="govuk-accordion__section-button" data-qa="show"
                                 aria-label="{{ funds[fund_id].name }} ({{ fund_summaries[fund_id] | length }}), Show this section">
                             <span class="govuk-accordion__section-heading-text" id="accordion-default-heading-{{ loop.index }}">
                                 <span class="govuk-accordion__section-heading-text-focus">
@@ -51,21 +51,21 @@
                             </span>
                         </button>
                     </h2>
-                    <div id="accordion-default-content-{{ loop.index }}" class="govuk-accordion__section-content display-none">
-                        {% if fund_summaries[fund_id] %}
-                            {% set chunk_size = 3 %}
-                            {% set summaries = fund_summaries[fund_id] %}
-                            {% for chunk in summaries|batch(chunk_size) %}
-                                <div class="govuk-grid-row">
-                                    {% for summary in chunk %}
-                                        <div class="govuk-grid-column-one-third">
-                                            {{ fund_summary(summary) }}
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
+                </div>
+                <div id="accordion-default-content-{{ loop.index }}" class="govuk-accordion__section-content">
+                    {% if fund_summaries[fund_id] %}
+                        {% set chunk_size = 3 %}
+                        {% set summaries = fund_summaries[fund_id] %}
+                        {% for chunk in summaries|batch(chunk_size) %}
+                            <div class="govuk-grid-row">
+                                {% for summary in chunk %}
+                                    <div class="govuk-grid-column-one-third">
+                                        {{ fund_summary(summary) }}
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        {% endfor %}
+                    {% endif %}
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
### 🎫 Ticket

[Fix accordion behavior to prevent unexpected collapse.](https://mhclgdigital.atlassian.net/browse/FLS-1403)

### ℹ️ Background

The accordion component on the assessor dashboard was collapsing unexpectedly when users clicked anywhere within the expanded content sections, including on non-interactive text areas. This occurred because the accordion content div was incorrectly nested inside the section header div, causing click events to bubble up to the header's click handlers and trigger the collapse behaviour. Only clicks on actual links worked as expected, while any other clicks within the content area would close the accordion section.

### 🪗 Changes made

Fixed the accordion structure to match the GOV.UK Design System standard by moving the `govuk-accordion__section-content` div outside of the `govuk-accordion__section-header` div so they are siblings rather than parent-child elements. Also removed the unnecessary `display-none` class since the GOV.UK accordion JavaScript handles visibility automatically. This prevents click events within the content area from bubbling up to the header's toggle handlers, ensuring only deliberate clicks on the accordion button will expand or collapse sections.

### 📸 Screen recording

https://github.com/user-attachments/assets/8238099b-b650-46fc-99c4-f29963192e20