### PR TITLE
FLS-1455 - Updating COF R2 form names where they duplicate form names from other funding rounds

### DIFF
--- a/pre_award/fund_store/config/fund_loader_config/cof/cof_r2.py
+++ b/pre_award/fund_store/config/fund_loader_config/cof/cof_r2.py
@@ -154,7 +154,7 @@ cof_r2_sections = [
         },
         "tree_path": f"{APPLICATION_BASE_PATH}.1.1",
         "form_name_json": {
-            "en": "organisation-information",
+            "en": "cof-r2-en-organisation-information",
             "cy": "gwybodaeth-am-y-sefydliad",
         },
     },
@@ -334,6 +334,6 @@ cof_r2_sections = [
     {
         "section_name": {"en": "Declarations", "cy": "Datganiadau"},
         "tree_path": f"{APPLICATION_BASE_PATH}.8.1",
-        "form_name_json": {"en": "declarations", "cy": "datganiadau"},
+        "form_name_json": {"en": "cof-r2-en-declarations", "cy": "datganiadau"},
     },
 ]


### PR DESCRIPTION
### 🎫 Ticket

[Migrate forms from fsd_config to form_definition table](https://mhclgdigital.atlassian.net/browse/FLS-1455)

### 🌍 Background

We are migrating forms into a database table with a unique constraint on name, thus duplicate form names are no longer acceptable in the global context. The form names `organisation-information.json` and `declarations.json` duplicate form names from the live funding round DPIF R4, and therefore they gotta go. We'll raise a separate PR simultaneously in Digital Form Builder Adapter to change the actual filenames themselves to match this new config.

Please note that although we discovered that `generic/name-your-application.json` should also be renamed (again due to a name clash with a DPIF R4 form), there was no reference to that file in the Pre-Award codebase.

### 🚶 Next steps

- Raise a Digital Form Builder Adapter PR to deploy simultaneously, changing the filenames of these forms to sync up (no need for anything more complicated than close deployment given we are dealing with an inactive funding round)
- On local machine, authenticate into each AWS environment in turn and run the script `copilot svc exec --name fsd-pre-award --command "launcher python -m pre_award.fund_store.scripts.fund_round_loaders.load_cof_r2"`