### PR TITLE
FLS-1307 Delete application data for unsuccessful COF applicants in accordance with privacy policy

### DIFF
--- a/pre_award/application_store/db/models/application/applications.py
+++ b/pre_award/application_store/db/models/application/applications.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, DateTime
 from sqlalchemy.dialects.postgresql import ENUM, UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+from sqlalchemy.sql.sqltypes import Boolean
 
 from pre_award.application_store.db.models.application.enums import Language, Status
 from pre_award.db import db
@@ -35,6 +36,7 @@ class Applications(BaseModel):
     status = Column("status", ENUM(Status), default="NOT_STARTED", nullable=False)
     date_submitted = Column("date_submitted", DateTime())
     last_edited = Column("last_edited", DateTime(), server_default=func.now())
+    is_deleted = Column(Boolean, nullable=False, default=False)
     forms = relationship("Forms")
     feedbacks = relationship("Feedback")
     end_of_application_survey = relationship("EndOfApplicationSurveyFeedback")

--- a/pre_award/application_store/db/models/application/applications.py
+++ b/pre_award/application_store/db/models/application/applications.py
@@ -63,4 +63,5 @@ class Applications(BaseModel):
             if self.last_edited
             else (self.started_at.isoformat() if self.started_at else None),
             "date_submitted": date_submitted,
+            "is_deleted": self.is_deleted,
         }

--- a/pre_award/application_store/db/queries/application/queries.py
+++ b/pre_award/application_store/db/queries/application/queries.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from flask import current_app
 from fsd_utils import extract_questions_and_answers, generate_text_of_application
-from sqlalchemy import exc, func, select
+from sqlalchemy import exc, false, func, select
 from sqlalchemy.dialects.postgresql import insert as postgres_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, load_only, noload
@@ -30,7 +30,7 @@ from pre_award.db import db
 
 
 def get_application(app_id, include_forms=False, as_json=False) -> dict | Applications:
-    stmt: Select = select(Applications).filter(Applications.id == app_id and Applications.is_deleted == False)
+    stmt: Select = select(Applications).filter(Applications.id == app_id and Applications.is_deleted == false())
 
     if include_forms:
         stmt.options(joinedload(Applications.forms))
@@ -49,7 +49,7 @@ def get_application(app_id, include_forms=False, as_json=False) -> dict | Applic
 
 
 def get_application_by_reference(app_ref) -> dict | Applications:
-    stmt: Select = select(Applications).filter(Applications.reference == app_ref and Applications.is_deleted == False)
+    stmt: Select = select(Applications).filter(Applications.reference == app_ref and Applications.is_deleted == false())
     stmt.options(noload(Applications.forms))
     return db.session.scalars(stmt).unique().one()
 
@@ -57,7 +57,7 @@ def get_application_by_reference(app_ref) -> dict | Applications:
 def get_applications(filters=None, include_forms=False, as_json=False) -> list[dict] | list[Applications]:
     if filters is None:
         filters = []
-    stmt: Select = select(Applications).filter(Applications.is_deleted == False)
+    stmt: Select = select(Applications).filter(Applications.is_deleted == false())
 
     if len(filters) > 0:
         stmt = stmt.where(*filters)
@@ -149,7 +149,7 @@ def create_application(account_id, fund_id, round_id, language) -> Applications:
 
 
 def get_all_applications() -> list:
-    application_list = db.session.query(Applications).filter(Applications.is_deleted == False).all()
+    application_list = db.session.query(Applications).filter(Applications.is_deleted == false()).all()
     return application_list
 
 
@@ -159,7 +159,7 @@ def get_count_by_status(round_ids: Optional[list] = None, fund_ids: Optional[lis
         Applications.round_id,
         Applications.status,
         func.count(Applications.status),
-    ).filter(Applications.is_deleted == False)
+    ).filter(Applications.is_deleted == false())
 
     if round_ids:
         query = query.filter(Applications.round_id.in_(round_ids))
@@ -229,7 +229,7 @@ def search_applications(**params):
     application_id = params.get("application_id")
     forms = params.get("forms")
 
-    filters = [Applications.is_deleted == False]
+    filters = [Applications.is_deleted == false()]
     if fund_id:
         filters.append(Applications.fund_id == fund_id)
     if round_id:

--- a/pre_award/apply/default/application_routes.py
+++ b/pre_award/apply/default/application_routes.py
@@ -212,7 +212,7 @@ def tasklist(application_id):
         ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
     )
 
-    if application.status == ApplicationStatus.SUBMITTED.name:
+    if application.status == ApplicationStatus.SUBMITTED.name or application.is_deleted:
         with force_locale(application.language):
             return redirect(
                 url_for(

--- a/pre_award/apply/models/application.py
+++ b/pre_award/apply/models/application.py
@@ -18,6 +18,7 @@ class Application:
     fund_id: str
     round_id: str
     project_name: str
+    is_deleted: bool
     date_submitted: datetime
     started_at: datetime
     last_edited: datetime

--- a/pre_award/assess/assessments/routes.py
+++ b/pre_award/assess/assessments/routes.py
@@ -249,7 +249,6 @@ def _get_fund_dashboard_data(fund: Fund, round: Round, request):
     tag_types = future_tag_types.result()
 
     thread_executor.executor.shutdown()
-
     unfiltered_stats = process_assessments_stats(all_applications_metadata)
     all_application_locations = LocationData.from_json_blob(all_applications_metadata)
 

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -38,7 +38,7 @@
         state.fund_name,
         state.fund_short_name,
         state.short_id,
-        state.project_name if not state.is_deleted else state.project_name + " [DELETED]",
+        state.project_name if not state.is_deleted else state.project_name + " [PROJECT DELETED]",
         state.funding_amount_requested,
         assessment_status,
         flag_status,

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -145,7 +145,7 @@
     {# Display multiple flag banner #}
     <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        {% if g.access_controller.has_any_assessor_role and is_qa_complete %}
+        {% if g.access_controller.has_any_assessor_role and is_qa_complete and not state.is_deleted %}
             {{ qa_complete_flag(qa_complete["date_created"], accounts_list[qa_complete["user_id"]], form.csrf_token, application_id, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
         {% endif %}
 
@@ -167,7 +167,7 @@
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        {% if all_uploaded_documents_section_available %}
+        {% if all_uploaded_documents_section_available and not state.is_deleted %}
         <h2 class="govuk-heading-l govuk-!-margin-top-8">All uploaded documents</h2>
         {{ section_element(
             "",

--- a/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
+++ b/pre_award/assess/assessments/templates/assessments/assessor_tasklist.html
@@ -38,7 +38,7 @@
         state.fund_name,
         state.fund_short_name,
         state.short_id,
-        state.project_name,
+        state.project_name if not state.is_deleted else state.project_name + " [DELETED]",
         state.funding_amount_requested,
         assessment_status,
         flag_status,
@@ -54,10 +54,10 @@
 {# djlint:on #}
     <div class="govuk-grid-column-one-quarter">
         {% if g.access_controller.is_assessor %}
-            {{ assessment_actions(application_id, fund.short_name, round.short_name) }}
+            {{ assessment_actions(application_id, fund.short_name, round.short_name, state) }}
         {% endif %}
 
-        {{ comment(comments, application_id, True, display_comment_box, display_comment_edit_box) }}
+        {{ comment(comments, application_id, True, display_comment_box, display_comment_edit_box, state) }}
 
         {% if display_comment_box %}
             {{ comment_box(comment_form = comment_form, application_id = application_id) }}
@@ -86,6 +86,7 @@
                         There are no tags on this assessment
                     </span>
                 {% endif %}
+                {% if not state.is_deleted %}
                     <span class="govuk-body-s govuk-!-margin-top-2">
                         <a class="govuk-link"
                             data-qa="add-change-tags"
@@ -93,6 +94,7 @@
                             {{ "Change" if tags else "Add" }} tags
                         </a>
                     </span>
+                {% endif %}
             </div>
             <div class="govuk-grid-column-full govuk-!-margin-top-4">
                 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
@@ -121,7 +123,7 @@
             </span>
 
             <span class="left govuk-!-padding-right-4">
-                {% if is_flaggable %}
+                {% if is_flaggable and not state.is_deleted %}
                 {{ flag_application_button(application_id) }}
                 {% endif %}
             </span>
@@ -158,7 +160,7 @@
             {% endif %}
         {% endfor %}
 
-    {% if sub_criteria_status_completed and g.access_controller.has_any_assessor_role and (not is_qa_complete) and (not flag_status) and not is_expression_of_interest %}
+    {% if not state.is_deleted and sub_criteria_status_completed and g.access_controller.has_any_assessor_role and (not is_qa_complete) and (not flag_status) and not is_expression_of_interest %}
         {{ assessment_complete(state, form.csrf_token, application_id, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
     {% endif %}
 </div>

--- a/pre_award/assess/assessments/templates/assessments/base_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/base_sub_criteria.html
@@ -60,7 +60,7 @@ Error:
       <div class="assessment-reponses">
         {% block sub_criteria_content %}{% endblock sub_criteria_content %}
 
-        {{ comment(comments, application_id, False, display_comment_box, display_comment_edit_box, sub_criteria, current_theme) }}
+        {{ comment(comments, application_id, False, display_comment_box, display_comment_edit_box, state, sub_criteria, current_theme) }}
 
         {% if display_comment_box == True %}
           {{ comment_box(comment_form) }}

--- a/pre_award/assess/assessments/templates/assessments/base_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/base_sub_criteria.html
@@ -54,7 +54,7 @@ Error:
   {{ sub_criteria_heading(sub_criteria)}}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-      {{ navbar(application_id, sub_criteria, current_theme.id, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
+      {{ navbar(application_id, sub_criteria, current_theme.id, state, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
     </div>
     <div class="govuk-grid-column-two-thirds">
       <div class="assessment-reponses">

--- a/pre_award/assess/assessments/templates/assessments/competed_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/competed_sub_criteria.html
@@ -1,10 +1,14 @@
 {% extends "assessments/base_sub_criteria.html" %}
 
 {% block sub_criteria_content %}
-  <h3 class="govuk-heading-s response-title">Applicant's response</h3>
-  {{ theme(answers_meta)}}
+    {% if not state.is_deleted %}
+      <h3 class="govuk-heading-s response-title">Applicant's response</h3>
+      {{ theme(answers_meta)}}
+    {% endif %}
   {% if score %}
-    <h2 class="govuk-heading-s govuk-!-margin-top-8 accepted-change-title">Responses accepted</h2>
+    {% if not state.is_deleted %}
+        <h2 class="govuk-heading-s govuk-!-margin-top-8 accepted-change-title">Responses accepted</h2>
+    {% endif %}
     {{ assessment_subcriteria_accepted(score, accounts_list[score.user_id]) }}
   {% endif %}
 {% endblock sub_criteria_content %}

--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -71,20 +71,22 @@
     {{ assessment_subcriteria_accepted(score, accounts_list[score.user_id]) }}
 {% endif %}
 
-<h3 class="govuk-heading-s response-title">
-    {% if change_requests %}
-        Applicant's updated response
-    {% else %}
-        Applicant's responses
-    {% endif %}
-</h3>
+{% if not state.is_deleted %}
+    <h3 class="govuk-heading-s response-title">
+        {% if change_requests %}
+            Applicant's updated response
+        {% else %}
+            Applicant's responses
+        {% endif %}
+    </h3>
 
-{{ theme(answers_meta, is_sub_criteria_scored=sub_criteria.is_scored )}}
-{% if not is_qa_complete and not has_active_change_request %}
-    {% if g.access_controller.has_any_assessor_role %}
-        {% if sub_criteria.is_scored %}
-            {{ application_feedback(application_id, sub_criteria, current_theme.id,
-            approval_form,change_requests,unrequested_changes,score) }}
+    {{ theme(answers_meta, is_sub_criteria_scored=sub_criteria.is_scored )}}
+    {% if not is_qa_complete and not has_active_change_request %}
+        {% if g.access_controller.has_any_assessor_role %}
+            {% if sub_criteria.is_scored %}
+                {{ application_feedback(application_id, sub_criteria, current_theme.id,
+                approval_form,change_requests,unrequested_changes,score) }}
+            {% endif %}
         {% endif %}
     {% endif %}
 {% endif %}

--- a/pre_award/assess/flagging/routes.py
+++ b/pre_award/assess/flagging/routes.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from flask import abort, current_app, g, redirect, render_template, request, url_for
 
 from pre_award.assess.authentication.validation import check_access_application_id
@@ -35,6 +37,8 @@ flagging_bp = Blueprint(
 def flag(application_id):
     # Get assessor tasks list
     state = get_state_for_tasklist_banner(application_id)
+    if state.is_deleted:
+        abort(HTTPStatus.METHOD_NOT_ALLOWED)
     choices = [(item["sub_section_id"], item["sub_section_name"]) for item in state.get_sub_sections_metadata()]
 
     teams_available = get_available_teams(
@@ -89,6 +93,9 @@ def flag(application_id):
 @flagging_bp.route("/resolve_flag/<application_id>", methods=["GET", "POST"])
 @check_access_application_id(roles_required=["LEAD_ASSESSOR"])
 def resolve_flag(application_id):
+    state = get_state_for_tasklist_banner(application_id)
+    if state.is_deleted:
+        abort(HTTPStatus.METHOD_NOT_ALLOWED)
     form = ResolveFlagForm()
     flag_id = request.args.get("flag_id")
 
@@ -96,7 +103,6 @@ def resolve_flag(application_id):
         current_app.logger.error("No flag id found in query params")
         abort(404)
     flag_data = get_flag(flag_id)
-    state = get_state_for_tasklist_banner(application_id)
     section = flag_data.sections_to_flag
     return resolve_application(
         form=form,

--- a/pre_award/assess/flagging/routes.py
+++ b/pre_award/assess/flagging/routes.py
@@ -1,5 +1,3 @@
-from http import HTTPStatus
-
 from flask import abort, current_app, g, redirect, render_template, request, url_for
 
 from pre_award.assess.authentication.validation import check_access_application_id
@@ -38,7 +36,7 @@ def flag(application_id):
     # Get assessor tasks list
     state = get_state_for_tasklist_banner(application_id)
     if state.is_deleted:
-        abort(HTTPStatus.METHOD_NOT_ALLOWED)
+        abort(403)
     choices = [(item["sub_section_id"], item["sub_section_name"]) for item in state.get_sub_sections_metadata()]
 
     teams_available = get_available_teams(
@@ -95,7 +93,7 @@ def flag(application_id):
 def resolve_flag(application_id):
     state = get_state_for_tasklist_banner(application_id)
     if state.is_deleted:
-        abort(HTTPStatus.METHOD_NOT_ALLOWED)
+        abort(403)
     form = ResolveFlagForm()
     flag_id = request.args.get("flag_id")
 

--- a/pre_award/assess/scoring/routes.py
+++ b/pre_award/assess/scoring/routes.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from flask import abort, current_app, g, render_template, request
 
 from pre_award.assess.authentication.validation import check_access_application_id, restrict_uncompeted_actions
@@ -38,12 +40,14 @@ def score(
     application_id,
     sub_criteria_id,
 ):
+    state = get_state_for_tasklist_banner(application_id)
+    if state.is_deleted:
+        abort(HTTPStatus.METHOD_NOT_ALLOWED)
     sub_criteria: SubCriteria = get_sub_criteria(application_id, sub_criteria_id)
 
     if not sub_criteria.is_scored:
         abort(404)
 
-    state = get_state_for_tasklist_banner(application_id)
     flags_list = get_flags(application_id)
 
     score_form = get_scoring_class(state.round_id)()

--- a/pre_award/assess/scoring/routes.py
+++ b/pre_award/assess/scoring/routes.py
@@ -1,5 +1,3 @@
-from http import HTTPStatus
-
 from flask import abort, current_app, g, render_template, request
 
 from pre_award.assess.authentication.validation import check_access_application_id, restrict_uncompeted_actions
@@ -42,7 +40,7 @@ def score(
 ):
     state = get_state_for_tasklist_banner(application_id)
     if state.is_deleted:
-        abort(HTTPStatus.METHOD_NOT_ALLOWED)
+        abort(403)
     sub_criteria: SubCriteria = get_sub_criteria(application_id, sub_criteria_id)
 
     if not sub_criteria.is_scored:

--- a/pre_award/assess/scoring/templates/scoring/score.html
+++ b/pre_award/assess/scoring/templates/scoring/score.html
@@ -55,7 +55,7 @@ Score – {{ sub_criteria.name }} – {{ sub_criteria.project_name }}
 
 <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-            {{ navbar(application_id, sub_criteria, current_theme_id, is_score_page=True, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
+            {{ navbar(application_id, sub_criteria, current_theme_id, state, is_score_page=True, is_uncompeted_flow_flag=is_uncompeted_flow(fund)) }}
         </div>
         <div class="theme govuk-grid-column-two-thirds">
             {{ scores_justification(score_form, rescore_form, is_rescore, latest_score, application_id,

--- a/pre_award/assess/services/aws.py
+++ b/pre_award/assess/services/aws.py
@@ -57,12 +57,21 @@ def list_files_in_folder(prefix):
 
 def delete_file_from_aws(file_key: str):
     try:
-        current_app.logger.info("Deleting file %(file_key)s from S3 bucket", dict(file_key=file_key))
+        current_app.logger.info(
+            "Deleting file %(file_key)s from S3 bucket",
+            {"file_key": file_key},
+        )
         _S3_CLIENT.delete_object(Bucket=Config.AWS_BUCKET_NAME, Key=file_key)
-        current_app.logger.info("File %(file_key)s deleted successfully.", dict(file_key=file_key))
-    except ClientError as e:
-        current_app.logger.error(e)
-        raise Exception(e) from e
+        current_app.logger.info(
+            "File %(file_key)s deleted successfully.",
+            {"file_key": file_key},
+        )
+    except ClientError:
+        current_app.logger.exception(
+            "Failed to delete file %(file_key)s from S3 bucket",
+            {"file_key": file_key},
+        )
+        raise
 
 
 _KEY_PARTS = ("application_id", "form", "path", "component_id", "filename")

--- a/pre_award/assess/services/aws.py
+++ b/pre_award/assess/services/aws.py
@@ -55,6 +55,16 @@ def list_files_in_folder(prefix):
     return keys
 
 
+def delete_file_from_aws(file_key: str):
+    try:
+        current_app.logger.info("Deleting file %(file_key)s from S3 bucket", dict(file_key=file_key))
+        _S3_CLIENT.delete_object(Bucket=Config.AWS_BUCKET_NAME, Key=file_key)
+        current_app.logger.info("File %(file_key)s deleted successfully.", dict(file_key=file_key))
+    except ClientError as e:
+        current_app.logger.error(e)
+        raise Exception(e) from e
+
+
 _KEY_PARTS = ("application_id", "form", "path", "component_id", "filename")
 FileData = namedtuple("FileData", _KEY_PARTS)
 

--- a/pre_award/assess/services/models/assessor_task_list.py
+++ b/pre_award/assess/services/models/assessor_task_list.py
@@ -46,6 +46,7 @@ class AssessorTaskList:
     fund_short_name: str
     round_short_name: str
     is_qa_complete: bool
+    is_deleted: bool
     fund_id: str
     round_id: str
     fund_guidance_url: str
@@ -66,6 +67,7 @@ class AssessorTaskList:
             funding_amount_requested=json.get("funding_amount_requested"),
             project_reference=json.get("project_reference"),
             fund_guidance_url=json.get("fund_guidance_url"),
+            is_deleted=json.get("is_deleted"),
             is_qa_complete=True if json.get("qa_complete") else False,
             sections=[
                 _Section(

--- a/pre_award/assess/tagging/routes.py
+++ b/pre_award/assess/tagging/routes.py
@@ -1,7 +1,8 @@
 import copy
+from http import HTTPStatus
 from typing import Dict
 
-from flask import current_app, flash, g, redirect, render_template, request, url_for
+from flask import abort, current_app, flash, g, redirect, render_template, request, url_for
 
 from pre_award.assess.authentication.validation import check_access_application_id, check_access_fund_id_round_id
 from pre_award.assess.config.display_value_mappings import search_params_tag
@@ -47,6 +48,9 @@ tagging_bp = Blueprint(
 @tagging_bp.route("/application/<application_id>/tags", methods=["GET", "POST"])
 @check_access_application_id(roles_required=["ASSESSOR"])
 def load_change_tags(application_id):
+    state = get_state_for_tasklist_banner(application_id)
+    if state.is_deleted:
+        abort(HTTPStatus.METHOD_NOT_ALLOWED)
     tag_association_form = TagAssociationForm()
     if request.method == "POST":
         associated_tags = get_associated_tags_for_application(application_id)
@@ -70,7 +74,6 @@ def load_change_tags(application_id):
             )
         )
 
-    state = get_state_for_tasklist_banner(application_id)
     all_tags = get_tags_for_fund_round(state.fund_id, state.round_id, "")
     associated_tags = get_associated_tags_for_application(application_id)
     associated_tag_ids = (

--- a/pre_award/assess/tagging/routes.py
+++ b/pre_award/assess/tagging/routes.py
@@ -1,5 +1,4 @@
 import copy
-from http import HTTPStatus
 from typing import Dict
 
 from flask import abort, current_app, flash, g, redirect, render_template, request, url_for
@@ -50,7 +49,7 @@ tagging_bp = Blueprint(
 def load_change_tags(application_id):
     state = get_state_for_tasklist_banner(application_id)
     if state.is_deleted:
-        abort(HTTPStatus.METHOD_NOT_ALLOWED)
+        abort(403)
     tag_association_form = TagAssociationForm()
     if request.method == "POST":
         associated_tags = get_associated_tags_for_application(application_id)

--- a/pre_award/assess/templates/assess/macros/application_overviews_table_all.html
+++ b/pre_award/assess/templates/assess/macros/application_overviews_table_all.html
@@ -96,7 +96,7 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users,
       <td class="govuk-table__cell">{{ overview.short_id[-6:] }}</td>
       <td class="govuk-table__cell"><a class="govuk-link" data-qa="project_name" id="project-name-{{ loop.index }}"
           href="{{ url_for('assessment_bp.application',application_id=overview.application_id) }}">{{
-          overview.project_name }}</a></td>
+              overview.project_name ~ (' [DELETED]' if overview.is_deleted else '') }}</a></td>
       <td class="govuk-table__cell">£{{ "{:,.2f}".format(overview.funding_amount_requested|int|round) }}</td>
       <td class="govuk-table__cell">{{ asset_types[overview.asset_type] }}</td>
       <td class="govuk-table__cell">{{ overview.location_json_blob.get('country') or "Not found" }}</td>

--- a/pre_award/assess/templates/assess/macros/application_overviews_table_all.html
+++ b/pre_award/assess/templates/assess/macros/application_overviews_table_all.html
@@ -96,7 +96,7 @@ sort_column, sort_order, tag_option_groups, tags, tagging_purpose_config, users,
       <td class="govuk-table__cell">{{ overview.short_id[-6:] }}</td>
       <td class="govuk-table__cell"><a class="govuk-link" data-qa="project_name" id="project-name-{{ loop.index }}"
           href="{{ url_for('assessment_bp.application',application_id=overview.application_id) }}">{{
-              overview.project_name ~ (' [DELETED]' if overview.is_deleted else '') }}</a></td>
+              overview.project_name ~ (' [PROJECT DELETED]' if overview.is_deleted else '') }}</a></td>
       <td class="govuk-table__cell">£{{ "{:,.2f}".format(overview.funding_amount_requested|int|round) }}</td>
       <td class="govuk-table__cell">{{ asset_types[overview.asset_type] }}</td>
       <td class="govuk-table__cell">{{ overview.location_json_blob.get('country') or "Not found" }}</td>

--- a/pre_award/assess/templates/assess/macros/assessment_actions.html
+++ b/pre_award/assess/templates/assess/macros/assessment_actions.html
@@ -1,9 +1,10 @@
-{% macro assessment_actions(application_id, fund_short_name, round_short_name) %}
+{% macro assessment_actions(application_id, fund_short_name, round_short_name, state) %}
 
     <h3 class="govuk-heading-m">Assessment actions</h3>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible section_break_blue">
+    {% if not state.is_deleted %}
     <p class="govuk-body">   <a href="{{ url_for('assessment_bp.view_entire_application', application_id=application_id) }}" target="_blank">View entire application (opens in new tab)</a></p>
-
+    {% endif %}
     {% if g.access_controller.is_lead_assessor %}
         <p class="govuk-body">
             <a href="{{ url_for('assessment_bp.comments_export_for_application',

--- a/pre_award/assess/templates/assess/macros/comments.html
+++ b/pre_award/assess/templates/assess/macros/comments.html
@@ -1,10 +1,10 @@
-{% macro comment(comments, application_id, scroll_comments, display_comment_box, display_comment_edit_box, sub_criteria=False, current_theme=False) %}
+{% macro comment(comments, application_id, scroll_comments, display_comment_box, display_comment_edit_box, state, sub_criteria=False, current_theme=False) %}
         <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-5" id="comments">
             <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Comments</h2>
             <div id="more-detail-hint" class="govuk-hint">
                 <p class="govuk-body govuk-!-margin-top-2">Summarise any thoughts you have on the assessment.</p>
             </div>
-            {% if sub_criteria and current_theme and display_comment_box != True and not display_comment_edit_box %}
+            {% if sub_criteria and current_theme and display_comment_box != True and not display_comment_edit_box and not state.is_deleted %}
                 <a
                     id="comment"
                     class="govuk-body govuk-link govuk-link--no-visited-state"
@@ -46,7 +46,7 @@
                         {% if g.account_id == comment.user_id or comment.updates|length > 1 %}
                             <div class="govuk-button-group">
                                 {% if g.account_id == comment.user_id %}
-                                    {% if comment.comment_type == "COMMENT" %}
+                                    {% if comment.comment_type == "COMMENT" and not state.is_deleted %}
                                         <a class="govuk-link" href="{{ url_for(
                                             "assessment_bp.display_sub_criteria",
                                             application_id=comment.application_id,
@@ -55,7 +55,7 @@
                                             edit_comment="1",
                                             comment_id=comment.id
                                         ) }}" >Edit comment<span class="govuk-visually-hidden"> left by {{ comment.full_name }} on {{ comment.updates[-1].date_created|utc_to_bst }}</span></a>
-                                    {% elif comment.comment_type == "WHOLE_APPLICATION" %}
+                                    {% elif comment.comment_type == "WHOLE_APPLICATION" and not state.is_deleted %}
                                         <a class="govuk-link" href="{{ url_for(
                                             "assessment_bp.application",
                                             application_id=comment.application_id,
@@ -94,7 +94,7 @@
             </div>
             {% endif %}
 
-        {% if not display_comment_box and not display_comment_edit_box and scroll_comments %}
+        {% if not display_comment_box and not display_comment_edit_box and scroll_comments and not state.is_deleted %}
             <a
                 id="comment"
                 class="govuk-button secondary-button govuk-!-margin-top-2 govuk-!-margin-bottom-6"

--- a/pre_award/assess/templates/assess/macros/sub_criteria_navbar.html
+++ b/pre_award/assess/templates/assess/macros/sub_criteria_navbar.html
@@ -1,4 +1,4 @@
-{% macro navbar(application_id, sub_criteria, current_theme_id, is_score_page=False, is_uncompeted_flow_flag=False) %}
+{% macro navbar(application_id, sub_criteria, current_theme_id, state, is_score_page=False, is_uncompeted_flow_flag=False) %}
 <nav class="assessment-navigation">
     {% if not is_uncompeted_flow_flag %}
         <ul class="govuk-list">
@@ -17,7 +17,7 @@
             {% endfor %}
         </ul>
 
-        {% if g.access_controller.has_any_assessor_role and sub_criteria.is_scored %}
+        {% if g.access_controller.has_any_assessor_role and sub_criteria.is_scored and not state.is_deleted %}
             <ul class="govuk-list">
                 <li>
                     {% if not is_score_page %}

--- a/pre_award/assessment_store/db/models/assessment_record/assessment_records.py
+++ b/pre_award/assessment_store/db/models/assessment_record/assessment_records.py
@@ -51,6 +51,8 @@ class AssessmentRecord(BaseModel):
         Computed(func.md5(cast(jsonb_blob, TEXT)), persisted=True),
     )
 
+    is_deleted = Column(Boolean, nullable=False, default=False)
+
     scores = relationship("Score")
 
     comments = relationship("Comment")

--- a/pre_award/assessment_store/db/queries/assessment_records/queries.py
+++ b/pre_award/assessment_store/db/queries/assessment_records/queries.py
@@ -51,6 +51,10 @@ def get_metadata_for_application(
     return metadata_serializer.dump(result)
 
 
+def get_assessment_record(app_id) -> AssessmentRecord | None:
+    return AssessmentRecord.query.get(app_id)
+
+
 def get_metadata_for_fund_round_id(  # noqa: C901 - historical sadness
     fund_id: str,
     round_id: str,
@@ -361,6 +365,7 @@ def find_assessor_task_list_state(application_id: str) -> dict:
             "round_id",
             "funding_amount_requested",
             "language",
+            "is_deleted",
         )
     ).dump(assessment_record)
 

--- a/pre_award/db/migrations/.current-alembic-head
+++ b/pre_award/db/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-014_introduse_newcolumn_for_soft
+014_introduce_new_column_del

--- a/pre_award/db/migrations/.current-alembic-head
+++ b/pre_award/db/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-013_add_zerotofour_scoringsystem
+014_introduse_newcolumn_for_soft

--- a/pre_award/db/migrations/versions/014_introduce_new_column_del.py
+++ b/pre_award/db/migrations/versions/014_introduce_new_column_del.py
@@ -9,7 +9,7 @@ Create Date: 2025-08-11 10:36:09.020749
 import sqlalchemy as sa
 from alembic import op
 
-revision = "014_introduse_newcolumn_for_soft"
+revision = "014_introduce_new_column_del"
 down_revision = "013_add_zerotofour_scoringsystem"
 branch_labels = None
 depends_on = None

--- a/pre_award/db/migrations/versions/014_introduse_newcolumn_for_soft.py
+++ b/pre_award/db/migrations/versions/014_introduse_newcolumn_for_soft.py
@@ -1,0 +1,30 @@
+"""Introduse newcolumn for soft delete applications but hard delete user inputs
+
+Revision ID: 014_introduse_newcolumn_for_soft
+Revises: 013_add_zerotofour_scoringsystem
+Create Date: 2025-08-11 10:36:09.020749
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '014_introduse_newcolumn_for_soft'
+down_revision = '013_add_zerotofour_scoringsystem'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('applications', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+
+    with op.batch_alter_table('assessment_records', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+
+
+def downgrade():
+    with op.batch_alter_table('assessment_records', schema=None) as batch_op:
+        batch_op.drop_column('is_deleted')
+
+    with op.batch_alter_table('applications', schema=None) as batch_op:
+        batch_op.drop_column('is_deleted')

--- a/pre_award/db/migrations/versions/014_introduse_newcolumn_for_soft.py
+++ b/pre_award/db/migrations/versions/014_introduse_newcolumn_for_soft.py
@@ -5,26 +5,27 @@ Revises: 013_add_zerotofour_scoringsystem
 Create Date: 2025-08-11 10:36:09.020749
 
 """
-from alembic import op
-import sqlalchemy as sa
 
-revision = '014_introduse_newcolumn_for_soft'
-down_revision = '013_add_zerotofour_scoringsystem'
+import sqlalchemy as sa
+from alembic import op
+
+revision = "014_introduse_newcolumn_for_soft"
+down_revision = "013_add_zerotofour_scoringsystem"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table('applications', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+    with op.batch_alter_table("applications", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("false")))
 
-    with op.batch_alter_table('assessment_records', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+    with op.batch_alter_table("assessment_records", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("false")))
 
 
 def downgrade():
-    with op.batch_alter_table('assessment_records', schema=None) as batch_op:
-        batch_op.drop_column('is_deleted')
+    with op.batch_alter_table("assessment_records", schema=None) as batch_op:
+        batch_op.drop_column("is_deleted")
 
-    with op.batch_alter_table('applications', schema=None) as batch_op:
-        batch_op.drop_column('is_deleted')
+    with op.batch_alter_table("applications", schema=None) as batch_op:
+        batch_op.drop_column("is_deleted")

--- a/scripts/delete_grant_application_data.py
+++ b/scripts/delete_grant_application_data.py
@@ -3,7 +3,9 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from app import create_app
 from pre_award.application_store.db.models import Applications
-from pre_award.application_store.db.queries.application import get_application_by_reference
+from pre_award.application_store.db.queries.application import (
+    get_applications_by_references,
+)
 from pre_award.assess.services.aws import delete_file_from_aws, list_files_in_folder
 from pre_award.assessment_store.db.models import AssessmentRecord
 from pre_award.assessment_store.db.queries.assessment_records.queries import (
@@ -14,43 +16,60 @@ from pre_award.db import db
 app = create_app()
 
 
+def _parse_refs(_ctx, _param, values) -> list[str]:
+    items = []
+    if values is None:
+        raise click.BadParameter("No application reference to delete")
+    for item in values.split(","):
+        items.append(item.strip())
+    return items
+
+
 @click.command()
 @click.option(
-    "--application_reference",
+    "-r",
+    "--application-reference",
+    "application_references",
+    callback=_parse_refs,
     help="Application reference to delete applications for",
-    prompt=True,
 )
-def delete_grant_application_data(application_reference) -> None:
-    print(f"Initialise application data deletion for application reference of {application_reference}")
-    try:
-        application: Applications = get_application_by_reference(application_reference)
-        if not application:
-            print(f"No application found with reference {application_reference}")
-            return
-        for form in application.forms:
-            db.session.delete(form)
-        application.is_deleted = True
-        application.project_name = ""
-        s3_files_list = list_files_in_folder(f"{application.id}/")
-        print(f"Found {len(s3_files_list)} files in {application.id}")
-        for file_key in s3_files_list:
-            delete_file_from_aws(file_key)
-        db.session.add(application)
-        db.session.commit()
-        print(f"Application marked as deleted and application id is {application.id}")
-        assessment_record: AssessmentRecord = get_assessment_record(application.id)
-        if assessment_record:
-            assessment_record.is_deleted = True
-            assessment_record.project_name = ""
-            assessment_record.jsonb_blob["forms"] = []
-            assessment_record.jsonb_blob["is_deleted"] = True
-            flag_modified(assessment_record, "jsonb_blob")
-            db.session.add(assessment_record)
+def delete_grant_application_data(application_references: list[str]) -> None:
+    print(f"Initialise application data deletion for application reference of {application_references}")
+    if not application_references:
+        print("Initialise application data deletion for reference(s): NONE PROVIDED")
+        return
+
+    applications: dict[str, Applications] = get_applications_by_references(application_references)
+    if not applications:
+        print("No application found with reference")
+        return
+
+    for application in applications.values():
+        try:
+            for form in application.forms:
+                db.session.delete(form)
+            application.is_deleted = True
+            application.project_name = ""
+            s3_files_list = list_files_in_folder(f"{application.id}/")
+            print(f"Found {len(s3_files_list)} files in {application.id}")
+            for file_key in s3_files_list:
+                delete_file_from_aws(file_key)
+            db.session.add(application)
             db.session.commit()
-            print(f"Assessment marked as deleted and application id is {application.id}")
-    except Exception as e:
-        db.session.rollback()
-        print(f"An error occurred: {e}")
+            print(f"Application marked as deleted and application id is {application.id}")
+            assessment_record: AssessmentRecord = get_assessment_record(application.id)
+            if assessment_record:
+                assessment_record.is_deleted = True
+                assessment_record.project_name = ""
+                assessment_record.jsonb_blob["forms"] = []
+                assessment_record.jsonb_blob["is_deleted"] = True
+                flag_modified(assessment_record, "jsonb_blob")
+                db.session.add(assessment_record)
+                db.session.commit()
+                print(f"Assessment marked as deleted and application id is {application.id}")
+        except Exception as e:
+            db.session.rollback()
+            print(f"An error occurred: {e}")
 
 
 if __name__ == "__main__":

--- a/scripts/delete_grant_application_data.py
+++ b/scripts/delete_grant_application_data.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from app import create_app
 from pre_award.application_store.db.models import Applications
-from pre_award.application_store.db.models.application.enums import Status
 from pre_award.application_store.db.queries.application import get_application_by_reference
 from pre_award.assess.services.aws import delete_file_from_aws, list_files_in_folder
 from pre_award.assessment_store.db.models import AssessmentRecord
@@ -41,8 +40,6 @@ def delete_grant_application_data(application_reference) -> None:
         assessment_record: AssessmentRecord = get_assessment_record(application.id)
         if assessment_record:
             assessment_record.is_deleted = True
-            assessment_record.jsonb_blob["forms"] = []
-            assessment_record.jsonb_blob["is_deleted"] = True
             assessment_record.jsonb_blob["forms"] = []
             assessment_record.jsonb_blob["is_deleted"] = True
             flag_modified(assessment_record, "jsonb_blob")

--- a/scripts/delete_grant_application_data.py
+++ b/scripts/delete_grant_application_data.py
@@ -1,0 +1,59 @@
+import click
+from sqlalchemy.orm.attributes import flag_modified
+
+from app import create_app
+from pre_award.application_store.db.models import Applications
+from pre_award.application_store.db.models.application.enums import Status
+from pre_award.application_store.db.queries.application import get_application_by_reference
+from pre_award.assess.services.aws import delete_file_from_aws, list_files_in_folder
+from pre_award.assessment_store.db.models import AssessmentRecord
+from pre_award.assessment_store.db.queries.assessment_records.queries import (
+    get_assessment_record,
+)
+from pre_award.db import db
+
+app = create_app()
+
+
+@click.command()
+@click.option(
+    "--application_reference",
+    help="Application reference to delete applications for",
+    prompt=True,
+)
+def delete_grant_application_data(application_reference) -> None:
+    print(f"Initialise application data deletion for application reference of {application_reference}")
+    try:
+        application: Applications = get_application_by_reference(application_reference)
+        if not application:
+            print(f"No application found with reference {application_reference}")
+            return
+        for form in application.forms:
+            db.session.delete(form)
+        application.is_deleted = True
+        s3_files_list = list_files_in_folder(f"{application.id}/")
+        print(f"Found {len(s3_files_list)} files in {application.id}")
+        for file_key in s3_files_list:
+            delete_file_from_aws(file_key)
+        db.session.add(application)
+        db.session.commit()
+        print(f"Application marked as deleted and application id is {application.id}")
+        assessment_record: AssessmentRecord = get_assessment_record(application.id)
+        if assessment_record:
+            assessment_record.is_deleted = True
+            assessment_record.jsonb_blob["forms"] = []
+            assessment_record.jsonb_blob["is_deleted"] = True
+            assessment_record.jsonb_blob["forms"] = []
+            assessment_record.jsonb_blob["is_deleted"] = True
+            flag_modified(assessment_record, "jsonb_blob")
+            db.session.add(assessment_record)
+            db.session.commit()
+            print(f"Assessment marked as deleted and application id is {application.id}")
+    except Exception as e:
+        db.session.rollback()
+        print(f"An error occurred: {e}")
+
+
+if __name__ == "__main__":
+    with app.app_context():
+        delete_grant_application_data()

--- a/scripts/delete_grant_application_data.py
+++ b/scripts/delete_grant_application_data.py
@@ -30,6 +30,7 @@ def delete_grant_application_data(application_reference) -> None:
         for form in application.forms:
             db.session.delete(form)
         application.is_deleted = True
+        application.project_name = ""
         s3_files_list = list_files_in_folder(f"{application.id}/")
         print(f"Found {len(s3_files_list)} files in {application.id}")
         for file_key in s3_files_list:
@@ -40,6 +41,7 @@ def delete_grant_application_data(application_reference) -> None:
         assessment_record: AssessmentRecord = get_assessment_record(application.id)
         if assessment_record:
             assessment_record.is_deleted = True
+            assessment_record.project_name = ""
             assessment_record.jsonb_blob["forms"] = []
             assessment_record.jsonb_blob["is_deleted"] = True
             flag_modified(assessment_record, "jsonb_blob")

--- a/tests/pre_award/apply_tests/api_data/test_data.py
+++ b/tests/pre_award/apply_tests/api_data/test_data.py
@@ -250,6 +250,7 @@ TEST_APPLICATIONS = [
             "status": "IN_PROGRESS",
             "language": "en",
             "forms": COF_TEST_FORMS,
+            "is_deleted": False,
         }
     ),
     Application.from_dict(
@@ -267,6 +268,7 @@ TEST_APPLICATIONS = [
             "status": "IN_PROGRESS",
             "language": "cy",
             "forms": COF_TEST_FORMS,
+            "is_deleted": False,
         }
     ),
 ]
@@ -286,6 +288,7 @@ SUBMITTED_APPLICATION = Application.from_dict(
         "status": "SUBMITTED",
         "language": "en",
         "forms": [],
+        "is_deleted": False,
     }
 )
 
@@ -398,5 +401,6 @@ NOT_STARTED_APPLICATION = Application.from_dict(
                 "status": "NOT_STARTED",
             },
         ],
+        "is_deleted": False,
     }
 )

--- a/tests/pre_award/apply_tests/test_models.py
+++ b/tests/pre_award/apply_tests/test_models.py
@@ -21,6 +21,7 @@ def test_match_forms_to_state_all_forms_complete(apply_test_client):
             {"name": "form_1", "status": ApplicationStatus.COMPLETED.name},
             {"name": "form_2", "status": ApplicationStatus.COMPLETED.name},
         ],
+        is_deleted=False,
     )
 
     display_config = [
@@ -81,6 +82,7 @@ def test_match_forms_to_state_not_complete(apply_test_client):
             {"name": "form_1", "status": ApplicationStatus.COMPLETED.name},
             {"name": "form_2", "status": ApplicationStatus.NOT_STARTED.name},
         ],
+        is_deleted=False,
     )
 
     display_config = [

--- a/tests/pre_award/assess_tests/api_data/test_data.py
+++ b/tests/pre_award/assess_tests/api_data/test_data.py
@@ -145,6 +145,7 @@ flagged_app = {
     "id": flagged_app_id,
     "workflow_status": "IN_PROGRESS",
     "project_name": "Project In prog and Res",
+    "is_deleted": False,
     "short_id": "INP",
     "flags": [
         {
@@ -205,6 +206,7 @@ resolved_app = {
     "id": resolved_app_id,
     "workflow_status": "IN_PROGRESS",
     "project_name": "Project In prog and Res",
+    "is_deleted": False,
     "short_id": "INP",
     "flags": [
         {
@@ -294,6 +296,7 @@ uncompeted_app = {
     "workflow_status": "CHANGE_RECEIVED",
     "project_name": "Uncompeted project In prog and Res",
     "short_id": "UNCMP-INP",
+    "is_deleted": False,
     "qa_complete": [],
     "is_qa_complete": True,
     "criteria_sub_criteria_name": "test_uncomp_sub_criteria",
@@ -580,6 +583,7 @@ mock_api_results = {
             "qa_complete": flagged_qa_completed_app["qa_complete"],
             "funding_amount_requested": test_funding_requested + 2000,
             "is_qa_complete": True,
+            "is_deleted": False,
             "language": "en",
             "location_json_blob": {
                 "constituency": "test-constituency",
@@ -607,6 +611,7 @@ mock_api_results = {
             "qa_complete": assigned_app["qa_complete"],
             "funding_amount_requested": test_funding_requested + 8000,
             "is_qa_complete": True,
+            "is_deleted": False,
             "language": "en",
             "location_json_blob": {
                 "constituency": "test-constituency",
@@ -634,6 +639,7 @@ mock_api_results = {
             "qa_complete": stopped_app["qa_complete"],
             "funding_amount_requested": test_funding_requested + 1000,
             "is_qa_complete": True,
+            "is_deleted": False,
             "language": "en",
             "location_json_blob": {
                 "constituency": "test-constituency",
@@ -661,6 +667,7 @@ mock_api_results = {
             "qa_complete": resolved_app["qa_complete"],
             "funding_amount_requested": test_funding_requested,
             "is_qa_complete": True,
+            "is_deleted": False,
             "language": "en",
             "location_json_blob": {
                 "constituency": "test-constituency",
@@ -688,6 +695,7 @@ mock_api_results = {
             "flags": stopped_app["flags"],
             "qa_complete": stopped_app["qa_complete"],
             "funding_amount_requested": test_funding_requested,
+            "is_deleted": False,
             "is_qa_complete": True,
             "language": "en",
             "location_json_blob": {
@@ -746,6 +754,7 @@ mock_api_results = {
         "workflow_status": stopped_app["workflow_status"],
         "fund_id": test_fund_id,
         "round_id": test_round_id,
+        "is_deleted": False,
         "qa_complete": stopped_app["qa_complete"],
     },
     "assessment_store/application_overviews/resolved_app": {
@@ -778,6 +787,7 @@ mock_api_results = {
         "fund_id": test_fund_id,
         "round_id": test_round_id,
         "qa_complete": resolved_app["qa_complete"],
+        "is_deleted": False,
         "is_qa_complete": resolved_app["is_qa_complete"],
     },
     "assessment_store/application_overviews/uncompeted_app": {
@@ -809,6 +819,7 @@ mock_api_results = {
         "workflow_status": uncompeted_app["workflow_status"],
         "fund_id": "UNCOMPETED_FUND",
         "round_id": test_round_id,
+        "is_deleted": False,
         "qa_complete": uncompeted_app["qa_complete"],
     },
     "assessment_store/application_overviews/flagged_app": {
@@ -839,6 +850,7 @@ mock_api_results = {
         "short_id": flagged_app["short_id"],
         "workflow_status": flagged_app["workflow_status"],
         "fund_id": test_fund_id,
+        "is_deleted": False,
         "round_id": test_round_id,
         "qa_complete": flagged_app["qa_complete"],
     },
@@ -847,6 +859,7 @@ mock_api_results = {
         "sections": [],
         "fund_id": test_fund_id,
         "round_id": test_round_id,
+        "is_deleted": False,
         "project_name": flagged_qa_completed_app["project_name"],
         "short_id": flagged_qa_completed_app["short_id"],
         "workflow_status": flagged_qa_completed_app["workflow_status"],
@@ -857,6 +870,7 @@ mock_api_results = {
         "project_name": resolved_app["project_name"],
         "funding_amount_requested": test_funding_requested,
         "workflow_status": resolved_app["workflow_status"],
+        "is_deleted": False,
         "fund_id": test_fund_id,
     },
     "assessment_store/sub_criteria_overview/banner_state/stopped_app": {
@@ -864,6 +878,7 @@ mock_api_results = {
         "project_name": stopped_app["project_name"],
         "funding_amount_requested": test_funding_requested,
         "workflow_status": stopped_app["workflow_status"],
+        "is_deleted": False,
         "fund_id": test_fund_id,
     },
     "assessment_store/sub_criteria_overview/banner_state/flagged_qa_completed_app": {
@@ -871,6 +886,7 @@ mock_api_results = {
         "project_name": flagged_qa_completed_app["project_name"],
         "funding_amount_requested": test_funding_requested,
         "workflow_status": flagged_qa_completed_app["workflow_status"],
+        "is_deleted": False,
         "fund_id": test_fund_id,
     },
     "assessment_store/flag_data?flag_id=flagged_app": flagged_app["flags"][-1],

--- a/tests/pre_award/assess_tests/conftest.py
+++ b/tests/pre_award/assess_tests/conftest.py
@@ -485,6 +485,40 @@ def mock_get_assessor_tasklist_state(request, mocker):
 
 
 @pytest.fixture
+def mock_get_assessor_tasklist_state_deleted_application(request, mocker):
+    application_id = request.node.get_closest_marker("application_id").args[0]
+    # Load the mock dict from your test data
+    mock_tasklist_state = mock_api_results[f"assessment_store/application_overviews/{application_id}"]
+
+    # Patch the raw dict-returning function
+    patch_1 = mocker.patch(
+        "pre_award.assess.services.shared_data_helpers.get_assessor_task_list_state",
+        return_value=mock_tasklist_state,
+    )
+
+    # Convert the dict into an AssessorTaskList object
+    mock_tasklist_object = AssessorTaskList.from_json(
+        {
+            **mock_tasklist_state,
+            "fund_name": "Test Fund",
+            "fund_short_name": "TF",
+            "round_short_name": "R1",
+            "fund_guidance_url": "https://example.com",
+            "is_eoi_round": False,
+            "is_deleted": True,
+        }
+    )
+
+    # Patch the object-returning function
+    patch_2 = mocker.patch(
+        "pre_award.assess.authentication.validation.get_state_for_tasklist_banner",
+        return_value=mock_tasklist_object,
+    )
+
+    yield patch_1, patch_2
+
+
+@pytest.fixture
 def expect_flagging():
     return False
 

--- a/tests/pre_award/assess_tests/conftest.py
+++ b/tests/pre_award/assess_tests/conftest.py
@@ -749,6 +749,7 @@ def mock_get_tasklist_state_for_banner(mocker):
         sections=[],
         criterias=[],
         is_eoi_round=False,
+        is_deleted=False,
     )
     mocker.patch(
         "pre_award.assess.assessments.routes.get_state_for_tasklist_banner",

--- a/tests/pre_award/assessment_store_tests/test_db_function.py
+++ b/tests/pre_award/assessment_store_tests/test_db_function.py
@@ -76,6 +76,7 @@ def test_find_assessor_task_list_ui_metadata(seed_application_records):
         "date_submitted": "2022-10-27T08:32:13.383999",
         "funding_amount_requested": 4600.00,
         "language": "en",
+        "is_deleted": False,
     }
 
 


### PR DESCRIPTION
**Ticket: [Remove the data of unsuccessful applicants from COF](https://mhclgdigital.atlassian.net/browse/FLS-1307)**


### Change description
As MHCLG, we need to remove application data for users who were unsuccessful in their grant applications, in line with our privacy notice.

This action ensures compliance with our data retention responsibilities under GDPR, even though there is no explicit legal requirement to notify data subjects when deletion occurs unless it is in response to a request. Our data protection team (consulted in April) confirmed that data should be removed in a “timely manner,”.

This PR implements backend logic to identify and securely delete data associated with unsuccessful applications.

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Create an application and submit it once done delete the data using this script it will delete all the user input data
