### PR TITLE
Retry connection errors in Assess get_data to fix intermittent Sentry noise on fund dashboard

### DIFF
--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -31,32 +31,33 @@ from pre_award.db import db
 from services.notify import get_notification_service
 
 
-def get_data(endpoint: str, payload: Dict = None):
+def _get_with_retry(endpoint: str, payload: Dict = None):
     # Retry transient connection errors (e.g. RemoteDisconnected from the stale
     # upstream sockets that Envoy occasionally reuses between Service Connect and
     # gunicorn's 2s keepalive). GET is idempotent so retrying is safe.
+    for attempt in range(3):
+        try:
+            if payload:
+                current_app.logger.info(
+                    "Fetching data from '%(endpoint)s', with payload: %(payload)s.",
+                    dict(endpoint=endpoint, payload=payload),
+                )
+                return requests.get(endpoint, params=payload)
+            current_app.logger.info("Fetching data from '%(endpoint)s'", dict(endpoint=endpoint))
+            return requests.get(endpoint)
+        except requests.exceptions.ConnectionError:
+            if attempt == 2:
+                raise
+
+
+def get_data(endpoint: str, payload: Dict = None):
     try:
-        for attempt in range(3):
-            try:
-                if payload:
-                    current_app.logger.info(
-                        "Fetching data from '%(endpoint)s', with payload: %(payload)s.",
-                        dict(endpoint=endpoint, payload=payload),
-                    )
-                    response = requests.get(endpoint, params=payload)
-                else:
-                    current_app.logger.info("Fetching data from '%(endpoint)s'", dict(endpoint=endpoint))
-                    response = requests.get(endpoint)
-                break
-            except requests.exceptions.ConnectionError:
-                if attempt == 2:
-                    raise
+        response = _get_with_retry(endpoint, payload)
         if response.status_code == 200:
             if "application/json" == response.headers["Content-Type"]:
                 return response.json()
-            else:
-                return response.content
-        elif response.status_code in [204, 404]:
+            return response.content
+        if response.status_code in [204, 404]:
             current_app.logger.warning(
                 "Request successful but no resources returned for endpoint '%(endpoint)s'", dict(endpoint=endpoint)
             )

--- a/pre_award/assess/services/data_services.py
+++ b/pre_award/assess/services/data_services.py
@@ -32,16 +32,25 @@ from services.notify import get_notification_service
 
 
 def get_data(endpoint: str, payload: Dict = None):
+    # Retry transient connection errors (e.g. RemoteDisconnected from the stale
+    # upstream sockets that Envoy occasionally reuses between Service Connect and
+    # gunicorn's 2s keepalive). GET is idempotent so retrying is safe.
     try:
-        if payload:
-            current_app.logger.info(
-                "Fetching data from '%(endpoint)s', with payload: %(payload)s.",
-                dict(endpoint=endpoint, payload=payload),
-            )
-            response = requests.get(endpoint, payload)
-        else:
-            current_app.logger.info("Fetching data from '%(endpoint)s'", dict(endpoint=endpoint))
-            response = requests.get(endpoint)
+        for attempt in range(3):
+            try:
+                if payload:
+                    current_app.logger.info(
+                        "Fetching data from '%(endpoint)s', with payload: %(payload)s.",
+                        dict(endpoint=endpoint, payload=payload),
+                    )
+                    response = requests.get(endpoint, params=payload)
+                else:
+                    current_app.logger.info("Fetching data from '%(endpoint)s'", dict(endpoint=endpoint))
+                    response = requests.get(endpoint)
+                break
+            except requests.exceptions.ConnectionError:
+                if attempt == 2:
+                    raise
         if response.status_code == 200:
             if "application/json" == response.headers["Content-Type"]:
                 return response.json()

--- a/tests/pre_award/assess_tests/test_data_operations.py
+++ b/tests/pre_award/assess_tests/test_data_operations.py
@@ -1,10 +1,14 @@
+from unittest.mock import Mock
+
 import pytest
+import requests
 from flask import Flask
 
 from pre_award.assess.services.data_services import (
     get_all_fund_short_codes,
     get_application_overviews,
     get_comments,
+    get_data,
     get_fund,
     get_round,
 )
@@ -126,3 +130,68 @@ def test_get_all_fund_short_codes(mock_get_all_funds_response, exp_result, mocke
     )
     result = get_all_fund_short_codes()
     assert result == exp_result
+
+
+_ENDPOINT = "http://example.test/x"
+
+
+def _json_response(payload, status=200):
+    response = Mock()
+    response.status_code = status
+    response.headers = {"Content-Type": "application/json"}
+    response.json.return_value = payload
+    return response
+
+
+class TestGetDataRetry:
+    test_app = Flask("app")
+
+    def test_returns_json_on_first_success(self, mocker):
+        get_mock = mocker.patch(
+            "pre_award.assess.services.data_services.requests.get",
+            return_value=_json_response({"ok": True}),
+        )
+        with self.test_app.app_context():
+            assert get_data(_ENDPOINT) == {"ok": True}
+        assert get_mock.call_count == 1
+
+    @pytest.mark.parametrize("failures_before_success", [1, 2])
+    def test_retries_connection_error_until_success(self, mocker, failures_before_success):
+        get_mock = mocker.patch(
+            "pre_award.assess.services.data_services.requests.get",
+            side_effect=[requests.exceptions.ConnectionError("stale")] * failures_before_success
+            + [_json_response({"ok": True})],
+        )
+        with self.test_app.app_context():
+            assert get_data(_ENDPOINT) == {"ok": True}
+        assert get_mock.call_count == failures_before_success + 1
+
+    def test_returns_none_after_three_connection_errors(self, mocker):
+        get_mock = mocker.patch(
+            "pre_award.assess.services.data_services.requests.get",
+            side_effect=requests.exceptions.ConnectionError("always"),
+        )
+        with self.test_app.app_context():
+            assert get_data(_ENDPOINT) is None
+        assert get_mock.call_count == 3
+
+    def test_does_not_retry_other_request_exceptions(self, mocker):
+        get_mock = mocker.patch(
+            "pre_award.assess.services.data_services.requests.get",
+            side_effect=requests.exceptions.ReadTimeout("read timed out"),
+        )
+        with self.test_app.app_context():
+            assert get_data(_ENDPOINT) is None
+        assert get_mock.call_count == 1
+
+    def test_payload_is_preserved_across_retry(self, mocker):
+        get_mock = mocker.patch(
+            "pre_award.assess.services.data_services.requests.get",
+            side_effect=[
+                requests.exceptions.ConnectionError("stale"),
+                _json_response({"ok": True}),
+            ],
+        )
+        with self.test_app.app_context():
+            assert get_data(_ENDPOINT, {"a": "b"}) == {"ok": True}
+        assert get_mock.call_args_list[0] == get_mock.call_args_list[1]

--- a/tests/pre_award/assess_tests/test_data_operations.py
+++ b/tests/pre_award/assess_tests/test_data_operations.py
@@ -132,7 +132,7 @@ def test_get_all_fund_short_codes(mock_get_all_funds_response, exp_result, mocke
     assert result == exp_result
 
 
-_ENDPOINT = "http://example.test/x"
+_ENDPOINT = "https://example.test/x"
 
 
 def _json_response(payload, status=200):
@@ -144,7 +144,7 @@ def _json_response(payload, status=200):
 
 
 class TestGetDataRetry:
-    test_app = Flask("app")
+    test_app = TestDataOperations.test_app
 
     def test_returns_json_on_first_success(self, mocker):
         get_mock = mocker.patch(


### PR DESCRIPTION
### Change description

The Assess fund dashboard occasionally logs `RemoteDisconnected` / `ConnectionError` to Sentry (83 events / 17 users over the last 16 days) when loading data from internal endpoints like `/account/accounts/fund/<code>`. See https://communitiesuk.sentry.io/issues/108884229/?alert_rule_id=463249&alert_type=issue&notification_uuid=6e4f1083-6c33-48d9-ba36-4d1ac840aa68&project=4511038204674128&referrer=slack

The cause is a keep-alive mismatch on the internal self-call hop: Envoy (Service Connect) pools upstream connections for up to an hour, but gunicorn's keep-alive is 2 seconds, so Envoy occasionally reuses a socket that gunicorn has already closed. The request never reaches the server (confirmed - no matching access log for failing trace IDs), and `get_data` swallows the error and returns `None`, leaving the dashboard rendered with blank "Assigned to" data. Users don't see an error page, just missing data that a refresh fixes.

This adds a small retry loop (3 attempts) around the `requests.get` calls in `get_data`, catching `ConnectionError` only. GETs are idempotent so this is safe, and retrying picks up a fresh connection from the pool. Deliberately kept minimal given the service is being sunsetted.