### PR TITLE
Bug fix: show who created the change request, not the last user to interact with it

### DIFF
--- a/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
+++ b/pre_award/assess/assessments/templates/assessments/uncompeted_sub_criteria.html
@@ -55,7 +55,7 @@
 {% if change_requests and not score %}
     {% for change_request in change_requests %}
         <h2 class="govuk-heading-s change-title">Change requested</h2>
-        {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], score) }}
+        {{ assessment_change_request(change_request, questions, accounts_list[change_request.raised_by_user_id], score) }}
     {% endfor %}
 {% endif %}
 
@@ -64,7 +64,7 @@
         {% for change_request in change_requests %}
             {% if change_request.latest_status.name == "RAISED" or change_request.latest_status.name == "RESOLVED" %}
                 <h2 class="govuk-heading-s change-title">Change requested</h2>
-                {{ assessment_change_request(change_request, questions, accounts_list[change_request.latest_user_id], score) }}
+                {{ assessment_change_request(change_request, questions, accounts_list[change_request.raised_by_user_id], score) }}
             {% endif %}
         {% endfor %}
     {% endif %}

--- a/pre_award/assess/services/models/flag.py
+++ b/pre_award/assess/services/models/flag.py
@@ -32,6 +32,7 @@ class Flag:
             self.updates = sorted(self.updates, key=lambda x: x["date_created"])
 
         self.latest_user_id = self.updates[-1]["user_id"] if self.updates else ""
+        self.raised_by_user_id = self.updates[0]["user_id"] if self.updates else ""
         self.date_created = self.updates[0]["date_created"] if self.updates else ""
         self.sections_to_flag = [] if not self.sections_to_flag else self.sections_to_flag
 

--- a/tests/pre_award/assess_tests/test_routes.py
+++ b/tests/pre_award/assess_tests/test_routes.py
@@ -1435,6 +1435,120 @@ class TestRoutes:
             in soup.findAll("p", class_="govuk-body")[4].text
         )
 
+    @pytest.mark.application_id("uncompeted_app")
+    @pytest.mark.fund_id("UNCOMPETED_FUND")
+    @pytest.mark.sub_criteria_id("test_uncomp_sub_criteria_id")
+    def test_change_request_shows_original_requester_when_only_raised(
+        self,
+        request,
+        mocker,
+        assess_test_client,
+        mock_get_sub_criteria,
+        mock_get_fund,
+        mock_get_funds,
+        mock_get_round,
+        mock_get_application_metadata,
+        mock_get_sub_criteria_theme,
+        mock_get_assessor_tasklist_state,
+        mock_get_bulk_accounts,
+        mock_uncompeted_pfn_fund,
+    ):
+        change_request_dict = {
+            "application_id": "uncompeted_app",
+            "id": "cr-1",
+            "latest_status": "RAISED",
+            "latest_allocation": None,
+            "sections_to_flag": ["test_uncomp_sub_criteria_id"],
+            "field_ids": ["JCACTy"],
+            "is_change_request": True,
+            "updates": [
+                {
+                    "id": "u1",
+                    "user_id": "assessor",
+                    "date_created": "2024-02-20T10:00:00",
+                    "justification": "Please clarify",
+                    "status": "RAISED",
+                    "allocation": None,
+                },
+            ],
+        }
+        mocker.patch(
+            "pre_award.assess.assessments.routes.get_change_requests_for_application",
+            return_value=[mock.Mock()],
+        )
+        mock_schema = mocker.patch("pre_award.assess.assessments.routes.AssessmentFlagSchema")
+        mock_schema.return_value.dump.return_value = [change_request_dict]
+
+        soup = get_subcriteria_soup(request, assess_test_client)
+        change_request_box = soup.select_one(".change-request-box")
+        assert change_request_box is not None, "Change request box should be rendered"
+        text = change_request_box.get_text()
+        assert "This change was requested by assessor," in text
+        assert "Assessor User" in text
+        assert "assessor@test.com" in text
+
+    @pytest.mark.application_id("uncompeted_app")
+    @pytest.mark.fund_id("UNCOMPETED_FUND")
+    @pytest.mark.sub_criteria_id("test_uncomp_sub_criteria_id")
+    def test_change_request_shows_original_requester_after_applicant_response(
+        self,
+        request,
+        mocker,
+        assess_test_client,
+        mock_get_sub_criteria,
+        mock_get_fund,
+        mock_get_funds,
+        mock_get_round,
+        mock_get_application_metadata,
+        mock_get_sub_criteria_theme,
+        mock_get_assessor_tasklist_state,
+        mock_get_bulk_accounts,
+        mock_uncompeted_pfn_fund,
+    ):
+        change_request_dict = {
+            "application_id": "uncompeted_app",
+            "id": "cr-1",
+            "latest_status": "RAISED",
+            "latest_allocation": None,
+            "sections_to_flag": ["test_uncomp_sub_criteria_id"],
+            "field_ids": ["JCACTy"],
+            "is_change_request": True,
+            "updates": [
+                {
+                    "id": "u1",
+                    "user_id": "assessor",
+                    "date_created": "2024-02-20T10:00:00",
+                    "justification": "Please clarify",
+                    "status": "RAISED",
+                    "allocation": None,
+                },
+                {
+                    "id": "u2",
+                    "user_id": "lead",
+                    "date_created": "2024-02-21T10:00:00",
+                    "justification": "Applicant reply",
+                    "status": "RAISED",
+                    "allocation": None,
+                },
+            ],
+        }
+        mocker.patch(
+            "pre_award.assess.assessments.routes.get_change_requests_for_application",
+            return_value=[mock.Mock()],
+        )
+        mock_schema = mocker.patch("pre_award.assess.assessments.routes.AssessmentFlagSchema")
+        mock_schema.return_value.dump.return_value = [change_request_dict]
+
+        soup = get_subcriteria_soup(request, assess_test_client)
+        change_request_box = soup.select_one(".change-request-box")
+        assert change_request_box is not None, "Change request box should be rendered"
+        text = change_request_box.get_text()
+        assert "This change was requested by assessor," in text
+        assert "Assessor User" in text
+        assert "assessor@test.com" in text
+        assert "Lead User" not in text
+        assert "lead@test.com" not in text
+
     @pytest.mark.application_id("resolved_app")
     @pytest.mark.fund_id("DPIF")
     @pytest.mark.sub_criteria_id("test_sub_criteria_id")


### PR DESCRIPTION
### Change description
If the change request was handled by an applicant, we would incorrectly show their name as the person who requested the change. It should always be the name of the user who actually raised the change request.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### How to test
Change the macro calls back to referencing `latest_user_id` and run the tests - they'll fail.

### Screenshots of UI changes (if applicable)

#### Before
<img width="1634" height="1091" alt="image" src="https://github.com/user-attachments/assets/8d73b77b-5f5a-4edb-bea6-8c069b9420ca" />

#### After

<img width="1649" height="1091" alt="image" src="https://github.com/user-attachments/assets/31471abe-9c54-4548-8b0d-1181217e7287" />