### PR TITLE
FLS-1450 - Remove JSON from GET /forms endpoint

### DIFF
--- a/pre_award/form_store/api/routes.py
+++ b/pre_award/form_store/api/routes.py
@@ -38,7 +38,7 @@ class FormsView(MethodView):
         """GET /forms - Returns a list of all forms"""
         try:
             forms = get_all_forms()
-            return [form.as_dict() for form in forms], 200
+            return [form.as_dict(include_json=False) for form in forms], 200
         except Exception as e:
             current_app.logger.error("Error retrieving forms: %s", str(e))
             return {"error": "Failed to retrieve forms"}, 500

--- a/pre_award/form_store/db/models/form_definition.py
+++ b/pre_award/form_store/db/models/form_definition.py
@@ -5,6 +5,7 @@ This table stores form configurations for both draft and published states.
 """
 
 import uuid
+from typing import Any
 
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import Column, DateTime, Text
@@ -36,15 +37,21 @@ class FormDefinition(BaseModel):
     draft_json = Column(JSONB, nullable=False)
     published_json = Column(JSONB, nullable=False, default="{}")
 
-    def as_dict(self):
-        """Convert the FormDefinition to a dictionary representation."""
-        return {
+    def as_dict(self, include_json: bool = True) -> dict[str, Any]:
+        """
+        Convert the FormDefinition to a dictionary representation. The argument include_json is included so that the
+        draft_json and published_json attributes can be optionally excluded, to reduce the size of data objects being
+        sent over the network.
+        """
+        ret = {
             "id": str(self.id),
             "name": self.name,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
             "published_at": self.published_at.isoformat() if self.published_at else None,
-            "draft_json": self.draft_json,
-            "published_json": self.published_json,
             "is_published": bool(self.published_json and self.published_json != {}),
         }
+        if include_json:
+            ret["draft_json"] = self.draft_json
+            ret["published_json"] = self.published_json
+        return ret

--- a/tests/pre_award/form_store_tests/test_routes.py
+++ b/tests/pre_award/form_store_tests/test_routes.py
@@ -34,8 +34,8 @@ class TestFormsView:
         for form in response.json:
             assert "id" in form
             assert "name" in form
-            assert "draft_json" in form
-            assert "published_json" in form
+            assert "draft_json" not in form
+            assert "published_json" not in form
             assert "is_published" in form
             assert "created_at" in form
             assert "updated_at" in form


### PR DESCRIPTION
### 🎫 Ticket

[Form Designer - Use Pre-Award API for retrieving and publishing forms](https://mhclgdigital.atlassian.net/browse/FLS-1450)

### ♻️ Changes

Previously we returned a list of forms along with all of their attributes from the `GET /forms` endpoint, including `draft_json` and `published_json`, which can be very large. The endpoint is only hit by the Form Designer and the `draft_json` and `published_json` attributes aren't accessed on the requester side, plus the amount of data being sent over the network meant the API call took an age to complete. This change removes those attributes from the response.

What's the link to the ticket? The performance implications of sending everything back in the response were only discovered during implementation / review of the Form Designer changes.

### 🚧 Testing

A test already existed for this endpoint; it has been updated in this PR.