### PR TITLE
Let any assess role satisfy the assess blueprint entry gate

### DIFF
--- a/pre_award/assess/authentication/auth.py
+++ b/pre_award/assess/authentication/auth.py
@@ -1,40 +1,40 @@
 from flask import g, redirect, request
 from fsd_utils.authentication.models import User
 
+from pre_award.assess.authentication.validation import ASSESS_ROLES
 from pre_award.assess.services.data_services import get_funds
 from pre_award.assess.shared.helpers import get_ttl_hash
 from pre_award.config import Config
 
 
-def auth_protect(minimum_roles_required: list, unprotected_routes: list):
+def auth_protect(unprotected_routes: list):
     """
-    Checks the authentication and authorisation attributes of the
-    user accessing the service and allows them to access the requested
-    resource if authorised, or redirect them to login (or a permissions
-    error message) if not authenticated/authorised.
+    Entry gate for the assess blueprint.
 
-    The function also incorporates support for bypassing authorisation
-    via setting of a DEBUG_USER_ROLE env var which will mimic the effect
-    of a user with that role (only used when FLASK_ENV is "development").
+    A user is granted access if they hold any role recognised by the assess
+    module (see ASSESS_ROLES) on any fund. Fine-grained role requirements for
+    specific actions are enforced by the per-route decorators in
+    ``pre_award.assess.authentication.validation``; the gate's only job is to
+    redirect users with zero assess access away from the blueprint.
+
+    Supports bypassing authorisation via ``DEBUG_USER_ON`` in development.
 
     Args:
-        minimum_roles_required: List[str]
-            - a list of minimum roles a user must at least one of to be authorised
         unprotected_routes: List[str]
-            - a list of routes e.g. ["/"]
-                that can be accessed without authentication
+            - a list of routes e.g. ["/"] that can be accessed without
+              authentication.
 
     Returns:
-        redirect (302) or None if authorised
-
+        redirect (302) or None if authorised.
     """
-    # expand roles to include all fund short names as a prefix, e.g. "COMMENTER" becomes "COF_COMMENTER"
-    minimum_roles_required = [
+    # Every {fund}_{role} string that counts as "has assess access", matching
+    # how tokens are emitted at sign-in (upper-cased, fund-prefixed).
+    permitted_roles = [
         f"{fund.short_name}_{role}".upper()
         for fund in get_funds(
             get_ttl_hash(seconds=Config.LRU_CACHE_TIME)
         )  # expensive call, so cache it & refresh every 5 minutes
-        for role in minimum_roles_required
+        for role in ASSESS_ROLES
     ]
 
     if not g.is_authenticated and Config.FLASK_ENV == "development" and Config.DEBUG_USER_ON:
@@ -46,17 +46,12 @@ def auth_protect(minimum_roles_required: list, unprotected_routes: list):
             return redirect(Config.DASHBOARD_ROUTE)
 
     elif g.is_authenticated:
-        # Ensure that authenticated users have
-        # all minimum required roles
-        if not g.user.roles or not any(  # any of the minimum roles are present
-            role_required in g.user.roles for role_required in minimum_roles_required
-        ):
+        if not g.user.roles or not any(role in g.user.roles for role in permitted_roles):
             return redirect(
-                Config.AUTHENTICATOR_HOST + "/service/user" + "?roles_required=" + "|".join(minimum_roles_required)
+                Config.AUTHENTICATOR_HOST + "/service/user" + "?roles_required=" + "|".join(permitted_roles)
             )
         elif request.path in ["", "/"]:
             return redirect(Config.DASHBOARD_ROUTE)
     elif request.path not in unprotected_routes and not request.path.startswith("/static/"):  # noqa
-        # Redirect unauthenticated users to
-        # login on the home page
+        # Redirect unauthenticated users to login on the home page
         return redirect("/")

--- a/pre_award/assess/authentication/validation.py
+++ b/pre_award/assess/authentication/validation.py
@@ -20,7 +20,7 @@ _UK_COUNTRIES: list[str] = [
     "NORTHERNIRELAND",  # normalise locations
 ]
 
-_ROLES: list[str] = [
+ASSESS_ROLES: list[str] = [
     "LEAD_ASSESSOR",
     "ASSESSOR",
     "COMMENTER",
@@ -36,7 +36,7 @@ _HAS_DEVOLVED_AUTHORITY_VALIDATION: Mapping[str, bool] = defaultdict(
 
 
 def _get_access_roles(fund_short_name: str) -> frozenset[str]:
-    return frozenset(f"{fund_short_name}_{role}".casefold() for role in _ROLES)
+    return frozenset(f"{fund_short_name}_{role}".casefold() for role in ASSESS_ROLES)
 
 
 def _normalise_country(country: str) -> str:

--- a/pre_award/assess/blueprint_middleware.py
+++ b/pre_award/assess/blueprint_middleware.py
@@ -81,6 +81,5 @@ def assess_ensure_minimum_required_roles():
     check_auth()
 
     return auth_protect(
-        minimum_roles_required=["COMMENTER"],
         unprotected_routes=["/", "/healthcheck", "/cookie_policy"],
     )

--- a/pre_award/common/error_routes.py
+++ b/pre_award/common/error_routes.py
@@ -23,7 +23,6 @@ def not_found(error):
         check_auth()
 
         return auth_protect(
-            minimum_roles_required=["COMMENTER"],
             unprotected_routes=["/", "/healthcheck", "/cookie_policy"],
         ) or redirect("/")
 

--- a/pre_award/frontend/README.md
+++ b/pre_award/frontend/README.md
@@ -178,7 +178,7 @@ The role types are created in Azure AD, and assigned to groups. Users can be mad
 ### Who needs what roles?
 *Applicants* do not require any roles at all currently nor do they need to use Azure AD to sign in (they can just use a magic link).
 
-Those using the *Assessment* frontend must be registered on the DLUHC FSD Azure AD tenant and also must have at least the role of "COMMENTER" (i.e. be in the "Commenters" group on Azure AD).
+Those using the *Assessment* frontend must be registered on the DLUHC FSD Azure AD tenant and must hold at least one assess role (COMMENTER, ASSESSOR, or LEAD_ASSESSOR) on at least one fund. Specific actions within the service (e.g. scoring, flag resolution) may require a higher role on the fund in question; those checks are enforced per-route.
 
 ### Permission denied error messages
 If an applicant user tried to access the assessment frontend (for assessment processes) they would be redirected to the [`/service/user`](https://github.com/communitiesuk/funding-service-design-authenticator/blob/453d03123f681a33ed836b7d370bf3d974c6a030/frontend/user/routes.py#L18) endpoint with a `?roles_required=COMMENTER` query string argument.

--- a/tests/pre_award/assess_tests/conftest.py
+++ b/tests/pre_award/assess_tests/conftest.py
@@ -35,6 +35,17 @@ test_lead_assessor_claims = {
     "roles": ["TF_LEAD_ASSESSOR", "TF_ASSESSOR", "TF_COMMENTER", "UF_LEAD_ASSESSOR", "UF_ASSESSOR", "UF_COMMENTER"],
 }
 
+# A user who only has LEAD_ASSESSOR roles (no ASSESSOR or COMMENTER). This is
+# what happens when Azure AD provisioning grants the lead assessor group only.
+# They should still get past the entry gate: any recognised assess role on any
+# fund is enough, regardless of which role it is.
+test_lead_assessor_only_claims = {
+    "accountId": "lead-only",
+    "email": "lead-only@test.com",
+    "fullName": "Test User",
+    "roles": ["TF_LEAD_ASSESSOR", "UF_LEAD_ASSESSOR"],
+}
+
 test_assessor_claims = {
     "accountId": "assessor",
     "email": "assessor@test.com",

--- a/tests/pre_award/assess_tests/test_authorisation.py
+++ b/tests/pre_award/assess_tests/test_authorisation.py
@@ -9,6 +9,7 @@ from tests.pre_award.assess_tests.conftest import (
     test_assessor_claims,
     test_commenter_claims,
     test_lead_assessor_claims,
+    test_lead_assessor_only_claims,
     test_roleless_user_claims,
 )
 
@@ -95,7 +96,12 @@ class TestAuthorisation:
         assert response.status_code == 302
         assert response.location == (
             "https://authenticator.communities.gov.localhost:4004/service/user?"
-            "roles_required=TF_COMMENTER%7CNSTF_COMMENTER%7CCYP_COMMENTER%7CCOF_COMMENTER%7CDPIF_COMMENTER"
+            "roles_required="
+            "TF_LEAD_ASSESSOR%7CTF_ASSESSOR%7CTF_COMMENTER"
+            "%7CNSTF_LEAD_ASSESSOR%7CNSTF_ASSESSOR%7CNSTF_COMMENTER"
+            "%7CCYP_LEAD_ASSESSOR%7CCYP_ASSESSOR%7CCYP_COMMENTER"
+            "%7CCOF_LEAD_ASSESSOR%7CCOF_ASSESSOR%7CCOF_COMMENTER"
+            "%7CDPIF_LEAD_ASSESSOR%7CDPIF_ASSESSOR%7CDPIF_COMMENTER"
         )
 
     @pytest.mark.mock_parameters(
@@ -114,6 +120,9 @@ class TestAuthorisation:
             (test_commenter_claims),
             (test_assessor_claims),
             (test_lead_assessor_claims),
+            # A user provisioned with only LEAD_ASSESSOR (no COMMENTER) should
+            # still get past the gate: any recognised assess role is enough.
+            (test_lead_assessor_only_claims),
         ],
     )
     def test_authorised_roles_redirected_to_dashboard(


### PR DESCRIPTION
## What's the problem?

The assessment service sits behind a gate that redirects anyone without a "Commenter" role on a fund away from every assess page, including the landing dashboard. So a user provisioned in Azure AD as a Lead Assessor — and nothing else — couldn't even see the dashboard, despite Lead Assessor being a strictly more privileged role than Commenter. An internal user hit exactly this and had to be granted a Commenter role as a workaround.

The reason it hadn't bitten before is operational: in practice, users are usually added to multiple AD groups (or groups are nested) so that a Lead Assessor also ends up with a Commenter role somewhere. The moment that assumption doesn't hold — a new fund, a one-off provisioning, a different AD tenant configuration — people get locked out of a service they have permission to use.

## What does this PR do?

It relaxes the gate. Instead of requiring a Commenter role specifically, the gate now lets in anyone who holds any recognised assess role (Commenter, Assessor, or Lead Assessor) on any fund. Users with no assess roles at all are still redirected to the "you don't have access" page exactly as before.

## How the assess permission model is layered

There are two layers, and this PR only touches the first:

1. **Entry gate** (`auth_protect`, called from the assess blueprint's `before_request` and from the 404 handler for the assess host — just these two call sites). Binary "do you have any assess access at all?" check.
2. **Per-route decorators** (`check_access_application_id`, `check_access_fund_short_name_round_sn`, `check_access_fund_id_round_id` in `validation.py`). These resolve the fund from the URL, check the user has access to that specific fund via `has_access_to_fund` (which already accepts any of the three roles), and then delegate to `fsd_utils.login_required(roles_required=...)` to enforce the specific role needed for the action — e.g. scoring requires Lead Assessor or Assessor, flag resolution requires Lead Assessor, tagging requires Assessor.

`auth_protect` has no business knowing about specific roles — that's what the per-route decorators are for. This PR makes the gate reflect that split.

## Why is this safe?

The per-route decorators are unchanged. A Lead Assessor who now gets through the gate will be accepted by `has_access_to_fund` on exactly the same basis a Commenter would have been, and the action-specific role checks (Lead Assessor to resolve a flag, Assessor to tag, etc.) run as normal. Anyone who lacks the right role for a specific action will still get a 403 at the route itself.

I also checked every production code path for Commenter-specific logic. The only reference outside the gate is in `round_summary.py`, and it goes the other way — it hides pre-assessment rounds from Commenters, which Lead Assessors pass through without issue. The `is_commenter` property on `AssessmentAccessController` exists but is never referenced.

## Why is this a good idea?

- Fixes a real user-facing bug where people with legitimately higher permissions were being denied access.
- Removes a latent footgun: any future AD provisioning that grants Lead Assessor without also bundling Commenter will no longer silently lock the user out.
- Aligns the gate with `has_access_to_fund`, so there's one shared definition of "has assess access" rather than two subtly different ones.
- Doesn't expand anyone's permissions. Every existing user sees exactly what they saw before; only users who were being incorrectly bounced at the front door are affected.

## Test plan

- [ ] Automated tests pass, including a new case covering a user with only a Lead Assessor role
- [ ] In a deployed environment, a user with only `{fund}_LEAD_ASSESSOR` (no Commenter anywhere) can reach the dashboard
- [ ] Commenter-only and Assessor-only users still reach the dashboard unchanged
- [ ] A user with no assess roles is still redirected to the "no access" page
- [ ] Spot-check an action gated by a specific role (e.g. flag resolution, which requires Lead Assessor) still denies users who lack that role
