### PR TITLE
Testing removal of UAT sidecar (not to be merged)

### DIFF
--- a/copilot/fsd-pre-award/manifest.yml
+++ b/copilot/fsd-pre-award/manifest.yml
@@ -179,17 +179,6 @@ environments:
         value: 80
       requests: 30
       response_time: 2s
-    sidecars:
-      nginx:
-        port: 8087
-        image:
-          location: xscys/nginx-sidecar-basic-auth
-        variables:
-          FORWARD_PORT: 8080
-          CLIENT_MAX_BODY_SIZE: 10m
-        secrets:
-          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
-          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
     http:
       alias:
         - account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
@@ -197,18 +186,12 @@ environments:
         - apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
       additional_rules:
         - path: /
-          target_container: nginx
           alias:
             - assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
             - frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
             - authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
           healthcheck:
             path: /healthcheck
-            port: 8080
-      target_container: nginx
-      healthcheck:
-        path: /healthcheck
-        port: 8080
   prod:
     http:
       alias:


### PR DESCRIPTION
We are seeing some 502 Gateway error in pre-prod environments. Removing certain roles from the database seems to fix this. We are not sure why but we suspect the nginx sidecar we are using may be causing problems, as it is deprecated (not updated in six years) and we have seen [issues with basic auth failing if response cookie is too large](https://mhclgdigital.atlassian.net/browse/FLS-1433). To test this theory, we are going to re-add the roles we removed from the UAT database to fix the issue, back into the UAT database, deploy a sidecar-less UAT service and see if we get the 502 still. If not, then we can feel more confident about deploying to prod and unblocking the pipeline while we figure out a longer-term fix for the sidecar issue.