### PR TITLE
FLS-1452 - Change response from published form endpoint from being straight-up published_json to object containing hash and published_json

### DIFF
--- a/tests/pre_award/form_store_tests/test_routes.py
+++ b/tests/pre_award/form_store_tests/test_routes.py
@@ -163,7 +163,11 @@ class TestFormPublishedView:
         response = flask_test_client.get(f"/forms/{published_form_record.name}/published")
 
         assert response.status_code == 200
-        assert response.json == published_form_record.published_json
+        assert "configuration" in response.json
+        assert "hash" in response.json
+        assert response.json["configuration"] == published_form_record.published_json
+        assert isinstance(response.json["hash"], str)
+        assert len(response.json["hash"]) == 32  # MD5 hash length
 
     def test_get_published_not_published(self, flask_test_client, sample_form_record):
         """Test GET /forms/{name}/published with unpublished form."""


### PR DESCRIPTION
### 🎫 Ticket

[Form Runner - Retrieve forms from Pre-Award API](https://mhclgdigital.atlassian.net/browse/FLS-1452)

### ♻️ Background

This saves the Form Runner having to either (A) make a separate request for form hash, or (B) implement its own hashing which would be tightly coupled to the Pre-Award implementation and therefore flimsy.

### 📓 Notes

The Pre-Award API is not currently being used by another service in production so we don't need to worry about the usual concerns you might have when updating an API interface.