### PR TITLE
Fix accessibility issue with description list on tasklist page

### DIFF
--- a/pre_award/apply/templates/apply/tasklist.html
+++ b/pre_award/apply/templates/apply/tasklist.html
@@ -114,7 +114,7 @@
         {% if is_past_submission_deadline %}
         {{ round_closed_warning(fund_name, round_title, submission_deadline) }}
         {% endif %}
-        <dl>
+        <dl class="govuk-!-margin-bottom-0">
             {% if not is_expression_of_interest %}
                 <dt class="govuk-heading-s dl-inline">{% trans %}Submission deadline:{% endtrans %}</dt>
                 <dd class="govuk-body govuk-!-margin-bottom-2"> {{ submission_deadline|string_to_datetime|datetime_format_full_month }}</dd>
@@ -147,17 +147,17 @@
                         {{ application_status("COMPLETED") }}
                     </dd>
                 {% endif %}
-                <dt class="govuk-body govuk-!-margin-bottom-7">
-                    {% if application_meta_data["number_of_completed_forms"] == 0 %}
-                        {% trans %}None of the sections have been completed.{% endtrans %}
-                    {% else %}
-                        {% trans %}You have completed{% endtrans %}
-                        {{ application_meta_data["number_of_completed_forms"] }} {% trans %}of{% endtrans %}
-                        {{ application_meta_data["number_of_forms"] }} {% trans %}sections.{% endtrans %}
-                    {% endif %}
-                </dt>
             {% endif %}
-            </dl>
+        </dl>
+        <p class="govuk-body govuk-!-margin-bottom-7">
+            {% if application_meta_data["number_of_completed_forms"] == 0 %}
+                {% trans %}None of the sections have been completed.{% endtrans %}
+            {% else %}
+                {% trans %}You have completed{% endtrans %}
+                {{ application_meta_data["number_of_completed_forms"] }} {% trans %}of{% endtrans %}
+                {{ application_meta_data["number_of_forms"] }} {% trans %}sections.{% endtrans %}
+            {% endif %}
+        </p>
 
         {% if application["status"] == application_meta_data["completed_status"] %}
             {{ tasklist_submit(application.id, application_meta_data, form, url_for('application_routes.submit_application')) }}


### PR DESCRIPTION
### Ticket

[Correct semantic structure for screen readers.](https://mhclgdigital.atlassian.net/browse/FLS-1398)

### Problem
  Screen readers were incorrectly interpreting the completion status text "You have completed X of Y sections" as a   description term (< dt >) within a description list, when it should be plain informational text.

### Solution

  - Moved completion status text outside the description list structure
  - Changed from (< dt >) to (< p >) element for proper semantic markup
  - Added govuk-!-margin-bottom-0 to description list to prevent double spacing
  - Maintained existing styling and functionality
  
### Files Changed

  pre_award/apply/templates/apply/tasklist.html

### Screenshots of UI changes (if applicable)

<img width="1102" height="1352" alt="Screenshot 2025-07-28 at 13 32 50" src="https://github.com/user-attachments/assets/e2173b3e-6036-48ea-a180-e555665d1bab" />

