### PR TITLE
FLS-1710: Ignore retention on PII deletion script

### DIFF
--- a/scripts/data_deletion/delete_grant_pii_data.py
+++ b/scripts/data_deletion/delete_grant_pii_data.py
@@ -169,6 +169,13 @@ def scrub_assessment_record(assessment_record: AssessmentRecord) -> None:
     help="Environment to run against e.g. local, dev, test, uat, production",
 )
 @click.option(
+    "--ignore-retention/--no-ignore-retention",
+    "ignore_retention",
+    default=False,
+    show_default=True,
+    help="Ignore round retention periods to delete submitted but unsuccessful applications",
+)
+@click.option(
     "--exclude-application",
     "exclude_application_ids",
     multiple=True,
@@ -185,6 +192,7 @@ def delete_pii(  # noqa: C901
     round_short_name: str,
     dry_run: bool,
     env: str,
+    ignore_retention: bool,
     exclude_application_ids: tuple,
 ) -> None:
     # get identity from aws for audit trail
@@ -270,6 +278,14 @@ def delete_pii(  # noqa: C901
     elif round_obj.pii_deleted_for_applications == PiiDeletionScope.SUBMITTED:
         # Submitted applications were already processed in a previous run
         submitted_eligible = False
+
+    if ignore_retention:
+        submitted_eligible = True
+        unsubmitted_eligible = True
+        print(
+            "You have chosen to override the retention period cutoff in order to delete applications before the end "
+            "of the retention period (eg. to delete submitted but unsucessful applications)."
+        )
 
     # Bail out here, before printing anything about what's "eligible", if nothing actually is - the
     # step 4 messaging below assumes at least one scope is eligible, and printing e.g. "All


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-1530

This adds a boolean flag to the PII deletion script to override and ignore the retention period for the submitted and unsubmitted applications.

This is needed because some privacy policies specify dates for successful and unsuccessful applications rather than submitted/unsubmitted, but we have no concept of successful/unsuccessful in the service or the codebase but might have a need to delete them according to these definitions.

The flag set to True overrides both retention period checks and allows deletion of all submitted and unsubmitted applications.