### PR TITLE
FLS-1411 - Improve error message clarity

### DIFF
--- a/pre_award/assess/tagging/forms/tags.py
+++ b/pre_award/assess/tagging/forms/tags.py
@@ -29,7 +29,7 @@ class NewTagForm(FlaskForm):
 
     type = RadioField(
         "type",
-        validators=[InputRequired()],
+        validators=[InputRequired(message="Select a tag purpose")],
     )
 
 

--- a/pre_award/assess/tagging/forms/tags.py
+++ b/pre_award/assess/tagging/forms/tags.py
@@ -17,9 +17,11 @@ class TagAssociationForm(FlaskForm):
 tag_value_field = TextAreaField(
     "value",
     validators=[
-        InputRequired(message="Provide a value for the tag."),
+        InputRequired(message="Enter a tag name"),
         length(max=Config.TEXT_AREA_INPUT_MAX_CHARACTERS),
-        Regexp(r"^[A-Za-z0-9_' -]+$", message="Invalid characters in value."),
+        Regexp(
+            r"^[A-Za-z0-9_' -]+$", message="Tag name can only include letters, numbers, apostrophes, hyphens and spaces"
+        ),
     ],
 )
 

--- a/tests/pre_award/assess_tests/test_tags.py
+++ b/tests/pre_award/assess_tests/test_tags.py
@@ -240,8 +240,8 @@ def test_create_tag_invalid_form_post(
     mock_get_active_tags_for_fund_round,
 ):
     expected_errors = [
-        "Provide a value for the tag.",
-        "This field is required.",
+        "Enter a tag name",
+        "Select a tag purpose",
     ]
     response = client_with_valid_session.post(
         f"/assess/tags/create/{test_fund_id}/{test_round_id}",
@@ -274,7 +274,10 @@ def test_create_tag_invalid_character_post(
     mock_get_round,
     mock_get_active_tags_for_fund_round,
 ):
-    expected_errors = ["Invalid characters in value.", "Not a valid choice."]
+    expected_errors = [
+        "Tag name can only include letters, numbers, apostrophes, hyphens and spaces",
+        "Not a valid choice.",
+    ]
     response = client_with_valid_session.post(
         f"/assess/tags/create/{test_fund_id}/{test_round_id}",
         data={"value": "!!", "type": "invalid_type"},  # SPECIAL CHARACTER


### PR DESCRIPTION
### 🎫 Ticket

[[Assessment] Improve clarity of error messages for form validation.](https://mhclgdigital.atlassian.net/browse/FLS-1411)

### 🌏 Background

When a user is creating a tag in Assess and does not select any of the radio buttons for the "Tag purpose" field, the default error message "This field is required" is shown. This was flagged in the accessibility audit.

### ♻️ Changes

- The error message "Select a tag purpose" is now used instead
- The other error messages on the "Create tag" page have been improved: "Provide a value for the tag." has been replaced with the more conventional "Enter a tag name", while "Invalid characters in value" has been replaced with the more specific "Tag name can only include letters, numbers, apostrophes, hyphens and spaces"