### PR TITLE
Updating page titles to assist screen reader users

### DIFF
--- a/apply/templates/apply/landing.html
+++ b/apply/templates/apply/landing.html
@@ -19,7 +19,7 @@
     {% else %}
         {% trans fund_title=fund.title%}Start or continue an application for {{ fund_title }}{%endtrans%}
     {% endif %}
-  {% endif %}
+  {% endif %} - GOV.UK
 {% endblock pageTitle %}
 
 

--- a/pre_award/apply/templates/apply/base.html
+++ b/pre_award/apply/templates/apply/base.html
@@ -5,7 +5,7 @@
 {% set assetPath = url_for('static', filename='/apply').rstrip('/') %}
 {% set title = gettext("Access Funding") if is_error else service_title or get_service_title() %}
 
-{% block pageTitle %}{{ [pageHeading, title]|join(' - ') if pageHeading else title }}{% endblock pageTitle %}
+{% block pageTitle %}{{ [pageHeading, title]|join(' - ') if pageHeading else title }} - GOV.UK{% endblock pageTitle %}
 
 {% block head %}
     <link rel="stylesheet" href="{{ url_for('static', filename='fs/govuk-frontend-5.6.0.min.css' ) }}"> </link>


### PR DESCRIPTION
**Ticket:**
https://mhclgdigital.atlassian.net/browse/FLS-1415

**Description:**
This PR is one of two that update page titles to improve accessibility for screen reader users.
Link to related digital-form-builder-adapter PR:
https://github.com/communitiesuk/digital-form-builder-adapter/pull/222

As outlined in the ticket comments, page titles should follow this format:
[H1] - [Application name (our service name)] - GOV.UK

This isn’t always exact, as there are cases where a page doesn’t have a separate section name, or the `<h1> `element itself is the application name.

**How to test:**
Check out both this branch and the digital-form-builder-adapter branch.
Go to the task list page of any fund round.
Click on one of the links in the task list - the page title should match the format above.
Test other pages as well.

