### PR TITLE
Add page title to 'Contact us' page

### DIFF
--- a/apply/templates/apply/contact-us.html
+++ b/apply/templates/apply/contact-us.html
@@ -4,6 +4,9 @@
 
 
 {% set pageHeading %}{% trans %}Get help with your application{% endtrans %}{% endset %}
+
+{% block pageTitle %}{{ pageHeading }} - {{ get_page_title() }}{% endblock pageTitle %}
+
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
**Ticket:**
https://mhclgdigital.atlassian.net/browse/FLS-1516

**Description:**
I’ve refactored the _app.py_ file to provide both `get_service_title` (for the core service name) and `get_page_title` (which appends " - GOV.UK") as template functions. This makes the template logic cleaner: we can still use `get_service_title` wherever needed, and we can avoid manual string concatenation to add “GOV.UK” in templates by using the new `get_page_title` function.

This PR only adds a page title to the "Contact us" page.
For all other pages, I will create a separate ticket and liaise with the content designers about the required page titles.

**Screenshot:**
<img width="1735" height="599" alt="Screenshot 2025-09-26 at 13 59 55" src="https://github.com/user-attachments/assets/88d22dd6-7d11-4818-befc-27b30c9e777c" />
