### PR TITLE
Validate SSO return_path parameter

### DIFF
--- a/pre_award/authenticator/api/sso/routes.py
+++ b/pre_award/authenticator/api/sso/routes.py
@@ -41,6 +41,10 @@ class SsoBase:
         parsed_uri = urlparse(url)
         return f"{parsed_uri.scheme}://{parsed_uri.netloc}"
 
+    @staticmethod
+    def _is_safe_return_path(path: str) -> bool:
+        return path.startswith("/") and not path.startswith("//") and "://" not in path and "@" not in path
+
     def build_auth_code_flow(self, authority=None, scopes=None):
         return self._build_msal_app(authority=authority).initiate_auth_code_flow(
             scopes or [], redirect_uri=Config.AZURE_AD_REDIRECT_URI
@@ -95,7 +99,8 @@ class SsoLoginView(SsoBase, MethodView):
 
         if return_app := request.args.get("return_app"):
             session["return_app"] = return_app
-            session["return_path"] = request.args.get("return_path")
+            return_path = request.args.get("return_path")
+            session["return_path"] = return_path if return_path and self._is_safe_return_path(return_path) else None
             current_app.logger.debug(
                 "Setting return app to %(return_app)s for this session", dict(return_app=return_app)
             )

--- a/tests/pre_award/authenticator_tests/test_sso.py
+++ b/tests/pre_award/authenticator_tests/test_sso.py
@@ -38,6 +38,28 @@ def test_sso_login_sets_return_app_in_session(authenticator_test_client):
     assert session.get("return_app") == return_app
 
 
+@pytest.mark.parametrize(
+    "malicious_path",
+    [
+        "@evil.com",
+        "//evil.com",
+        "https://evil.com",
+        "@evil.com/phishing",
+        "//evil.com/phishing",
+    ],
+)
+def test_sso_login_rejects_unsafe_return_path(authenticator_test_client, malicious_path):
+    endpoint = f"/sso/login?return_app=post-award-frontend&return_path={malicious_path}"
+    authenticator_test_client.get(endpoint)
+    assert session.get("return_path") is None
+
+
+def test_sso_login_allows_safe_return_path(authenticator_test_client):
+    endpoint = "/sso/login?return_app=post-award-frontend&return_path=/dashboard/overview"
+    authenticator_test_client.get(endpoint)
+    assert session.get("return_path") == "/dashboard/overview"
+
+
 def test_sso_login_sets_return_path_in_session(authenticator_test_client):
     return_app = "post-award-frontend"
 


### PR DESCRIPTION
### Summary

- Add `_is_safe_return_path` validation to `SsoBase` that rejects paths containing `@`, `://`, or protocol-relative `//` prefixes
- Apply validation in `SsoLoginView.get` before storing `return_path` in the session - unsafe values are discarded as `None`, which the downstream `SsoGetTokenView` already handles gracefully via its `if return_path :=` check
- Add parameterized tests covering malicious paths (`@evil.com`, `//evil.com`, `https://evil.com`) and a valid path (`/dashboard/overview`)
- Fixes an open redirect where a crafted `return_path=@evil.com` would produce a redirect URL with `evil.com` as the hostname due to URL userinfo parsing
- In practice modern browsers block or warn on the `@` trick in HTTPS URLs and the session cookie wouldn't follow the redirect, so real-world exploitability is low - but this is a straightforward defence-in-depth fix
