### PR TITLE
FLS-1449 - Implement forms API

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,6 +63,7 @@ from pre_award.assessment_store.api.routes import assessment_store_bp
 from pre_award.common.locale_selector.get_lang import get_lang
 from pre_award.common.locale_selector.set_lang import LanguageSelector
 from pre_award.config import Config
+from pre_award.form_store.api.routes import form_store_bp
 from pre_award.fund_store.api.routes import fund_store_bp
 from services.notify import NotificationService
 
@@ -266,10 +267,12 @@ def create_app() -> Flask:  # noqa: C901
     flask_app.register_blueprint(fund_store_bp, url_prefix="/fund", host=Config.API_HOST)
     flask_app.register_blueprint(application_store_bp, url_prefix="/application", host=Config.API_HOST)
     flask_app.register_blueprint(assessment_store_bp, url_prefix="/assessment", host=Config.API_HOST)
+    flask_app.register_blueprint(form_store_bp, url_prefix="/forms", host=Config.API_HOST)
     csrf.exempt(account_core_bp)
     csrf.exempt(fund_store_bp)
     csrf.exempt(application_store_bp)
     csrf.exempt(assessment_store_bp)
+    csrf.exempt(form_store_bp)
     for bp, _ in assessment_store_bp._blueprints:
         csrf.exempt(bp)
 

--- a/pre_award/form_store/api/routes.py
+++ b/pre_award/form_store/api/routes.py
@@ -51,6 +51,10 @@ class FormsView(MethodView):
             name = data["name"]
             form_json = data["form_json"]
 
+            # Validate that name is not empty or whitespace-only
+            if not name or not name.strip():
+                return {"error": "Form name cannot be empty"}, 400
+
             # Validate that form_json is valid JSON if it's a string
             if isinstance(form_json, str):
                 try:

--- a/pre_award/form_store/api/routes.py
+++ b/pre_award/form_store/api/routes.py
@@ -1,0 +1,140 @@
+import hashlib
+import json
+
+from flask import current_app, request
+from flask.views import MethodView
+from fsd_utils.authentication.decorators import login_required
+from sqlalchemy.orm.exc import NoResultFound
+
+from pre_award.common.blueprints import Blueprint
+from pre_award.form_store.db.queries import (
+    create_or_update_form,
+    get_all_forms,
+    get_form_by_name,
+    publish_form,
+)
+
+form_store_bp = Blueprint("form_store_bp", __name__)
+
+
+class FormsView(MethodView):
+    decorators = [login_required]
+
+    def get(self):
+        """GET /forms - Returns a list of all forms"""
+        try:
+            forms = get_all_forms()
+            return [form.as_dict() for form in forms], 200
+        except Exception as e:
+            current_app.logger.error("Error retrieving forms: %s", str(e))
+            return {"error": "Failed to retrieve forms"}, 500
+
+    def post(self):
+        """POST /forms - Creates or updates a form"""
+        try:
+            if not request.is_json:
+                return {"error": "Missing required fields: name, form_json"}, 400
+
+            data = request.get_json()
+
+            if not data or "name" not in data or "form_json" not in data:
+                return {"error": "Missing required fields: name, form_json"}, 400
+
+            name = data["name"]
+            form_json = data["form_json"]
+
+            # Validate that form_json is valid JSON if it's a string
+            if isinstance(form_json, str):
+                try:
+                    form_json = json.loads(form_json)
+                except json.JSONDecodeError:
+                    return {"error": "Invalid JSON in form_json field"}, 400
+
+            form = create_or_update_form(name, form_json)
+            current_app.logger.info("Form %s created/updated successfully", name)
+
+            return form.as_dict(), 201
+
+        except Exception as e:
+            current_app.logger.error("Error creating/updating form: %s", str(e))
+            return {"error": "Failed to create/update form"}, 500
+
+
+class FormDraftView(MethodView):
+    decorators = [login_required]
+
+    def get(self, name):
+        """GET /forms/{name}/draft - Returns the draft_json object"""
+        try:
+            form = get_form_by_name(name)
+            return form.draft_json, 200
+        except NoResultFound:
+            return {"error": f"Form '{name}' not found"}, 404
+        except Exception as e:
+            current_app.logger.error("Error retrieving draft for form %s: %s", name, str(e))
+            return {"error": "Failed to retrieve form draft"}, 500
+
+
+class FormPublishedView(MethodView):
+    decorators = [login_required]
+
+    def get(self, name):
+        """GET /forms/{name}/published - Returns the published_json object"""
+        try:
+            form = get_form_by_name(name)
+            if not form.published_json or form.published_json == {}:
+                return {"error": f"Form '{name}' has not been published"}, 404
+            return form.published_json, 200
+        except NoResultFound:
+            return {"error": f"Form '{name}' not found"}, 404
+        except Exception as e:
+            current_app.logger.error("Error retrieving published form %s: %s", name, str(e))
+            return {"error": "Failed to retrieve published form"}, 500
+
+
+class FormHashView(MethodView):
+    decorators = [login_required]
+
+    def get(self, name):
+        """GET /forms/{name}/hash - Returns hash of published_json for cache validation"""
+        try:
+            form = get_form_by_name(name)
+            if not form.published_json or form.published_json == {}:
+                return {"error": f"Form '{name}' has not been published"}, 404
+
+            # Create hash of published_json
+            json_string = json.dumps(form.published_json, sort_keys=True, separators=(",", ":"))
+            hash_value = hashlib.md5(json_string.encode()).hexdigest()
+
+            return {"hash": hash_value}, 200
+        except NoResultFound:
+            return {"error": f"Form '{name}' not found"}, 404
+        except Exception as e:
+            current_app.logger.error("Error retrieving hash for form %s: %s", name, str(e))
+            return {"error": "Failed to retrieve form hash"}, 500
+
+
+class FormPublishView(MethodView):
+    decorators = [login_required]
+
+    def put(self, name):
+        """PUT /forms/{name}/publish - Publishes a form (copies draft to published)"""
+        try:
+            form = publish_form(name)
+            current_app.logger.info("Form %s published successfully", name)
+            return form.as_dict(), 200
+        except NoResultFound:
+            return {"error": f"Form '{name}' not found"}, 404
+        except ValueError as e:
+            return {"error": str(e)}, 400
+        except Exception as e:
+            current_app.logger.error("Error publishing form %s: %s", name, str(e))
+            return {"error": "Failed to publish form"}, 500
+
+
+# Register URL rules
+form_store_bp.add_url_rule("", view_func=FormsView.as_view("forms"))
+form_store_bp.add_url_rule("/<name>/draft", view_func=FormDraftView.as_view("form_draft"))
+form_store_bp.add_url_rule("/<name>/published", view_func=FormPublishedView.as_view("form_published"))
+form_store_bp.add_url_rule("/<name>/hash", view_func=FormHashView.as_view("form_hash"))
+form_store_bp.add_url_rule("/<name>/publish", view_func=FormPublishView.as_view("form_publish"))

--- a/pre_award/form_store/db/models/form_definition.py
+++ b/pre_award/form_store/db/models/form_definition.py
@@ -35,3 +35,16 @@ class FormDefinition(BaseModel):
     name = Column(Text, unique=True, nullable=False)
     draft_json = Column(JSONB, nullable=False)
     published_json = Column(JSONB, nullable=False, default="{}")
+
+    def as_dict(self):
+        """Convert the FormDefinition to a dictionary representation."""
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "published_at": self.published_at.isoformat() if self.published_at else None,
+            "draft_json": self.draft_json,
+            "published_json": self.published_json,
+            "is_published": bool(self.published_json and self.published_json != {}),
+        }

--- a/pre_award/form_store/db/queries.py
+++ b/pre_award/form_store/db/queries.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from typing import List
+
+from sqlalchemy.sql import func
+
+from pre_award.db import db
+from pre_award.form_store.db.models.form_definition import FormDefinition
+
+
+def get_all_forms() -> List[FormDefinition]:
+    """
+    Retrieve all forms from the database.
+
+    Returns:
+        List[FormDefinition]: List of all form definitions
+    """
+    return db.session.query(FormDefinition).all()
+
+
+def get_form_by_name(name: str) -> FormDefinition:
+    """
+    Retrieve a form by its name.
+
+    Args:
+        name (str): The name of the form
+
+    Returns:
+        FormDefinition: The form definition
+
+    Raises:
+        NoResultFound: If no form with the given name exists
+    """
+    return db.session.query(FormDefinition).filter(FormDefinition.name == name).one()
+
+
+def create_or_update_form(name: str, form_json: dict) -> FormDefinition:
+    """
+    Create a new form or update an existing form's draft.
+
+    Args:
+        name (str): The name of the form
+        form_json (dict): The form JSON data
+
+    Returns:
+        FormDefinition: The created or updated form definition
+    """
+    existing_form = db.session.query(FormDefinition).filter(FormDefinition.name == name).first()
+
+    if existing_form:
+        # Update existing form's draft
+        existing_form.draft_json = form_json
+        existing_form.updated_at = func.now()
+        db.session.commit()
+        return existing_form
+    else:
+        # Create new form
+        new_form = FormDefinition(name=name, draft_json=form_json, published_json={})
+        db.session.add(new_form)
+        db.session.commit()
+        return new_form
+
+
+def publish_form(name: str) -> FormDefinition:
+    """
+    Publish a form by copying draft_json to published_json.
+
+    Args:
+        name (str): The name of the form to publish
+
+    Returns:
+        FormDefinition: The published form definition
+
+    Raises:
+        NoResultFound: If no form with the given name exists
+        ValueError: If the form has no draft to publish
+    """
+    form = db.session.query(FormDefinition).filter(FormDefinition.name == name).one()
+
+    if not form.draft_json:
+        raise ValueError(f"Form '{name}' has no draft to publish")
+
+    form.published_json = form.draft_json
+    form.published_at = datetime.now()
+    form.updated_at = func.now()
+
+    db.session.commit()
+    return form

--- a/tests/pre_award/form_store_tests/conftest.py
+++ b/tests/pre_award/form_store_tests/conftest.py
@@ -1,0 +1,143 @@
+"""
+Contains test configuration for form_store tests.
+"""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask.testing import FlaskClient
+from werkzeug.test import TestResponse
+
+from pre_award.config import Config
+from pre_award.form_store.db.models.form_definition import FormDefinition
+
+
+class _FlaskClientWithHost(FlaskClient):
+    def open(
+        self,
+        *args: Any,
+        buffered: bool = False,
+        follow_redirects: bool = False,
+        **kwargs: Any,
+    ) -> TestResponse:
+        if "headers" in kwargs:
+            kwargs["headers"].setdefault("Host", Config.API_HOST)
+        else:
+            kwargs.setdefault("headers", {"Host": Config.API_HOST})
+        return super().open(*args, buffered=buffered, follow_redirects=follow_redirects, **kwargs)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_auth():
+    """Mock authentication for all tests."""
+    mock_payload = {
+        "accountId": "test-account-id",
+        "fullName": "Test User",
+        "email": "test@example.com",
+        "roles": ["ADMIN"],
+    }
+
+    # Mock the entire _check_access_token function to always return valid payload
+    with patch("fsd_utils.authentication.decorators._check_access_token") as mock_check:
+        mock_check.return_value = mock_payload
+        with patch("fsd_utils.authentication.decorators.User.set_with_token") as mock_user_set:
+            mock_user = MagicMock()
+            mock_user.email = "test@example.com"
+            mock_user.full_name = "Test User"
+            mock_user.roles = ["ADMIN"]
+            mock_user.highest_role_map = {}
+            mock_user_set.return_value = mock_user
+
+            yield
+
+
+@pytest.fixture(scope="function")
+def flask_test_client(app, db):
+    """Create test client with authentication mocked."""
+    app.test_client_class = _FlaskClientWithHost
+    with app.test_client() as test_client:
+        yield test_client
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_forms(db):
+    """Clean up all forms after each test."""
+    yield
+    # This runs after each test
+    try:
+        FormDefinition.query.delete()
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+
+
+@pytest.fixture(scope="function")
+def sample_form_data():
+    """Sample form JSON data for testing."""
+    return {
+        "name": "test-form",
+        "form_json": {
+            "pages": [
+                {
+                    "path": "/test-page",
+                    "title": "Test Page",
+                    "components": [{"name": "test-field", "title": "Test Field", "type": "TextField"}],
+                }
+            ],
+            "startPage": "/test-page",
+        },
+    }
+
+
+@pytest.fixture(scope="function")
+def sample_form_record(db, sample_form_data):
+    """Create a sample form record in the database."""
+    form = FormDefinition(name=sample_form_data["name"], draft_json=sample_form_data["form_json"], published_json={})
+    db.session.add(form)
+    db.session.commit()
+    yield form
+
+
+@pytest.fixture(scope="function")
+def published_form_record(db):
+    """Create a sample form record with published content."""
+    form_json = {
+        "pages": [{"path": "/published-page", "title": "Published Page", "components": []}],
+        "startPage": "/published-page",
+    }
+
+    form = FormDefinition(
+        name="published-form",
+        draft_json=form_json,
+        published_json=form_json,
+        published_at=datetime.now(),
+    )
+    db.session.add(form)
+    db.session.commit()
+    yield form
+
+
+@pytest.fixture(scope="function")
+def multiple_form_records(db):
+    """Create multiple form records for testing."""
+    forms = []
+    form_data = [
+        {
+            "name": "form-1",
+            "draft_json": {"title": "Form 1", "pages": []},
+            "published_json": {"title": "Form 1", "pages": []},
+            "published_at": datetime.now(),
+        },
+        {"name": "form-2", "draft_json": {"title": "Form 2", "pages": []}, "published_json": {}},
+        {"name": "form-3", "draft_json": {"title": "Form 3", "pages": []}, "published_json": {}},
+    ]
+
+    for data in form_data:
+        form = FormDefinition(**data)
+        db.session.add(form)
+        forms.append(form)
+
+    db.session.commit()
+    yield forms

--- a/tests/pre_award/form_store_tests/test_queries.py
+++ b/tests/pre_award/form_store_tests/test_queries.py
@@ -1,0 +1,202 @@
+"""
+Tests for form_store database queries.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm.exc import NoResultFound
+
+from pre_award.form_store.db.models.form_definition import FormDefinition
+from pre_award.form_store.db.queries import create_or_update_form, get_all_forms, get_form_by_name, publish_form
+
+
+class TestGetAllForms:
+    """Tests for get_all_forms query."""
+
+    def test_get_all_forms_empty(self, db):
+        """Test get_all_forms returns empty list when no forms exist."""
+        result = get_all_forms()
+        assert result == []
+
+    def test_get_all_forms_with_data(self, db, multiple_form_records):
+        """Test get_all_forms returns all forms."""
+        result = get_all_forms()
+
+        assert len(result) == 3
+        form_names = [form.name for form in result]
+        assert "form-1" in form_names
+        assert "form-2" in form_names
+        assert "form-3" in form_names
+
+
+class TestGetFormByName:
+    """Tests for get_form_by_name query."""
+
+    def test_get_form_by_name_success(self, db, sample_form_record):
+        """Test get_form_by_name returns correct form."""
+        result = get_form_by_name(sample_form_record.name)
+
+        assert result.id == sample_form_record.id
+        assert result.name == sample_form_record.name
+        assert result.draft_json == sample_form_record.draft_json
+        assert result.published_json == sample_form_record.published_json
+
+    def test_get_form_by_name_not_found(self, db):
+        """Test get_form_by_name raises NoResultFound for non-existent form."""
+        with pytest.raises(NoResultFound):
+            get_form_by_name("non-existent-form")
+
+
+class TestCreateOrUpdateForm:
+    """Tests for create_or_update_form query."""
+
+    def test_create_new_form(self, db):
+        """Test create_or_update_form creates new form."""
+        form_name = "new-test-form"
+        form_json = {"pages": [{"path": "/test", "title": "Test"}], "startPage": "/test"}
+
+        result = create_or_update_form(form_name, form_json)
+
+        assert result.name == form_name
+        assert result.draft_json == form_json
+        assert result.published_json == {}
+        assert result.created_at is not None
+        assert result.updated_at is not None
+
+        # Verify it was saved to database
+        saved_form = db.session.query(FormDefinition).filter_by(name=form_name).first()
+        assert saved_form is not None
+        assert saved_form.name == form_name
+
+    def test_update_existing_form(self, db, sample_form_record):
+        """Test create_or_update_form updates existing form."""
+        new_form_json = {"pages": [{"path": "/updated", "title": "Updated"}], "startPage": "/updated"}
+
+        result = create_or_update_form(sample_form_record.name, new_form_json)
+
+        assert result.id == sample_form_record.id
+        assert result.name == sample_form_record.name
+        assert result.draft_json == new_form_json
+        assert result.published_json == sample_form_record.published_json  # Should remain unchanged
+
+        # Verify database was updated
+        db.session.refresh(sample_form_record)
+        assert sample_form_record.draft_json == new_form_json
+
+
+class TestPublishForm:
+    """Tests for publish_form query."""
+
+    def test_publish_form_success(self, db, sample_form_record):
+        """Test publish_form copies draft to published."""
+        original_published_at = sample_form_record.published_at
+
+        result = publish_form(sample_form_record.name)
+
+        assert result.id == sample_form_record.id
+        assert result.name == sample_form_record.name
+        assert result.published_json == sample_form_record.draft_json
+        assert result.published_at is not None
+        assert result.published_at != original_published_at
+
+        # Verify database was updated
+        db.session.refresh(sample_form_record)
+        assert sample_form_record.published_json == sample_form_record.draft_json
+        assert sample_form_record.published_at is not None
+
+    def test_publish_form_not_found(self, db):
+        """Test publish_form raises NoResultFound for non-existent form."""
+        with pytest.raises(NoResultFound):
+            publish_form("non-existent-form")
+
+    def test_publish_form_no_draft(self, db):
+        """Test publish_form raises ValueError when no draft exists."""
+        # Create form with no draft_json
+        form = FormDefinition(name="no-draft-form", draft_json=None, published_json={})
+        db.session.add(form)
+        db.session.commit()
+
+        with pytest.raises(ValueError) as exc_info:
+            publish_form("no-draft-form")
+        assert "has no draft to publish" in str(exc_info.value)
+
+    def test_publish_form_empty_draft(self, db):
+        """Test publish_form raises ValueError when draft is empty dict."""
+        # Create form with empty draft_json
+        form = FormDefinition(name="empty-draft-form", draft_json={}, published_json={})
+        db.session.add(form)
+        db.session.commit()
+
+        # Empty dict should be considered as "no draft"
+        with pytest.raises(ValueError) as exc_info:
+            publish_form("empty-draft-form")
+        assert "has no draft to publish" in str(exc_info.value)
+
+    @patch("pre_award.form_store.db.queries.datetime")
+    def test_publish_form_sets_current_timestamp(self, mock_datetime, db, sample_form_record):
+        """Test publish_form sets published_at to current timestamp."""
+        mock_now = datetime(2025, 1, 1, 12, 0, 0)
+        mock_datetime.now.return_value = mock_now
+
+        result = publish_form(sample_form_record.name)
+
+        assert result.published_at == mock_now
+        mock_datetime.now.assert_called_once()
+
+
+class TestFormDefinitionModel:
+    """Tests for FormDefinition model methods."""
+
+    def test_as_dict_published_form(self, db, published_form_record):
+        """Test as_dict method for published form."""
+        result = published_form_record.as_dict()
+
+        assert result["id"] == str(published_form_record.id)
+        assert result["name"] == published_form_record.name
+        assert result["draft_json"] == published_form_record.draft_json
+        assert result["published_json"] == published_form_record.published_json
+        assert result["is_published"] is True
+        assert result["created_at"] is not None
+        assert result["updated_at"] is not None
+        assert result["published_at"] is not None
+
+    def test_as_dict_unpublished_form(self, db, sample_form_record):
+        """Test as_dict method for unpublished form."""
+        result = sample_form_record.as_dict()
+
+        assert result["id"] == str(sample_form_record.id)
+        assert result["name"] == sample_form_record.name
+        assert result["draft_json"] == sample_form_record.draft_json
+        assert result["published_json"] == {}
+        assert result["is_published"] is False
+        assert result["created_at"] is not None
+        assert result["updated_at"] is not None
+        assert result["published_at"] is None
+
+    def test_as_dict_handles_none_timestamps(self, db):
+        """Test as_dict handles None timestamps gracefully."""
+        form = FormDefinition(name="test-form", draft_json={"test": "data"}, published_json={})
+        # Don't add to session to avoid auto-setting timestamps
+
+        result = form.as_dict()
+
+        assert result["created_at"] is None
+        assert result["updated_at"] is None
+        assert result["published_at"] is None
+        assert result["is_published"] is False
+
+    def test_is_published_logic(self, db):
+        """Test is_published logic in as_dict method."""
+        # Test with empty dict
+        form1 = FormDefinition(name="form1", draft_json={}, published_json={})
+        assert form1.as_dict()["is_published"] is False
+
+        # Test with None
+        form2 = FormDefinition(name="form2", draft_json={}, published_json=None)
+        assert form2.as_dict()["is_published"] is False
+
+        # Test with actual data
+        form3 = FormDefinition(name="form3", draft_json={}, published_json={"test": "data"})
+        assert form3.as_dict()["is_published"] is True

--- a/tests/pre_award/form_store_tests/test_routes.py
+++ b/tests/pre_award/form_store_tests/test_routes.py
@@ -112,6 +112,22 @@ class TestFormsView:
             assert response.status_code == 500
             assert response.json == {"error": "Failed to create/update form"}
 
+    def test_post_empty_name(self, flask_test_client):
+        """Test POST /forms with empty or whitespace-only name."""
+        # Test empty string
+        response = flask_test_client.post(
+            "/forms", data=json.dumps({"name": "", "form_json": {"test": "data"}}), content_type="application/json"
+        )
+        assert response.status_code == 400
+        assert response.json["error"] == "Form name cannot be empty"
+
+        # Test whitespace-only string
+        response = flask_test_client.post(
+            "/forms", data=json.dumps({"name": "   ", "form_json": {"test": "data"}}), content_type="application/json"
+        )
+        assert response.status_code == 400
+        assert response.json["error"] == "Form name cannot be empty"
+
 
 class TestFormDraftView:
     """Tests for the /forms/{name}/draft endpoint."""

--- a/tests/pre_award/form_store_tests/test_routes.py
+++ b/tests/pre_award/form_store_tests/test_routes.py
@@ -1,0 +1,256 @@
+"""
+Tests for form_store API routes.
+"""
+
+import json
+from unittest.mock import patch
+
+
+class TestFormsView:
+    """Tests for the /forms endpoint."""
+
+    def test_get_all_forms_empty(self, flask_test_client):
+        """Test GET /forms returns empty list when no forms exist."""
+        with patch("pre_award.form_store.api.routes.get_all_forms", return_value=[]):
+            response = flask_test_client.get("/forms")
+
+            assert response.status_code == 200
+            assert response.json == []
+
+    def test_get_all_forms_with_data(self, flask_test_client, multiple_form_records):
+        """Test GET /forms returns all forms."""
+        response = flask_test_client.get("/forms")
+
+        assert response.status_code == 200
+        assert len(response.json) == 3
+
+        # Check form names are present
+        form_names = [form["name"] for form in response.json]
+        assert "form-1" in form_names
+        assert "form-2" in form_names
+        assert "form-3" in form_names
+
+        # Check structure includes required fields
+        for form in response.json:
+            assert "id" in form
+            assert "name" in form
+            assert "draft_json" in form
+            assert "published_json" in form
+            assert "is_published" in form
+            assert "created_at" in form
+            assert "updated_at" in form
+
+    def test_get_all_forms_error(self, flask_test_client):
+        """Test GET /forms handles database errors."""
+        with patch("pre_award.form_store.api.routes.get_all_forms", side_effect=Exception("Database error")):
+            response = flask_test_client.get("/forms")
+
+            assert response.status_code == 500
+            assert response.json == {"error": "Failed to retrieve forms"}
+
+    def test_post_create_form_success(self, flask_test_client, sample_form_data):
+        """Test POST /forms creates a new form."""
+        response = flask_test_client.post("/forms", data=json.dumps(sample_form_data), content_type="application/json")
+
+        assert response.status_code == 201
+        assert response.json["name"] == sample_form_data["name"]
+        assert response.json["draft_json"] == sample_form_data["form_json"]
+        assert response.json["published_json"] == {}
+        assert response.json["is_published"] is False
+
+    def test_post_update_existing_form(self, flask_test_client, sample_form_record):
+        """Test POST /forms updates existing form."""
+        updated_data = {
+            "name": sample_form_record.name,
+            "form_json": {
+                "pages": [{"path": "/updated-page", "title": "Updated Page", "components": []}],
+                "startPage": "/updated-page",
+            },
+        }
+
+        response = flask_test_client.post("/forms", data=json.dumps(updated_data), content_type="application/json")
+
+        assert response.status_code == 201
+        assert response.json["name"] == updated_data["name"]
+        assert response.json["draft_json"] == updated_data["form_json"]
+
+    def test_post_missing_required_fields(self, flask_test_client):
+        """Test POST /forms with missing required fields."""
+        # Missing form_json
+        response = flask_test_client.post(
+            "/forms", data=json.dumps({"name": "test-form"}), content_type="application/json"
+        )
+
+        assert response.status_code == 400
+        assert "Missing required fields" in response.json["error"]
+
+    def test_post_invalid_json_string(self, flask_test_client):
+        """Test POST /forms with invalid JSON string in form_json."""
+        response = flask_test_client.post(
+            "/forms",
+            data=json.dumps({"name": "test-form", "form_json": "invalid json string"}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "Invalid JSON in form_json field" in response.json["error"]
+
+    def test_post_no_json_body(self, flask_test_client):
+        """Test POST /forms with no JSON body."""
+        response = flask_test_client.post("/forms")
+
+        assert response.status_code == 400
+        assert "Missing required fields" in response.json["error"]
+
+    def test_post_error_handling(self, flask_test_client, sample_form_data):
+        """Test POST /forms handles database errors."""
+        with patch("pre_award.form_store.api.routes.create_or_update_form", side_effect=Exception("Database error")):
+            response = flask_test_client.post(
+                "/forms", data=json.dumps(sample_form_data), content_type="application/json"
+            )
+
+            assert response.status_code == 500
+            assert response.json == {"error": "Failed to create/update form"}
+
+
+class TestFormDraftView:
+    """Tests for the /forms/{name}/draft endpoint."""
+
+    def test_get_draft_success(self, flask_test_client, sample_form_record):
+        """Test GET /forms/{name}/draft returns draft JSON."""
+        response = flask_test_client.get(f"/forms/{sample_form_record.name}/draft")
+
+        assert response.status_code == 200
+        assert response.json == sample_form_record.draft_json
+
+    def test_get_draft_not_found(self, flask_test_client):
+        """Test GET /forms/{name}/draft with non-existent form."""
+        response = flask_test_client.get("/forms/non-existent-form/draft")
+
+        assert response.status_code == 404
+        assert "not found" in response.json["error"]
+
+    def test_get_draft_error(self, flask_test_client):
+        """Test GET /forms/{name}/draft handles database errors."""
+        with patch("pre_award.form_store.api.routes.get_form_by_name", side_effect=Exception("Database error")):
+            response = flask_test_client.get("/forms/test-form/draft")
+
+            assert response.status_code == 500
+            assert response.json == {"error": "Failed to retrieve form draft"}
+
+
+class TestFormPublishedView:
+    """Tests for the /forms/{name}/published endpoint."""
+
+    def test_get_published_success(self, flask_test_client, published_form_record):
+        """Test GET /forms/{name}/published returns published JSON."""
+        response = flask_test_client.get(f"/forms/{published_form_record.name}/published")
+
+        assert response.status_code == 200
+        assert response.json == published_form_record.published_json
+
+    def test_get_published_not_published(self, flask_test_client, sample_form_record):
+        """Test GET /forms/{name}/published with unpublished form."""
+        response = flask_test_client.get(f"/forms/{sample_form_record.name}/published")
+
+        assert response.status_code == 404
+        assert "has not been published" in response.json["error"]
+
+    def test_get_published_not_found(self, flask_test_client):
+        """Test GET /forms/{name}/published with non-existent form."""
+        response = flask_test_client.get("/forms/non-existent-form/published")
+
+        assert response.status_code == 404
+        assert "not found" in response.json["error"]
+
+    def test_get_published_error(self, flask_test_client):
+        """Test GET /forms/{name}/published handles database errors."""
+        with patch("pre_award.form_store.api.routes.get_form_by_name", side_effect=Exception("Database error")):
+            response = flask_test_client.get("/forms/test-form/published")
+
+            assert response.status_code == 500
+            assert response.json == {"error": "Failed to retrieve published form"}
+
+
+class TestFormHashView:
+    """Tests for the /forms/{name}/hash endpoint."""
+
+    def test_get_hash_success(self, flask_test_client, published_form_record):
+        """Test GET /forms/{name}/hash returns hash of published JSON."""
+        response = flask_test_client.get(f"/forms/{published_form_record.name}/hash")
+
+        assert response.status_code == 200
+        assert "hash" in response.json
+        assert isinstance(response.json["hash"], str)
+        assert len(response.json["hash"]) == 32  # MD5 hash length
+
+    def test_get_hash_not_published(self, flask_test_client, sample_form_record):
+        """Test GET /forms/{name}/hash with unpublished form."""
+        response = flask_test_client.get(f"/forms/{sample_form_record.name}/hash")
+
+        assert response.status_code == 404
+        assert "has not been published" in response.json["error"]
+
+    def test_get_hash_not_found(self, flask_test_client):
+        """Test GET /forms/{name}/hash with non-existent form."""
+        response = flask_test_client.get("/forms/non-existent-form/hash")
+
+        assert response.status_code == 404
+        assert "not found" in response.json["error"]
+
+    def test_get_hash_error(self, flask_test_client):
+        """Test GET /forms/{name}/hash handles database errors."""
+        with patch("pre_award.form_store.api.routes.get_form_by_name", side_effect=Exception("Database error")):
+            response = flask_test_client.get("/forms/test-form/hash")
+
+            assert response.status_code == 500
+            assert response.json == {"error": "Failed to retrieve form hash"}
+
+    def test_get_hash_consistency(self, flask_test_client, published_form_record):
+        """Test hash is consistent for same published JSON."""
+        response1 = flask_test_client.get(f"/forms/{published_form_record.name}/hash")
+        response2 = flask_test_client.get(f"/forms/{published_form_record.name}/hash")
+
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+        assert response1.json["hash"] == response2.json["hash"]
+
+
+class TestFormPublishView:
+    """Tests for the /forms/{name}/publish endpoint."""
+
+    def test_publish_form_success(self, flask_test_client, sample_form_record):
+        """Test PUT /forms/{name}/publish publishes a form."""
+        response = flask_test_client.put(f"/forms/{sample_form_record.name}/publish")
+
+        assert response.status_code == 200
+        assert response.json["name"] == sample_form_record.name
+        assert response.json["published_json"] == sample_form_record.draft_json
+        assert response.json["is_published"] is True
+        assert response.json["published_at"] is not None
+
+    def test_publish_form_not_found(self, flask_test_client):
+        """Test PUT /forms/{name}/publish with non-existent form."""
+        response = flask_test_client.put("/forms/non-existent-form/publish")
+
+        assert response.status_code == 404
+        assert "not found" in response.json["error"]
+
+    def test_publish_form_no_draft(self, flask_test_client):
+        """Test PUT /forms/{name}/publish with form having no draft."""
+        with patch(
+            "pre_award.form_store.api.routes.publish_form",
+            side_effect=ValueError('Form "test" has no draft to publish'),
+        ):
+            response = flask_test_client.put("/forms/test-form/publish")
+
+            assert response.status_code == 400
+            assert "has no draft to publish" in response.json["error"]
+
+    def test_publish_form_error(self, flask_test_client):
+        """Test PUT /forms/{name}/publish handles database errors."""
+        with patch("pre_award.form_store.api.routes.publish_form", side_effect=Exception("Database error")):
+            response = flask_test_client.put("/forms/test-form/publish")
+
+            assert response.status_code == 500
+            assert response.json == {"error": "Failed to publish form"}


### PR DESCRIPTION
### 🎫 Ticket

[Pre-Award - Implement forms API](https://mhclgdigital.atlassian.net/browse/FLS-1449)

### 🌍 Background

Forms are going to be stored in a shared location, a new table `form_definition` in the Pre-Award database. We need an API to mediate access to the contents of the table, which will be used by three different services - FAB, Form Designer and Form Runner.

This PR creates that API, including route functions, query functions (data layer) and tests. The new API endpoints are as follows:

- `GET /forms` - Returns a list of all forms as objects including `name`, `draft_json` and `published_json`
- `GET /forms/{name}/draft` - Returns the `draft_json` object
- `GET /forms/{name}/published` - Returns the `published_json` object
- `GET /forms/{name}/hash` - Returns just the hash of the `published_json` for cache validation in Form Runner
- `POST /forms` - Accepts JSON payload containing `name` and `form_json`; creates or updates a form, propagating `form_json` to the `draft_json` field of `form_definition`, and leaving `published_json` empty
- `PUT /forms/{name}/publish` - No request body; publishes a form (copies JSON from `draft_json` column to `published_json`)

### 🚧 Testing

- Tests have been added for both the route functions and the underlying query functions
- The route function tests only need to assert against the API responses rather than against the database, keeping them tightly scoped. This is possible thanks to the fact that the API responds with the output of the `as_dict` method called on the `form_definition` object being operated on
- The query tests assert against the database to give us confidence at the data layer